### PR TITLE
[settlement-pipeline] rent payer for init and claim

### DIFF
--- a/.buildkite/claim-settlements.yml
+++ b/.buildkite/claim-settlements.yml
@@ -67,12 +67,15 @@ steps:
     - '. "$HOME/.cargo/env"'
     - 'buildkite-agent artifact download --include-retried-jobs target/release/claim-settlement .'
     - 'chmod +x target/release/claim-settlement'
+    - 'echo "UNKNOWN ERROR" > ./claiming-report.txt'
     - |
       ./target/release/claim-settlement \
         --rpc-url $$RPC_URL \
         --merkle-trees-dir "./merkle-trees/" \
         --operator-authority "$$VALIDATOR_BONDS_OPERATOR_AUTHORITY" \
-        --fee-payer "$$VALIDATOR_BONDS_FUNDING_WALLET" | tee ./claiming-report.txt
+        --fee-payer "$$VALIDATOR_BONDS_RANDOM_TX_FEE_PAYER" \
+        --rent-payer "$$VALIDATOR_BONDS_RANDOM_RENT_PAYER" \
+        | tee ./claiming-report.txt
     artifact_paths:
     - "./claiming-report.txt"
   

--- a/.buildkite/init-settlements.yml
+++ b/.buildkite/init-settlements.yml
@@ -97,7 +97,8 @@ steps:
         --input-merkle-tree-collection "./settlement-merkle-trees.json" \
         --input-settlement-collection "./settlements.json" \
         --operator-authority "$$VALIDATOR_BONDS_OPERATOR_AUTHORITY" \
-        --fee-payer "$$VALIDATOR_BONDS_FUNDING_WALLET" \
+        --fee-payer "$$VALIDATOR_BONDS_MARINADE_TX_FEE_PAYER" \
+        --rent-payer "$$VALIDATOR_BONDS_MARINADE_RENT_PAYER" \
         --epoch "$$epoch" || true)
     - 'echo "$$report" | tee -a "./build-report.$$BUILDKITE_RETRY_COUNT"'
     - '[ -n "$$result_code" ] && echo "init-settlement command FAILED" && exit $$result_code'


### PR DESCRIPTION
Init and claim settlements to use different wallets for tx fee payer and rent payer.
For close settlements I assume there will be used the `VALIDATOR_BONDS_MARINADE_TX_FEE_PAYER` to pay for tx fees.