### PR TITLE
[pipelines] claim settlement to be capable to merge stake accounts

### DIFF
--- a/common-rs/src/stake_accounts.rs
+++ b/common-rs/src/stake_accounts.rs
@@ -32,7 +32,9 @@ pub async fn get_clock(rpc_client: Arc<RpcClient>) -> anyhow::Result<Clock> {
 }
 
 /// stake account pubkey, lamports in account, stake state
-pub type CollectedStakeAccounts = Vec<(Pubkey, u64, StakeStateV2)>;
+
+pub type CollectedStakeAccount = (Pubkey, u64, StakeStateV2);
+pub type CollectedStakeAccounts = Vec<CollectedStakeAccount>;
 
 pub async fn collect_stake_accounts(
     rpc_client: Arc<RpcClient>,

--- a/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
+++ b/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
@@ -63,7 +63,7 @@ const VOTE_ACCOUNT_IDENTITY = Keypair.fromSecretKey(
 // This test case runs really long as using data from epoch 601 and needs to setup
 // all parts and create 10K settlements. Run this manually when needed
 // FILE='settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts' pnpm test:validator
-describe('Cargo CLI: Pipeline Settlement', () => {
+describe.skip('Cargo CLI: Pipeline Settlement', () => {
   let provider: AnchorExtendedProvider
   let program: ValidatorBondsProgram
 

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -1,10 +1,24 @@
+use crate::anchor::add_instruction_to_builder;
 use anchor_client::anchor_lang::solana_program::stake_history::StakeHistoryEntry;
+use anchor_client::{DynSigner, Program};
 use anyhow::anyhow;
+use log::warn;
 use solana_sdk::clock::Clock;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::stake::program::ID as stake_program_id;
 use solana_sdk::stake::state::StakeStateV2;
 use solana_sdk::stake_history::StakeHistory;
-use validator_bonds_common::stake_accounts::{is_locked, CollectedStakeAccounts};
+use solana_sdk::sysvar::{
+    clock::ID as clock_sysvar_id, stake_history::ID as stake_history_sysvar_id,
+};
+use solana_transaction_builder::TransactionBuilder;
+use std::sync::Arc;
+use validator_bonds::instructions::MergeStakeArgs;
+use validator_bonds::ID as validator_bonds_id;
+use validator_bonds_common::constants::find_event_authority;
+use validator_bonds_common::stake_accounts::{
+    is_locked, CollectedStakeAccount, CollectedStakeAccounts,
+};
 
 // TODO: better to be loaded from chain
 pub const STAKE_ACCOUNT_RENT_EXEMPTION: u64 = 2282880;
@@ -112,4 +126,68 @@ pub fn filter_settlement_funded(
             is_settlement_funded && !is_locked(state, clock)
         })
         .collect()
+}
+
+/// Preparing instructions to merge stake accounts from stake_accounts_to_merge into destination_stake
+/// Returning list of stake accounts addresses that cannot be merged.
+#[allow(clippy::too_many_arguments)]
+pub async fn prepare_merge_instructions(
+    stake_accounts_to_merge: Vec<&CollectedStakeAccount>,
+    destination_stake: Pubkey,
+    destination_stake_state_type: StakeAccountStateType,
+    settlement_address: &Pubkey,
+    vote_account_address: Option<&Pubkey>,
+    program: &Program<Arc<DynSigner>>,
+    config_address: &Pubkey,
+    staker_authority: &Pubkey,
+    transaction_builder: &mut TransactionBuilder,
+    clock: &Clock,
+    stake_history: &StakeHistory,
+) -> anyhow::Result<Vec<Pubkey>> {
+    let mut non_mergeable_stake_accounts: Vec<Pubkey> = vec![];
+    // can we merge stake accounts? (stake accounts can be merged only when both in the same state)
+    for (stake_account_address, _, stake_account_state) in stake_accounts_to_merge {
+        let stake_account_to_merge_state_type =
+            get_stake_state_type(stake_account_state, clock, stake_history);
+        if stake_account_to_merge_state_type != destination_stake_state_type {
+            // will be funded each separately
+            warn!(
+                "Cannot merge stake accounts {} and {} for funding settlement {} (vote account {}) as they are in different states",
+                stake_account_address,
+                destination_stake,
+                settlement_address,
+                vote_account_address.map_or_else(|| "not-known".to_string(), |v| v.to_string())
+            );
+            non_mergeable_stake_accounts.push(*stake_account_address);
+        } else {
+            // will be funded as one merged account
+            let req = program
+                .request()
+                .accounts(validator_bonds::accounts::MergeStake {
+                    config: *config_address,
+                    stake_history: stake_history_sysvar_id,
+                    clock: clock_sysvar_id,
+                    source_stake: *stake_account_address,
+                    destination_stake,
+                    staker_authority: *staker_authority,
+                    stake_program: stake_program_id,
+                    program: validator_bonds_id,
+                    event_authority: find_event_authority().0,
+                })
+                .args(validator_bonds::instruction::MergeStake {
+                    merge_args: MergeStakeArgs {
+                        settlement: *settlement_address,
+                    },
+                });
+            add_instruction_to_builder(
+                transaction_builder,
+                &req,
+                format!(
+                    "MergeStake: {} -> {}",
+                    stake_account_address, destination_stake
+                ),
+            )?;
+        }
+    }
+    Ok(non_mergeable_stake_accounts)
 }


### PR DESCRIPTION

For claiming from stake accounts it should be checked to merge provided stake accounts.
This helps to align the number of stake accounts for Settlement and fixes possible unclear states that the stake account is not funded directly through contract.

- Not urgent for review.
- I was playing with this on my way back from IslandDAO but needed to finalize it now.