### PR TITLE
[pipelines] init to verify funding stake state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -5921,7 +5921,7 @@ dependencies = [
  "anyhow",
  "base64 0.13.1",
  "bincode",
- "borsh 0.10.3",
+ "borsh 0.9.3",
  "log",
  "once_cell",
  "solana-sdk",

--- a/common-rs/src/stake_accounts.rs
+++ b/common-rs/src/stake_accounts.rs
@@ -1,4 +1,3 @@
-use crate::utils::get_sysvar_clock;
 use log::{info, warn};
 use solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig};
 use solana_client::{
@@ -91,7 +90,7 @@ pub async fn obtain_delegated_stake_accounts(
     rpc_client: Arc<RpcClient>,
     stake_accounts: CollectedStakeAccounts,
 ) -> anyhow::Result<HashMap<Pubkey, CollectedStakeAccounts>> {
-    let clock: Clock = get_sysvar_clock(rpc_client).await?;
+    let clock: Clock = get_clock(rpc_client).await?;
     let mut vote_account_map: HashMap<Pubkey, CollectedStakeAccounts> = HashMap::new();
     for (pubkey, lamports, stake) in stake_accounts {
         // locked stake accounts are not correctly delegated to bonds
@@ -122,7 +121,7 @@ pub async fn obtain_claimable_stake_accounts_for_settlement(
     settlement_addresses: Vec<Pubkey>,
     rpc_client: Arc<RpcClient>,
 ) -> anyhow::Result<HashMap<Pubkey, (u64, CollectedStakeAccounts)>> {
-    let clock = get_sysvar_clock(rpc_client.clone()).await?;
+    let clock = get_clock(rpc_client.clone()).await?;
     let stake_history = get_stake_history(rpc_client.clone()).await?;
     let filtered_deactivated_stake_accounts: CollectedStakeAccounts = stake_accounts
         .into_iter()
@@ -169,7 +168,7 @@ pub async fn obtain_funded_stake_accounts_for_settlement(
     config_address: &Pubkey,
     settlement_addresses: Vec<Pubkey>,
 ) -> anyhow::Result<HashMap<Pubkey, (u64, CollectedStakeAccounts)>> {
-    let clock = get_sysvar_clock(rpc_client.clone()).await?;
+    let clock = get_clock(rpc_client.clone()).await?;
     let stake_history = get_stake_history(rpc_client.clone()).await?;
     let filtered_to_be_deactivated_stake_accounts: CollectedStakeAccounts = stake_accounts
         .into_iter()

--- a/common-rs/src/utils.rs
+++ b/common-rs/src/utils.rs
@@ -3,15 +3,10 @@ use anyhow::anyhow;
 use log::error;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_config::RpcAccountInfoConfig;
-use solana_program::clock::Clock;
-use solana_program::pubkey::Pubkey;
-use solana_program::sysvar::clock;
-use std::sync::Arc;
 
-pub async fn get_sysvar_clock(client: Arc<RpcClient>) -> anyhow::Result<Clock> {
-    let clock = client.get_account(&clock::ID).await?;
-    bincode::deserialize(&clock.data).map_err(Into::into)
-}
+use solana_program::pubkey::Pubkey;
+
+use std::sync::Arc;
 
 pub async fn get_accounts_for_pubkeys<T: AccountDeserialize>(
     rpc_client: Arc<RpcClient>,

--- a/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
+++ b/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
@@ -63,7 +63,7 @@ const VOTE_ACCOUNT_IDENTITY = Keypair.fromSecretKey(
 // This test case runs really long as using data from epoch 601 and needs to setup
 // all parts and create 10K settlements. Run this manually when needed
 // FILE='settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts' pnpm test:validator
-describe.skip('Cargo CLI: Pipeline Settlement', () => {
+describe('Cargo CLI: Pipeline Settlement', () => {
   let provider: AnchorExtendedProvider
   let program: ValidatorBondsProgram
 

--- a/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
+++ b/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
@@ -63,7 +63,7 @@ const VOTE_ACCOUNT_IDENTITY = Keypair.fromSecretKey(
 // This test case runs really long as using data from epoch 601 and needs to setup
 // all parts and create 10K settlements. Run this manually when needed
 // FILE='settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts' pnpm test:validator
-describe('Cargo CLI: Pipeline Settlement', () => {
+describe.skip('Cargo CLI: Pipeline Settlement', () => {
   let provider: AnchorExtendedProvider
   let program: ValidatorBondsProgram
 
@@ -237,7 +237,7 @@ describe('Cargo CLI: Pipeline Settlement', () => {
       settlementAddresses.length -
         1 +
         ' executed successfully(.|\n|\r)*' +
-        'Stake accounts management txes 0(.|\n|\r)*FundSettlements: txes 1'
+        'Stake accounts management: txes 0(.|\n|\r)*FundSettlements: txes 1'
     )
     await (
       expect([
@@ -298,7 +298,7 @@ describe('Cargo CLI: Pipeline Settlement', () => {
     ).toHaveMatchingSpawnOutput({
       code: 2,
       stderr:
-        /InitSettlement ... txes 0(.|\n|\r)*already funded(.|\n|\r)*Stake accounts management txes 0(.|\n|\r)*FundSettlements: txes 0/,
+        /InitSettlement ... txes 0(.|\n|\r)*already funded(.|\n|\r)*Stake accounts management: txes 0(.|\n|\r)*FundSettlements: txes 0/,
       stdout: /Cannot find stake account to fund settlement/,
     })
 
@@ -378,7 +378,7 @@ describe('Cargo CLI: Pipeline Settlement', () => {
     ).toHaveMatchingSpawnOutput({
       code: 0,
       stderr:
-        /InitSettlement ... txes 0(.|\n|\r)*Stake accounts management txes 1(.|\n|\r)*FundSettlements:.*ixes 9 executed/,
+        /InitSettlement ... txes 0(.|\n|\r)*Stake accounts management: txes 1(.|\n|\r)*FundSettlements:.*ixes 9 executed/,
       stdout: stdoutRegExp,
     })
 
@@ -417,7 +417,7 @@ describe('Cargo CLI: Pipeline Settlement', () => {
     ).toHaveMatchingSpawnOutput({
       code: 0,
       stderr:
-        /InitSettlement ... txes 0(.|\n|\r)*already funded(.|\n|\r)*Stake accounts management txes 0(.|\n|\r)*FundSettlements: txes 0/,
+        /InitSettlement ... txes 0(.|\n|\r)*already funded(.|\n|\r)*Stake accounts management: txes 0(.|\n|\r)*FundSettlements: txes 0/,
       stdout: stdoutRegExp,
     })
     previousTest = TestNames.InitSettlement

--- a/settlement-pipelines/src/bin/claim_settlement.rs
+++ b/settlement-pipelines/src/bin/claim_settlement.rs
@@ -52,8 +52,9 @@ use validator_bonds_common::settlement_claims::{
     collect_existence_settlement_claims_from_addresses, get_settlement_claims_for_settlement,
 };
 use validator_bonds_common::settlements::get_settlements_for_pubkeys;
-use validator_bonds_common::stake_accounts::{get_stake_history, CollectedStakeAccounts};
-use validator_bonds_common::utils::get_sysvar_clock;
+use validator_bonds_common::stake_accounts::{
+    get_clock, get_stake_history, CollectedStakeAccounts,
+};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -147,8 +148,12 @@ async fn real_main(reporting: &mut ReportHandler<ClaimSettlementReport>) -> anyh
     transaction_builder.add_signer_checked(&rent_payer);
     let transaction_executor = get_executor(rpc_client.clone(), tip_policy);
 
-    let clock = get_sysvar_clock(rpc_client.clone()).await?;
-    let stake_history = get_stake_history(rpc_client.clone()).await?;
+    let clock = get_clock(rpc_client.clone())
+        .await
+        .map_err(CliError::retry_able)?;
+    let stake_history = get_stake_history(rpc_client.clone())
+        .await
+        .map_err(CliError::retry_able)?;
 
     let mut settlement_claimed_amounts: HashMap<Pubkey, u64> = HashMap::new();
     let mut stake_accounts_to_cache = StakeAccountsCache::default();

--- a/settlement-pipelines/src/bin/close_settlement.rs
+++ b/settlement-pipelines/src/bin/close_settlement.rs
@@ -46,8 +46,7 @@ use validator_bonds_common::config::get_config;
 use validator_bonds_common::constants::find_event_authority;
 use validator_bonds_common::settlement_claims::get_settlement_claims;
 use validator_bonds_common::settlements::get_settlements;
-use validator_bonds_common::stake_accounts::collect_stake_accounts;
-use validator_bonds_common::utils::get_sysvar_clock;
+use validator_bonds_common::stake_accounts::{collect_stake_accounts, get_clock};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -335,7 +334,7 @@ async fn reset_stake_accounts(
             .map(|(k, v)| (k, v.settlement))
             .collect::<Vec<(&Pubkey, Pubkey)>>()
     );
-    let clock = get_sysvar_clock(rpc_client.clone())
+    let clock = get_clock(rpc_client.clone())
         .await
         .map_err(CliError::retry_able)?;
     let all_stake_accounts =

--- a/settlement-pipelines/src/cli_result.rs
+++ b/settlement-pipelines/src/cli_result.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use log::error;
 use std::fmt;
 use std::fmt::Debug;
 use std::process::{ExitCode, Termination};
@@ -62,8 +63,14 @@ impl From<CliError> for ExitCode {
     fn from(err: CliError) -> ExitCode {
         match err {
             // default exit code for failure is 1
-            CliError::Processing(_) => ExitCode::from(2),
-            CliError::RetryAble(_) => ExitCode::from(100),
+            CliError::Processing(e) => {
+                error!("{:?}", e);
+                ExitCode::from(2)
+            }
+            CliError::RetryAble(e) => {
+                error!("{:?}", e);
+                ExitCode::from(100)
+            }
         }
     }
 }

--- a/settlement-pipelines/src/reporting.rs
+++ b/settlement-pipelines/src/reporting.rs
@@ -132,7 +132,7 @@ pub async fn with_reporting<T: PrintReportable>(
         Ok(_) => CliResult(report_handler.finalize()),
         // when main returned some error we pass it to terminate with it
         Err(err) => {
-            println!("ERROR: {:?}", err);
+            println!("ERROR: {}", err);
             CliResult(Err(err))
         }
     }

--- a/settlement-pipelines/src/settlements.rs
+++ b/settlement-pipelines/src/settlements.rs
@@ -10,9 +10,9 @@ use validator_bonds::state::settlement::{find_settlement_staker_authority, Settl
 use validator_bonds::state::settlement_claim::SettlementClaim;
 use validator_bonds_common::settlements::{get_bonds_for_settlements, get_settlements};
 use validator_bonds_common::stake_accounts::{
-    collect_stake_accounts, obtain_claimable_stake_accounts_for_settlement, CollectedStakeAccounts,
+    collect_stake_accounts, get_clock, obtain_claimable_stake_accounts_for_settlement,
+    CollectedStakeAccounts,
 };
-use validator_bonds_common::utils::get_sysvar_clock;
 
 pub const SETTLEMENT_CLAIM_ACCOUNT_SIZE: usize = 8 + std::mem::size_of::<SettlementClaim>();
 
@@ -28,7 +28,7 @@ pub async fn list_claimable_settlements(
     config_address: &Pubkey,
     config: &Config,
 ) -> Result<Vec<ClaimableSettlementsReturn>, CliError> {
-    let clock = get_sysvar_clock(rpc_client.clone())
+    let clock = get_clock(rpc_client.clone())
         .await
         .map_err(CliError::RetryAble)?;
     let current_epoch = clock.epoch;
@@ -110,7 +110,7 @@ pub async fn load_expired_settlements(
     config_address: &Pubkey,
     config: &Config,
 ) -> anyhow::Result<Vec<(Pubkey, Settlement)>> {
-    let clock = get_sysvar_clock(rpc_client.clone()).await?;
+    let clock = get_clock(rpc_client.clone()).await?;
     let current_epoch = clock.epoch;
 
     let all_settlements = get_settlements(rpc_client.clone()).await?;


### PR DESCRIPTION
The `init_settlement` pipeline started to fail as the pipeline wrongly did not consider the stake account state and was not able to merge in such cases.

The change verifies the stake state and lets only those with the same state merge. If the state differs then it funds the accounts directly without merging beforehand.

Still, the merging is beneficial for claiming we need the best one big account that is just split into parts and not pointing into settlements multiple accounts that need to stay with "overflow" of 1 SOL as being the requirements for the existence of the stake account.
