### PR TITLE
[contract] changing bond authority from vote account withdrawer to validator identity

### DIFF
--- a/.github/workflows/typescript-lint.yml
+++ b/.github/workflows/typescript-lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 50
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -27,6 +27,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.73.0
         with:
           components: rustfmt, clippy
+
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - run: pnpm install
       - run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "4.9.5",
-        "@marinade.finance/jest-utils": "^2.0.20"
+        "@marinade.finance/jest-utils": "^2.0.21"
     },
     "pnpm": {
         "peerDependencyRules": {

--- a/packages/validator-bonds-cli/README.md
+++ b/packages/validator-bonds-cli/README.md
@@ -19,8 +19,9 @@ The bond account is bound to a validator vote account.
 ```sh
 # bond account at mainnet
 validator-bonds -um init-bond -k <fee-payer-keypair> \
-  --vote-account <vote-account-pubkey> --vote-account-withdrawer <vote-account-withdrawer-keypair> \
-  --bond-authority <authority-on-bond-account-pubkey> --rent-payer <rent-payer-account-keypair>
+  --vote-account <vote-account-pubkey> --validator-identity <validator-identity-keypair> \
+  --bond-authority <authority-on-bond-account-pubkey> \
+  --rent-payer <rent-payer-account-keypair>
 
 # to configure bond account properties
 validator-bonds -um configure-bond --help

--- a/packages/validator-bonds-cli/__tests__/test-validator/configureBond.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/configureBond.spec.ts
@@ -15,7 +15,7 @@ import {
   getValidatorInfo,
   initTest,
 } from '@marinade.finance/validator-bonds-sdk/__tests__/test-validator/testValidator'
-import { createVoteAccount } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/staking'
+import { createVoteAccountWithIdentity } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/staking'
 
 describe('Configure bond account using CLI', () => {
   let provider: AnchorExtendedProvider
@@ -35,7 +35,6 @@ describe('Configure bond account using CLI', () => {
   })
 
   beforeEach(async () => {
-    const voteWithdrawerKeypair = Keypair.generate()
     ;({
       path: bondAuthorityPath,
       keypair: bondAuthorityKeypair,
@@ -53,11 +52,8 @@ describe('Configure bond account using CLI', () => {
     ;({ validatorIdentity, validatorIdentityPath } = await getValidatorInfo(
       provider.connection
     ))
-    ;({ voteAccount } = await createVoteAccount(
+    ;({ voteAccount } = await createVoteAccountWithIdentity(
       provider,
-      undefined,
-      undefined,
-      voteWithdrawerKeypair,
       validatorIdentity
     ))
     ;({ bondAccount } = await executeInitBondInstruction(

--- a/packages/validator-bonds-cli/__tests__/test-validator/initBond.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/initBond.spec.ts
@@ -18,7 +18,7 @@ import {
   getValidatorInfo,
   initTest,
 } from '@marinade.finance/validator-bonds-sdk/__tests__/test-validator/testValidator'
-import { createVoteAccount } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/staking'
+import { createVoteAccountWithIdentity } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/staking'
 
 describe('Init bond account using CLI', () => {
   let provider: AnchorExtendedProvider
@@ -27,7 +27,6 @@ describe('Init bond account using CLI', () => {
   let rentPayerKeypair: Keypair
   let rentPayerCleanup: () => Promise<void>
   const rentPayerFunds = 10 * LAMPORTS_PER_SOL
-  let voteWithdrawerKeypair: Keypair
   let configAccount: PublicKey
   let voteAccount: PublicKey
   let validatorIdentity: Keypair
@@ -44,7 +43,6 @@ describe('Init bond account using CLI', () => {
       keypair: rentPayerKeypair,
       cleanup: rentPayerCleanup,
     } = await createTempFileKeypair())
-    voteWithdrawerKeypair = Keypair.generate()
     ;({ configAccount } = await executeInitConfigInstruction({
       program,
       provider,
@@ -57,11 +55,8 @@ describe('Init bond account using CLI', () => {
     ;({ validatorIdentity, validatorIdentityPath } = await getValidatorInfo(
       provider.connection
     ))
-    ;({ voteAccount } = await createVoteAccount(
+    ;({ voteAccount } = await createVoteAccountWithIdentity(
       provider,
-      undefined,
-      undefined,
-      voteWithdrawerKeypair,
       validatorIdentity
     ))
 

--- a/packages/validator-bonds-cli/__tests__/test-validator/show.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/show.spec.ts
@@ -207,9 +207,7 @@ describe('Show command using CLI', () => {
     expect(
       provider.connection.getAccountInfo(configAccount)
     ).resolves.not.toBeNull()
-    const { voteAccount, authorizedWithdrawer } = await createVoteAccount(
-      provider
-    )
+    const { voteAccount, validatorIdentity } = await createVoteAccount(provider)
     const bondAuthority = Keypair.generate()
     const { bondAccount } = await executeInitBondInstruction(
       program,
@@ -217,7 +215,7 @@ describe('Show command using CLI', () => {
       configAccount,
       bondAuthority,
       voteAccount,
-      authorizedWithdrawer,
+      validatorIdentity,
       222
     )
     const [, bump] = bondAddress(configAccount, voteAccount, program.programId)

--- a/packages/validator-bonds-cli/package.json
+++ b/packages/validator-bonds-cli/package.json
@@ -27,9 +27,9 @@
     "@marinade.finance/validator-bonds-sdk": "^1.0.1",
     "@coral-xyz/anchor": "^0.29.0",
     "@solana/web3.js": "^1.87.6",
-    "@marinade.finance/cli-common": "^2.0.20",
-    "@marinade.finance/anchor-common": "^2.0.20",
-    "@marinade.finance/web3js-common": "^2.0.20",
+    "@marinade.finance/cli-common": "^2.0.21",
+    "@marinade.finance/anchor-common": "^2.0.21",
+    "@marinade.finance/web3js-common": "^2.0.21",
     "bn.js": "^5.2.1",
     "jsbi": "^4.3.0",
     "commander": "^9.5.0",
@@ -39,6 +39,6 @@
     "yaml": "^2.3.3"
   },
   "devDependencies": {
-    "@marinade.finance/jest-utils": "^2.0.20"
+    "@marinade.finance/jest-utils": "^2.0.21"
   }
 }

--- a/packages/validator-bonds-cli/src/commands/manage/configureBond.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/configureBond.ts
@@ -37,7 +37,7 @@ export function installConfigureBond(program: Command) {
       '--authority <keypair_or_pubkey>',
       'Authority that is permitted to do changes in bonds account. ' +
         'It is either the authority defined in bonds account or ' +
-        'validator vote account withdrawer authority that the bond account is connected to. ' +
+        'vote account validator identity that the bond account is connected to. ' +
         '(default: wallet keypair)',
       parsePubkeyOrKeypair
     )

--- a/packages/validator-bonds-cli/src/commands/manage/initBond.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/initBond.ts
@@ -26,9 +26,9 @@ export function installInitBond(program: Command) {
       parsePubkey
     )
     .option(
-      '--vote-account-withdrawer <keypair_or_pubkey>',
-      'Validator vote account withdrawer authority. ' +
-        'To create the bond the signature of the account is needed (default: wallet keypair)',
+      '--validator-identity <keypair_or_pubkey>',
+      'Validator identity linked to the vote account. ' +
+        'To create the bond the signature of the validator identity is needed (default: wallet keypair)',
       parsePubkeyOrKeypair
     )
     .option(
@@ -52,14 +52,14 @@ export function installInitBond(program: Command) {
       async ({
         config,
         voteAccount,
-        voteAccountWithdrawer,
+        validatorIdentity,
         bondAuthority,
         revenueShare,
         rentPayer,
       }: {
         config?: Promise<PublicKey>
         voteAccount: Promise<PublicKey>
-        voteAccountWithdrawer?: Promise<PublicKey | Keypair>
+        validatorIdentity?: Promise<PublicKey | Keypair>
         bondAuthority: Promise<PublicKey>
         revenueShare: number
         rentPayer?: Promise<PublicKey | Keypair>
@@ -67,7 +67,7 @@ export function installInitBond(program: Command) {
         await manageInitBond({
           config: await config,
           voteAccount: await voteAccount,
-          voteAccountWithdrawer: await voteAccountWithdrawer,
+          validatorIdentity: await validatorIdentity,
           bondAuthority: await bondAuthority,
           revenueShare: revenueShare,
           rentPayer: await rentPayer,
@@ -79,14 +79,14 @@ export function installInitBond(program: Command) {
 async function manageInitBond({
   config = CONFIG_ADDRESS,
   voteAccount,
-  voteAccountWithdrawer,
+  validatorIdentity,
   bondAuthority,
   revenueShare,
   rentPayer,
 }: {
   config?: PublicKey
   voteAccount: PublicKey
-  voteAccountWithdrawer?: PublicKey | Keypair
+  validatorIdentity?: PublicKey | Keypair
   bondAuthority: PublicKey
   revenueShare: number
   rentPayer?: PublicKey | Keypair
@@ -102,10 +102,10 @@ async function manageInitBond({
     signers.push(rentPayer)
     rentPayer = rentPayer.publicKey
   }
-  voteAccountWithdrawer = voteAccountWithdrawer || wallet.publicKey
-  if (voteAccountWithdrawer instanceof Keypair) {
-    signers.push(voteAccountWithdrawer)
-    voteAccountWithdrawer = voteAccountWithdrawer.publicKey
+  validatorIdentity = validatorIdentity || wallet.publicKey
+  if (validatorIdentity instanceof Keypair) {
+    signers.push(validatorIdentity)
+    validatorIdentity = validatorIdentity.publicKey
   }
 
   bondAuthority = bondAuthority || wallet.publicKey
@@ -115,7 +115,7 @@ async function manageInitBond({
     configAccount: config,
     bondAuthority,
     validatorVoteAccount: voteAccount,
-    validatorVoteWithdrawer: voteAccountWithdrawer,
+    validatorIdentity,
     revenueShareHundredthBps: revenueShare,
     rentPayer,
   })

--- a/packages/validator-bonds-sdk/__tests__/bankrun/fundBond.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/fundBond.spec.ts
@@ -50,9 +50,7 @@ describe('Validator Bonds fund bond account', () => {
       publicKey: configAccount,
       account: await getConfig(program, configAccount),
     }
-    const { voteAccount, authorizedWithdrawer } = await createVoteAccount(
-      provider
-    )
+    const { voteAccount, validatorIdentity } = await createVoteAccount(provider)
     bondAuthority = Keypair.generate()
     const { bondAccount } = await executeInitBondInstruction(
       program,
@@ -60,7 +58,7 @@ describe('Validator Bonds fund bond account', () => {
       config.publicKey,
       bondAuthority,
       voteAccount,
-      authorizedWithdrawer,
+      validatorIdentity,
       123
     )
     bond = {

--- a/packages/validator-bonds-sdk/__tests__/bankrun/initBond.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/initBond.spec.ts
@@ -41,9 +41,7 @@ describe('Validator Bonds init bond account', () => {
 
   it('init bond', async () => {
     const bondAuthority = Keypair.generate()
-    const { voteAccount, authorizedWithdrawer } = await createVoteAccount(
-      provider
-    )
+    const { voteAccount, validatorIdentity } = await createVoteAccount(provider)
     const rentWallet = await createUserAndFund(
       provider,
       Keypair.generate(),
@@ -55,10 +53,10 @@ describe('Validator Bonds init bond account', () => {
       bondAuthority: bondAuthority.publicKey,
       revenueShareHundredthBps: 30,
       validatorVoteAccount: voteAccount,
-      validatorVoteWithdrawer: authorizedWithdrawer.publicKey,
+      validatorIdentity: validatorIdentity.publicKey,
       rentPayer: rentWallet.publicKey,
     })
-    await provider.sendIx([rentWallet, authorizedWithdrawer], instruction)
+    await provider.sendIx([rentWallet, validatorIdentity], instruction)
 
     const rentWalletInfo = await provider.connection.getAccountInfo(
       rentWallet.publicKey

--- a/packages/validator-bonds-sdk/__tests__/test-validator/configureBond.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/test-validator/configureBond.spec.ts
@@ -6,7 +6,7 @@ import {
   configureBondInstruction,
   getBond,
 } from '../../src'
-import { initTest } from './testValidator'
+import { getValidatorInfo, initTest } from './testValidator'
 import {
   executeInitBondInstruction,
   executeInitConfigInstruction,
@@ -16,10 +16,12 @@ import { ExtendedProvider } from '../utils/provider'
 describe('Validator Bonds configure bond', () => {
   let provider: ExtendedProvider
   let program: ValidatorBondsProgram
+  let validatorIdentity: Keypair
   let configAccount: PublicKey
 
   beforeAll(async () => {
     ;({ provider, program } = await initTest())
+    ;({ validatorIdentity } = await getValidatorInfo(provider.connection))
   })
 
   afterAll(async () => {
@@ -41,7 +43,7 @@ describe('Validator Bonds configure bond', () => {
       configAccount,
       undefined,
       undefined,
-      undefined,
+      validatorIdentity,
       22
     )
 

--- a/packages/validator-bonds-sdk/__tests__/test-validator/fundBond.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/test-validator/fundBond.spec.ts
@@ -36,9 +36,7 @@ describe('Validator Bonds fund bond', () => {
       program,
       provider,
     }))
-    const { voteAccount, authorizedWithdrawer } = await createVoteAccount(
-      provider
-    )
+    const { voteAccount, validatorIdentity } = await createVoteAccount(provider)
     validatorVoteAccount = voteAccount
     ;({ bondAccount } = await executeInitBondInstruction(
       program,
@@ -46,7 +44,7 @@ describe('Validator Bonds fund bond', () => {
       configAccount,
       undefined,
       validatorVoteAccount,
-      authorizedWithdrawer
+      validatorIdentity
     ))
   })
 

--- a/packages/validator-bonds-sdk/__tests__/utils/testTransactions.ts
+++ b/packages/validator-bonds-sdk/__tests__/utils/testTransactions.ts
@@ -129,20 +129,20 @@ export async function executeInitBondInstruction(
   config: PublicKey,
   bondAuthority?: Keypair,
   voteAccount?: PublicKey,
-  authorizedWithdrawer?: Keypair,
+  validatorIdentity?: Keypair,
   revenueShareHundredthBps: BN | number = Math.floor(Math.random() * 100) + 1
 ): Promise<{
   bondAccount: PublicKey
   bondAuthority: Keypair
   voteAccount: PublicKey
-  authorizedWithdrawer: Keypair
+  validatorIdentity: Keypair
 }> {
   bondAuthority = bondAuthority || Keypair.generate()
   if (!voteAccount) {
-    ;({ voteAccount, authorizedWithdrawer } = await createVoteAccount(provider))
+    ;({ voteAccount, validatorIdentity } = await createVoteAccount(provider))
   }
-  if (authorizedWithdrawer === undefined) {
-    throw new Error('authorizedWithdrawer is undefined')
+  if (validatorIdentity === undefined) {
+    throw new Error('nodeIdentity is undefined')
   }
   const { instruction, bondAccount } = await initBondInstruction({
     program,
@@ -150,21 +150,19 @@ export async function executeInitBondInstruction(
     bondAuthority: bondAuthority.publicKey,
     revenueShareHundredthBps,
     validatorVoteAccount: voteAccount,
-    validatorVoteWithdrawer: authorizedWithdrawer.publicKey,
+    validatorIdentity: validatorIdentity.publicKey,
   })
   try {
-    await provider.sendIx([authorizedWithdrawer], instruction)
+    await provider.sendIx([validatorIdentity], instruction)
   } catch (e) {
     console.error(
       `executeInitBondInstruction: bond account ${pubkey(
         bondAccount
       ).toBase58()}, ` +
         `config: ${pubkey(config).toBase58()}, ` +
-        `bondAuthority: ${pubkey(bondAuthority.publicKey).toBase58()}, ` +
+        `bondAuthority: ${pubkey(bondAuthority).toBase58()}, ` +
         `voteAccount: ${pubkey(voteAccount).toBase58()}, ` +
-        `authorizedWithdrawer: ${pubkey(
-          authorizedWithdrawer.publicKey
-        ).toBase58()}`,
+        `validatorIdentity: ${pubkey(validatorIdentity).toBase58()}`,
       e
     )
     throw e
@@ -174,6 +172,6 @@ export async function executeInitBondInstruction(
     bondAccount,
     bondAuthority,
     voteAccount,
-    authorizedWithdrawer,
+    validatorIdentity,
   }
 }

--- a/packages/validator-bonds-sdk/generated/validator_bonds.ts
+++ b/packages/validator-bonds-sdk/generated/validator_bonds.ts
@@ -122,11 +122,11 @@ export type ValidatorBonds = {
           "isSigner": false
         },
         {
-          "name": "authorizedWithdrawer",
+          "name": "validatorIdentity",
           "isMut": false,
           "isSigner": true,
           "docs": [
-            "only validator vote account withdrawer authority may can create the bond"
+            "only validator vote account validator identity may create the bond"
           ]
         },
         {
@@ -213,7 +213,7 @@ export type ValidatorBonds = {
           "isMut": false,
           "isSigner": true,
           "docs": [
-            "validator vote account owner or bond authority may change the account"
+            "validator vote account validator identity or bond authority may change the account"
           ]
         },
         {
@@ -276,7 +276,7 @@ export type ValidatorBonds = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "new authority owner, it's the bonds program"
+            "new owner of the stake account, it's the bonds program PDA"
           ],
           "pda": {
             "seeds": [
@@ -378,7 +378,7 @@ export type ValidatorBonds = {
           "isMut": false,
           "isSigner": true,
           "docs": [
-            "validator vote account owner or bond authority may ask for the withdrawal"
+            "validator vote account node identity or bond authority may ask for the withdrawal"
           ]
         },
         {
@@ -470,7 +470,7 @@ export type ValidatorBonds = {
           "isMut": false,
           "isSigner": true,
           "docs": [
-            "validator vote account owner or bond authority may ask for cancelling"
+            "validator vote account validator identity or bond authority may ask for cancelling"
           ]
         },
         {
@@ -2213,7 +2213,7 @@ export type ValidatorBonds = {
           "index": false
         },
         {
-          "name": "validatorVoteWithdrawer",
+          "name": "validatorIdentity",
           "type": "publicKey",
           "index": false
         },
@@ -3044,8 +3044,8 @@ export type ValidatorBonds = {
     },
     {
       "code": 6035,
-      "name": "ValidatorVoteAccountOwnerMismatch",
-      "msg": "Owner of validator vote account does not match with the provided owner signature"
+      "name": "VoteAccountValidatorIdentityMismatch",
+      "msg": "Validator vote account does not match to provided validator identity signature"
     },
     {
       "code": 6036,
@@ -3229,11 +3229,11 @@ export const IDL: ValidatorBonds = {
           "isSigner": false
         },
         {
-          "name": "authorizedWithdrawer",
+          "name": "validatorIdentity",
           "isMut": false,
           "isSigner": true,
           "docs": [
-            "only validator vote account withdrawer authority may can create the bond"
+            "only validator vote account validator identity may create the bond"
           ]
         },
         {
@@ -3320,7 +3320,7 @@ export const IDL: ValidatorBonds = {
           "isMut": false,
           "isSigner": true,
           "docs": [
-            "validator vote account owner or bond authority may change the account"
+            "validator vote account validator identity or bond authority may change the account"
           ]
         },
         {
@@ -3383,7 +3383,7 @@ export const IDL: ValidatorBonds = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "new authority owner, it's the bonds program"
+            "new owner of the stake account, it's the bonds program PDA"
           ],
           "pda": {
             "seeds": [
@@ -3485,7 +3485,7 @@ export const IDL: ValidatorBonds = {
           "isMut": false,
           "isSigner": true,
           "docs": [
-            "validator vote account owner or bond authority may ask for the withdrawal"
+            "validator vote account node identity or bond authority may ask for the withdrawal"
           ]
         },
         {
@@ -3577,7 +3577,7 @@ export const IDL: ValidatorBonds = {
           "isMut": false,
           "isSigner": true,
           "docs": [
-            "validator vote account owner or bond authority may ask for cancelling"
+            "validator vote account validator identity or bond authority may ask for cancelling"
           ]
         },
         {
@@ -5320,7 +5320,7 @@ export const IDL: ValidatorBonds = {
           "index": false
         },
         {
-          "name": "validatorVoteWithdrawer",
+          "name": "validatorIdentity",
           "type": "publicKey",
           "index": false
         },
@@ -6151,8 +6151,8 @@ export const IDL: ValidatorBonds = {
     },
     {
       "code": 6035,
-      "name": "ValidatorVoteAccountOwnerMismatch",
-      "msg": "Owner of validator vote account does not match with the provided owner signature"
+      "name": "VoteAccountValidatorIdentityMismatch",
+      "msg": "Validator vote account does not match to provided validator identity signature"
     },
     {
       "code": 6036,

--- a/packages/validator-bonds-sdk/package.json
+++ b/packages/validator-bonds-sdk/package.json
@@ -28,10 +28,10 @@
   ],
   "devDependencies": {
     "@coral-xyz/anchor": "^0.29.0",
-    "@marinade.finance/anchor-common": "^2.0.20",
+    "@marinade.finance/anchor-common": "^2.0.21",
     "@marinade.finance/marinade-ts-sdk": "^5.0.6",
-    "@marinade.finance/ts-common": "^2.0.20",
-    "@marinade.finance/web3js-common": "^2.0.20",
+    "@marinade.finance/ts-common": "^2.0.21",
+    "@marinade.finance/web3js-common": "^2.0.21",
     "@solana/buffer-layout": "^4.0.1",
     "@solana/web3.js": "^1.87.6",
     "anchor-bankrun": "^0.3.0",

--- a/packages/validator-bonds-sdk/src/instructions/claimWithdrawRequest.ts
+++ b/packages/validator-bonds-sdk/src/instructions/claimWithdrawRequest.ts
@@ -91,7 +91,7 @@ export async function claimWithdrawRequestInstruction({
       program,
       withdrawRequestData.validatorVoteAccount
     )
-    withdrawer = voteAccountData.account.data.authorizedWithdrawer
+    withdrawer = voteAccountData.account.data.nodePubkey
   }
 
   splitStakeRentPayer =

--- a/packages/validator-bonds-sdk/src/instructions/initBond.ts
+++ b/packages/validator-bonds-sdk/src/instructions/initBond.ts
@@ -12,7 +12,7 @@ export async function initBondInstruction({
   program,
   configAccount = CONFIG_ADDRESS,
   validatorVoteAccount,
-  validatorVoteWithdrawer = walletPubkey(program),
+  validatorIdentity = walletPubkey(program),
   bondAuthority = walletPubkey(program),
   revenueShareHundredthBps,
   rentPayer = walletPubkey(program),
@@ -20,7 +20,7 @@ export async function initBondInstruction({
   program: ValidatorBondsProgram
   configAccount?: PublicKey
   validatorVoteAccount: PublicKey
-  validatorVoteWithdrawer?: PublicKey | Keypair | Signer // signer
+  validatorIdentity?: PublicKey | Keypair | Signer // signer
   bondAuthority?: PublicKey
   revenueShareHundredthBps: BN | number
   rentPayer?: PublicKey | Keypair | Signer // signer
@@ -28,10 +28,10 @@ export async function initBondInstruction({
   instruction: TransactionInstruction
   bondAccount: PublicKey
 }> {
-  const authorizedWithdrawer =
-    validatorVoteWithdrawer instanceof PublicKey
-      ? validatorVoteWithdrawer
-      : validatorVoteWithdrawer.publicKey
+  validatorIdentity =
+    validatorIdentity instanceof PublicKey
+      ? validatorIdentity
+      : validatorIdentity.publicKey
   const renPayerPubkey =
     rentPayer instanceof PublicKey ? rentPayer : rentPayer.publicKey
   const [bondAccount] = bondAddress(
@@ -53,7 +53,7 @@ export async function initBondInstruction({
       config: configAccount,
       bond: bondAccount,
       validatorVoteAccount,
-      authorizedWithdrawer,
+      validatorIdentity,
       rentPayer: renPayerPubkey,
     })
     .instruction()

--- a/packages/validator-bonds-sdk/src/orchestrators/orchestrateWithdrawDeposit.ts
+++ b/packages/validator-bonds-sdk/src/orchestrators/orchestrateWithdrawDeposit.ts
@@ -80,7 +80,7 @@ export async function orchestrateWithdrawDeposit({
     program,
     withdrawRequestData.validatorVoteAccount
   )
-  const withdrawer = voteAccountData.account.data.authorizedWithdrawer
+  const withdrawer = voteAccountData.account.data.nodePubkey
   const configAccount = bondData.config
 
   let amountToWithdraw = withdrawRequestData.requestedAmount.sub(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0
       '@marinade.finance/jest-utils':
-        specifier: ^2.0.20
-        version: 2.0.20(@jest/globals@29.7.0)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(jest-shell-matchers@1.0.2)
+        specifier: ^2.0.21
+        version: 2.0.21(@jest/globals@29.7.0)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(jest-shell-matchers@1.0.2)
       '@types/bn.js':
         specifier: ^5.1.3
         version: 5.1.3
@@ -45,17 +45,17 @@ importers:
         specifier: ^0.29.0
         version: 0.29.0
       '@marinade.finance/anchor-common':
-        specifier: ^2.0.20
-        version: 2.0.20(@coral-xyz/anchor@0.29.0)(@marinade.finance/ts-common@2.0.20)(@solana/web3.js@1.87.6)(bn.js@5.2.1)
+        specifier: ^2.0.21
+        version: 2.0.21(@coral-xyz/anchor@0.29.0)(@marinade.finance/ts-common@2.0.21)(@solana/web3.js@1.87.6)(bn.js@5.2.1)
       '@marinade.finance/cli-common':
-        specifier: ^2.0.20
-        version: 2.0.20(@marinade.finance/web3js-common@2.0.20)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0)(expand-tilde@2.0.2)(pino@8.16.1)(yaml@2.3.3)
+        specifier: ^2.0.21
+        version: 2.0.21(@marinade.finance/web3js-common@2.0.21)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0)(expand-tilde@2.0.2)(pino@8.16.1)(yaml@2.3.3)
       '@marinade.finance/validator-bonds-sdk':
         specifier: ^1.0.1
         version: link:../validator-bonds-sdk
       '@marinade.finance/web3js-common':
-        specifier: ^2.0.20
-        version: 2.0.20(@marinade.finance/ts-common@2.0.20)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0)
+        specifier: ^2.0.21
+        version: 2.0.21(@marinade.finance/ts-common@2.0.21)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0)
       '@solana/web3.js':
         specifier: ^1.87.6
         version: 1.87.6
@@ -82,8 +82,8 @@ importers:
         version: 2.3.3
     devDependencies:
       '@marinade.finance/jest-utils':
-        specifier: ^2.0.20
-        version: 2.0.20(@jest/globals@29.7.0)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(jest-shell-matchers@1.0.2)
+        specifier: ^2.0.21
+        version: 2.0.21(@jest/globals@29.7.0)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(jest-shell-matchers@1.0.2)
 
   packages/validator-bonds-sdk:
     dependencies:
@@ -95,17 +95,17 @@ importers:
         specifier: ^0.29.0
         version: 0.29.0
       '@marinade.finance/anchor-common':
-        specifier: ^2.0.20
-        version: 2.0.20(@coral-xyz/anchor@0.29.0)(@marinade.finance/ts-common@2.0.20)(@solana/web3.js@1.87.6)(bn.js@5.2.1)
+        specifier: ^2.0.21
+        version: 2.0.21(@coral-xyz/anchor@0.29.0)(@marinade.finance/ts-common@2.0.21)(@solana/web3.js@1.87.6)(bn.js@5.2.1)
       '@marinade.finance/marinade-ts-sdk':
         specifier: ^5.0.6
         version: 5.0.6(@solana/web3.js@1.87.6)(bn.js@5.2.1)(jsbi@4.3.0)
       '@marinade.finance/ts-common':
-        specifier: ^2.0.20
-        version: 2.0.20
+        specifier: ^2.0.21
+        version: 2.0.21
       '@marinade.finance/web3js-common':
-        specifier: ^2.0.20
-        version: 2.0.20(@marinade.finance/ts-common@2.0.20)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0)
+        specifier: ^2.0.21
+        version: 2.0.21(@marinade.finance/ts-common@2.0.21)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0)
       '@solana/buffer-layout':
         specifier: ^4.0.1
         version: 4.0.1
@@ -917,24 +917,24 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@marinade.finance/anchor-common@2.0.20(@coral-xyz/anchor@0.29.0)(@marinade.finance/ts-common@2.0.20)(@solana/web3.js@1.87.6)(bn.js@5.2.1):
-    resolution: {integrity: sha512-o1vw2SevnHE+eRWwyMqwSqFk4RMXPR5ZqAYCAEZBkzcw7QJI0K1BCq3ER1LCMjLPc1gpkO27Dq8vNN6r1cmXbg==}
+  /@marinade.finance/anchor-common@2.0.21(@coral-xyz/anchor@0.29.0)(@marinade.finance/ts-common@2.0.21)(@solana/web3.js@1.87.6)(bn.js@5.2.1):
+    resolution: {integrity: sha512-QwPrjqk6uLnFefW9m4ib2VBvf3DoOXF5/YipRGV0/ZKPTVYk+WdePw8srVcr2NauJ/aDY5hSe8Y02zwlkn/1yA==}
     peerDependencies:
       '@coral-xyz/anchor': ^0.28.0 || 0.29
-      '@marinade.finance/ts-common': ^2.0.20
+      '@marinade.finance/ts-common': ^2.0.21
       '@solana/web3.js': ^1.78.5
       bn.js: ^5.2.1
     dependencies:
       '@coral-xyz/anchor': 0.29.0
-      '@marinade.finance/ts-common': 2.0.20
+      '@marinade.finance/ts-common': 2.0.21
       '@solana/web3.js': 1.87.6
       bn.js: 5.2.1
 
-  /@marinade.finance/cli-common@2.0.20(@marinade.finance/web3js-common@2.0.20)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0)(expand-tilde@2.0.2)(pino@8.16.1)(yaml@2.3.3):
-    resolution: {integrity: sha512-UBnoE3thCu0VxIV9QSpIVzg3SyaPi65NQH8WCzsfjuacnV0/0vLUl253/rvpbe7TPYGoZDiykAQRyXUtYBdWjQ==}
+  /@marinade.finance/cli-common@2.0.21(@marinade.finance/web3js-common@2.0.21)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0)(expand-tilde@2.0.2)(pino@8.16.1)(yaml@2.3.3):
+    resolution: {integrity: sha512-PDob845+X/dZJK9AKtANjFPpQ0N3e8vLBpjGLHE51UZY3mWgwSdntSazRLNV4H7E1SC9Ihl/oKxJt4nKx3Lzzw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@marinade.finance/web3js-common': ^2.0.20
+      '@marinade.finance/web3js-common': ^2.0.21
       '@solana/web3.js': ^1.78.5
       bn.js: ^5.2.1
       borsh: ^0.7.0
@@ -943,7 +943,7 @@ packages:
       pino: ^8.15.1
       yaml: ^2.3.2
     dependencies:
-      '@marinade.finance/web3js-common': 2.0.20(@marinade.finance/ts-common@2.0.20)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0)
+      '@marinade.finance/web3js-common': 2.0.21(@marinade.finance/ts-common@2.0.21)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0)
       '@solana/web3.js': 1.87.6
       bn.js: 5.2.1
       borsh: 0.7.0
@@ -972,8 +972,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@marinade.finance/jest-utils@2.0.20(@jest/globals@29.7.0)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(jest-shell-matchers@1.0.2):
-    resolution: {integrity: sha512-X//GglnqlkWSSng85ak011gHRyzM10Pfg/hKrJUR3SlzUtbUxP4ZbK6NRnAI2hhBPjW/GEY/ete/nndm+qxQgw==}
+  /@marinade.finance/jest-utils@2.0.21(@jest/globals@29.7.0)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(jest-shell-matchers@1.0.2):
+    resolution: {integrity: sha512-a0TaESqYlEfU9VkAuvzJr5VosBAkWws3RRQAJjjTssTVXm54oZ1wgpSB6s+peu7ESYvgFom3IoniY/CnKOrr+Q==}
     peerDependencies:
       '@jest/globals': ^29.5.0
       '@solana/web3.js': ^1.78.4
@@ -1018,20 +1018,20 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@marinade.finance/ts-common@2.0.20:
-    resolution: {integrity: sha512-DOr3VNCVxADBlQQ2tLDJEgpF974dsw8lwMvNObxLVyHhckR2aWnT+bIIxuuQxB+XqbRvyyS/gc2kXOKaQzu4Rg==}
+  /@marinade.finance/ts-common@2.0.21:
+    resolution: {integrity: sha512-OOoRlmcL5UVHqrM/nhK90c6JYrjJygrhOMqsl1/RcBxm5AbbcQv8Nbt2XHRJ7A844BkGCLuqUQh635N8t1jA4w==}
 
-  /@marinade.finance/web3js-common@2.0.20(@marinade.finance/ts-common@2.0.20)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0):
-    resolution: {integrity: sha512-TBxIUfo0YDOU6MH3iZPQPuRuyKV7WMiFZPdOVE/01rj67TIivlVTiAFM4qOj+hIrNU93zrkGn4Bv2HTx8KbtDg==}
+  /@marinade.finance/web3js-common@2.0.21(@marinade.finance/ts-common@2.0.21)(@solana/web3.js@1.87.6)(bn.js@5.2.1)(borsh@0.7.0)(bs58@5.0.0):
+    resolution: {integrity: sha512-iPeozPDUzYpWPtkmXa+UBHg7KgIl8rwj2GHeuvI81AOKgO8Zt8uO1nGwfkSW0NPTWwql2gN/oyjQ5fm6zjPa9w==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@marinade.finance/ts-common': 2.0.20
+      '@marinade.finance/ts-common': 2.0.21
       '@solana/web3.js': ^1.78.5
       bn.js: ^5.2.1
       borsh: ^0.7.0
       bs58: ^5.0.0
     dependencies:
-      '@marinade.finance/ts-common': 2.0.20
+      '@marinade.finance/ts-common': 2.0.21
       '@solana/web3.js': 1.87.6
       bn.js: 5.2.1
       borsh: 0.7.0

--- a/programs/validator-bonds/src/error.rs
+++ b/programs/validator-bonds/src/error.rs
@@ -107,8 +107,8 @@ pub enum ErrorCode {
     #[msg("Provided stake account is not funded under a settlement")]
     StakeAccountNotFunded, // 6034 0x1792
 
-    #[msg("Owner of validator vote account does not match with the provided owner signature")]
-    ValidatorVoteAccountOwnerMismatch, // 6035 0x1793
+    #[msg("Validator vote account does not match to provided validator identity signature")]
+    VoteAccountValidatorIdentityMismatch, // 6035 0x1793
 
     #[msg("Bond vote account address does not match with the provided validator vote account")]
     VoteAccountMismatch, // 6036 0x1794

--- a/programs/validator-bonds/src/events/bond.rs
+++ b/programs/validator-bonds/src/events/bond.rs
@@ -6,7 +6,7 @@ use anchor_lang::prelude::*;
 pub struct InitBondEvent {
     pub config_address: Pubkey,
     pub validator_vote_account: Pubkey,
-    pub validator_vote_withdrawer: Pubkey,
+    pub validator_identity: Pubkey,
     pub authority: Pubkey,
     pub revenue_share: HundredthBasisPoint,
     pub bond_bump: u8,

--- a/programs/validator-bonds/src/instructions/bond/configure_bond.rs
+++ b/programs/validator-bonds/src/instructions/bond/configure_bond.rs
@@ -26,7 +26,7 @@ pub struct ConfigureBond<'info> {
     )]
     bond: Account<'info, Bond>,
 
-    /// validator vote account owner or bond authority may change the account
+    /// validator vote account validator identity or bond authority may change the account
     #[account()]
     authority: Signer<'info>,
 

--- a/programs/validator-bonds/src/instructions/bond/fund_bond.rs
+++ b/programs/validator-bonds/src/instructions/bond/fund_bond.rs
@@ -30,7 +30,7 @@ pub struct FundBond<'info> {
     bond: Account<'info, Bond>,
 
     /// CHECK: PDA
-    /// new authority owner, it's the bonds program
+    /// new owner of the stake account, it's the bonds program PDA
     #[account(
         seeds = [
             b"bonds_authority",

--- a/programs/validator-bonds/src/instructions/bond/init_bond.rs
+++ b/programs/validator-bonds/src/instructions/bond/init_bond.rs
@@ -1,4 +1,4 @@
-use crate::checks::check_validator_vote_account_withdrawer_authority;
+use crate::checks::check_validator_vote_account_validator_identity;
 use crate::error::ErrorCode;
 use crate::events::bond::InitBondEvent;
 use crate::state::bond::Bond;
@@ -28,9 +28,9 @@ pub struct InitBond<'info> {
     )]
     validator_vote_account: UncheckedAccount<'info>,
 
-    /// only validator vote account withdrawer authority may can create the bond
+    /// only validator vote account validator identity may create the bond
     #[account()]
-    authorized_withdrawer: Signer<'info>,
+    validator_identity: Signer<'info>,
 
     #[account(
         init,
@@ -65,9 +65,9 @@ impl<'info> InitBond<'info> {
         bond_bump: u8,
     ) -> Result<()> {
         // verification of the validator vote account
-        check_validator_vote_account_withdrawer_authority(
+        check_validator_vote_account_validator_identity(
             &self.validator_vote_account,
-            &self.authorized_withdrawer.key(),
+            &self.validator_identity.key(),
         )?;
 
         self.bond.set_inner(Bond {
@@ -81,7 +81,7 @@ impl<'info> InitBond<'info> {
         emit!(InitBondEvent {
             config_address: self.bond.config,
             validator_vote_account: self.bond.validator_vote_account,
-            validator_vote_withdrawer: self.authorized_withdrawer.key(),
+            validator_identity: self.validator_identity.key(),
             authority: self.bond.authority,
             revenue_share: self.bond.revenue_share,
             bond_bump: self.bond.bump,

--- a/programs/validator-bonds/src/instructions/withdraw/cancel_withdraw_request.rs
+++ b/programs/validator-bonds/src/instructions/withdraw/cancel_withdraw_request.rs
@@ -25,7 +25,7 @@ pub struct CancelWithdrawRequest<'info> {
     #[account()]
     validator_vote_account: UncheckedAccount<'info>,
 
-    /// validator vote account owner or bond authority may ask for cancelling
+    /// validator vote account validator identity or bond authority may ask for cancelling
     #[account()]
     pub authority: Signer<'info>,
 

--- a/programs/validator-bonds/src/instructions/withdraw/init_withdraw_request.rs
+++ b/programs/validator-bonds/src/instructions/withdraw/init_withdraw_request.rs
@@ -36,7 +36,7 @@ pub struct InitWithdrawRequest<'info> {
     #[account()]
     validator_vote_account: UncheckedAccount<'info>,
 
-    /// validator vote account owner or bond authority may ask for the withdrawal
+    /// validator vote account node identity or bond authority may ask for the withdrawal
     #[account()]
     authority: Signer<'info>,
 


### PR DESCRIPTION
The authority for bond account is moved from vote account withdrawer to validator identity (node pubkey).