### PR TITLE
[clippy] --fix + warning recommendations

### DIFF
--- a/settlement-engine/src/merkle_tree_collection.rs
+++ b/settlement-engine/src/merkle_tree_collection.rs
@@ -76,7 +76,7 @@ pub fn generate_merkle_tree_collection(
     let mut merkle_trees = vec![];
 
     for settlement in settlement_collection.settlements.iter() {
-        merkle_trees.push(generate_merkle_tree_meta(&settlement)?);
+        merkle_trees.push(generate_merkle_tree_meta(settlement)?);
     }
 
     Ok(MerkleTreeCollection {

--- a/settlement-engine/src/protected_events.rs
+++ b/settlement-engine/src/protected_events.rs
@@ -141,7 +141,7 @@ pub fn collect_commission_increase_events(
         .iter()
         .map(|past_validator_meta| {
             (
-                past_validator_meta.vote_account.clone(),
+                past_validator_meta.vote_account,
                 past_validator_meta.clone(),
             )
         })
@@ -195,8 +195,8 @@ pub fn generate_protected_event_collection(
     let low_credits_events = collect_low_credits_events(&validator_meta_collection);
 
     let mut events: Vec<_> = Default::default();
-    events.extend(commission_increase_events.into_iter());
-    events.extend(low_credits_events.into_iter());
+    events.extend(commission_increase_events);
+    events.extend(low_credits_events);
 
     ProtectedEventCollection {
         epoch: validator_meta_collection.epoch,

--- a/settlement-engine/src/settlement_config.rs
+++ b/settlement-engine/src/settlement_config.rs
@@ -81,7 +81,7 @@ pub fn build_protected_event_matcher(
 }
 
 pub fn stake_authorities_filter(whitelist: HashSet<Pubkey>) -> Box<dyn Fn(&Pubkey) -> bool> {
-    Box::new(move |pubkey| whitelist.contains(&pubkey))
+    Box::new(move |pubkey| whitelist.contains(pubkey))
 }
 
 pub fn no_filter() -> Box<dyn Fn(&Pubkey) -> bool> {


### PR DESCRIPTION
Using clippy fix and using the recommendation from the warning output. I'm not fully sure about the `&Box<dyn>` but based on the documentation that should be auto de-referenced.


```
warning: you seem to be trying to use `&Box<T>`. Consider using just `&T`
  --> settlement-engine/src/settlement_claims.rs:66:29
   |
66 |     stake_authority_filter: &Box<dyn Fn(&Pubkey) -> bool>,
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&dyn Fn(&Pubkey) -> bool`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrowed_box
   = note: `#[warn(clippy::borrowed_box)]` on by default

warning: you seem to be trying to use `&Box<T>`. Consider using just `&T`
   --> settlement-engine/src/settlement_claims.rs:139:29
    |
139 |     stake_authority_filter: &Box<dyn Fn(&Pubkey) -> bool>,
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&dyn Fn(&Pubkey) -> bool`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrowed_box

warning: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
   --> settlement-engine/src/settlement_claims.rs:140:25
    |
140 |     settlement_configs: &Vec<SettlementConfig>,
    |                         ^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `&[SettlementConfig]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
    = note: `#[warn(clippy::ptr_arg)]` on by default

warning: `settlement-engine` (lib test) generated 3 warnings
warning: `settlement-engine` (lib) generated 3 warnings (3 duplicates)
```