### PR TITLE
[contract] fund makes possible when activating

### DIFF
--- a/common-rs/src/stake_accounts.rs
+++ b/common-rs/src/stake_accounts.rs
@@ -149,7 +149,8 @@ pub async fn obtain_claimable_stake_accounts_for_settlement(
                     .effective
                     == 0
             } else {
-                // non-locked, non-delegated, maybe initialized (more filtering under map_stake_accounts_to_settlement)
+                // non-locked, non-delegated, maybe initialized (initialized has got authorities but not delegation)
+                // (more filtering under map_stake_accounts_to_settlement)
                 true
             }
         })

--- a/packages/validator-bonds-sdk/__tests__/bankrun/bankrun.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/bankrun.ts
@@ -126,7 +126,6 @@ export enum StakeActivationState {
   Activated, // 2
   Deactivated, // 3
   NonDelegated, // 4
-  Unknown = 128,
 }
 
 export async function stakeActivation(
@@ -169,7 +168,8 @@ export async function stakeActivation(
       // activationEpoch is set in the past
       return StakeActivationState.Activated
     } else {
-      return StakeActivationState.Unknown
+      // unexpected state for the check
+      throw new Error("Unexpected state for the stake account's activation")
     }
   }
   // Uninitialized, RewardsPool, anything else...

--- a/packages/validator-bonds-sdk/__tests__/bankrun/bankrun.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/bankrun.ts
@@ -144,7 +144,7 @@ export async function stakeActivation(
       stakeState.Stake.stake.delegation.deactivationEpoch
     const curEpoch = new BN(await currentEpoch(provider))
 
-    // when deactivation or activation epoch is set to U64_MAX, it is not set
+    // value U64_MAX means "not being set"
     if (
       !deactivationEpoch.eq(U64_MAX) &&
       deactivationEpoch.gte(curEpoch) &&

--- a/packages/validator-bonds-sdk/__tests__/bankrun/fundBond.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/fundBond.spec.ts
@@ -137,7 +137,7 @@ describe('Validator Bonds fund bond account', () => {
     }
   })
 
-  it('fund deactivated', async () => {
+  it('not permitted to fund deactivated', async () => {
     const { stakeAccount, withdrawer, staker } = await delegatedStakeAccount({
       provider,
       lamports: LAMPORTS_PER_SOL * 2,
@@ -163,12 +163,15 @@ describe('Validator Bonds fund bond account', () => {
       stakeAccount,
       stakeAccountAuthority: withdrawer,
     })
-    await provider.sendIx([withdrawer], instruction)
-
-    await checkStakeFundedToBond(stakeAccount)
+    try {
+      await provider.sendIx([withdrawer], instruction)
+      throw new Error('failure expected as deactivated state')
+    } catch (e) {
+      verifyError(e, Errors, 6064, 'not activating or activated')
+    }
   })
 
-  it('fund deactivating', async () => {
+  it('not permitted to fund deactivating', async () => {
     const { stakeAccount, withdrawer, staker } = await delegatedStakeAccount({
       provider,
       lamports: LAMPORTS_PER_SOL * 2,
@@ -197,9 +200,12 @@ describe('Validator Bonds fund bond account', () => {
       stakeAccount,
       stakeAccountAuthority: withdrawer,
     })
-    await provider.sendIx([withdrawer], instruction)
-
-    await checkStakeFundedToBond(stakeAccount)
+    try {
+      await provider.sendIx([withdrawer], instruction)
+      throw new Error('failure expected as deactivating state')
+    } catch (e) {
+      verifyError(e, Errors, 6064, 'not activating or activated')
+    }
   })
 
   it('fund stake just created', async () => {
@@ -221,9 +227,6 @@ describe('Validator Bonds fund bond account', () => {
     })
     await provider.sendIx([withdrawer], instruction)
 
-    expect(await stakeActivation(provider, stakeAccount)).toEqual(
-      StakeActivationState.Activating
-    )
     await checkStakeFundedToBond(stakeAccount)
   })
 

--- a/packages/validator-bonds-sdk/__tests__/bankrun/fundBond.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/fundBond.spec.ts
@@ -152,6 +152,9 @@ describe('Validator Bonds fund bond account', () => {
       authorizedPubkey: staker.publicKey,
     })
     await provider.sendIx([provider.wallet, staker], deactivateIx)
+    expect(await stakeActivation(provider, stakeAccount)).toEqual(
+      StakeActivationState.Deactivated
+    )
 
     const { instruction } = await fundBondInstruction({
       program,
@@ -205,6 +208,9 @@ describe('Validator Bonds fund bond account', () => {
       lamports: LAMPORTS_PER_SOL * 2,
       voteAccountToDelegate: bond.account.voteAccount,
     })
+    expect(await stakeActivation(provider, stakeAccount)).toEqual(
+      StakeActivationState.Activating
+    )
 
     const { instruction } = await fundBondInstruction({
       program,
@@ -283,6 +289,9 @@ describe('Validator Bonds fund bond account', () => {
       stakeAccountAuthority: withdrawer,
     })
     await warpToNextEpoch(provider)
+    expect(await stakeActivation(provider, stakeAccount)).toEqual(
+      StakeActivationState.Activated
+    )
     await provider.sendIx([withdrawer], instruction)
 
     const [stakeAccountData2, stakeAccountInfo] = await getAndCheckStakeAccount(

--- a/packages/validator-bonds-sdk/__tests__/bankrun/fundBond.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/fundBond.spec.ts
@@ -16,18 +16,27 @@ import {
   executeInitConfigInstruction,
 } from '../utils/testTransactions'
 import { ProgramAccount } from '@coral-xyz/anchor'
-import { Keypair, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js'
+import {
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  StakeProgram,
+} from '@solana/web3.js'
+import BN from 'bn.js'
+import { signer } from '@marinade.finance/web3js-common'
+import { verifyError } from '@marinade.finance/anchor-common'
+import {
+  StakeActivationState,
+  initBankrunTest,
+  stakeActivation,
+} from './bankrun'
 import {
   StakeStates,
+  createInitializedStakeAccount,
   createVoteAccount,
   delegatedStakeAccount,
   getAndCheckStakeAccount,
-  createInitializedStakeAccount,
 } from '../utils/staking'
-import { BN } from 'bn.js'
-import { signer } from '@marinade.finance/web3js-common'
-import { verifyError } from '@marinade.finance/anchor-common'
-import { initBankrunTest } from './bankrun'
 
 describe('Validator Bonds fund bond account', () => {
   let provider: BankrunExtendedProvider
@@ -35,6 +44,7 @@ describe('Validator Bonds fund bond account', () => {
   let configAccount: PublicKey
   let bond: ProgramAccount<Bond>
   let bondAuthority: Keypair
+  let bondWithdrawAuthority: PublicKey
   const startUpEpoch = Math.floor(Math.random() * 100) + 100
 
   beforeAll(async () => {
@@ -64,6 +74,10 @@ describe('Validator Bonds fund bond account', () => {
       publicKey: bondAccount,
       account: await getBond(program, bondAccount),
     }
+    bondWithdrawAuthority = bondsWithdrawerAuthority(
+      configAccount,
+      program.programId
+    )[0]
   })
 
   it('cannot fund with non-delegated stake account', async () => {
@@ -84,11 +98,12 @@ describe('Validator Bonds fund bond account', () => {
     }
   })
 
-  it('cannot fund bond non activated with wrong delegation', async () => {
+  it('cannot fund wrong delegation', async () => {
     // random vote account is generated on the call of method delegatedStakeAccount
+    const stakeAccountLamports = LAMPORTS_PER_SOL * 2
     const { stakeAccount, withdrawer } = await delegatedStakeAccount({
       provider,
-      lamports: LAMPORTS_PER_SOL * 2,
+      lamports: stakeAccountLamports,
     })
     const { instruction } = await fundBondInstruction({
       program,
@@ -97,20 +112,113 @@ describe('Validator Bonds fund bond account', () => {
       stakeAccount,
       stakeAccountAuthority: withdrawer,
     })
-    try {
-      await provider.sendIx([withdrawer], instruction)
-      throw new Error('failure expected as not activated')
-    } catch (e) {
-      verifyError(e, Errors, 6025, 'Stake account is not fully activated')
-    }
 
-    await warpToNextEpoch(provider)
+    // activating, wrongly delegated
+    expect(await stakeActivation(provider, stakeAccount)).toEqual(
+      StakeActivationState.Activating
+    )
     try {
       await provider.sendIx([withdrawer], instruction)
       throw new Error('failure expected as delegated to wrong validator')
     } catch (e) {
       verifyError(e, Errors, 6020, 'delegated to a wrong validator')
     }
+
+    await warpToNextEpoch(provider)
+    // activated, still wrongly delegated
+    expect(await stakeActivation(provider, stakeAccount)).toEqual(
+      StakeActivationState.Activated
+    )
+    try {
+      await provider.sendIx([withdrawer], instruction)
+      throw new Error('failure expected as delegated to wrong validator')
+    } catch (e) {
+      verifyError(e, Errors, 6020, 'delegated to a wrong validator')
+    }
+  })
+
+  it('fund deactivated', async () => {
+    const { stakeAccount, withdrawer, staker } = await delegatedStakeAccount({
+      provider,
+      lamports: LAMPORTS_PER_SOL * 2,
+      voteAccountToDelegate: bond.account.voteAccount,
+    })
+    expect(await stakeActivation(provider, stakeAccount)).toEqual(
+      StakeActivationState.Activating
+    )
+
+    const deactivateIx = StakeProgram.deactivate({
+      stakePubkey: stakeAccount,
+      authorizedPubkey: staker.publicKey,
+    })
+    await provider.sendIx([provider.wallet, staker], deactivateIx)
+
+    const { instruction } = await fundBondInstruction({
+      program,
+      configAccount,
+      bondAccount: bond.publicKey,
+      stakeAccount,
+      stakeAccountAuthority: withdrawer,
+    })
+    await provider.sendIx([withdrawer], instruction)
+
+    await checkStakeFundedToBond(stakeAccount)
+  })
+
+  it('fund deactivating', async () => {
+    const { stakeAccount, withdrawer, staker } = await delegatedStakeAccount({
+      provider,
+      lamports: LAMPORTS_PER_SOL * 2,
+      voteAccountToDelegate: bond.account.voteAccount,
+    })
+    expect(await stakeActivation(provider, stakeAccount)).toEqual(
+      StakeActivationState.Activating
+    )
+    warpToNextEpoch(provider)
+    expect(await stakeActivation(provider, stakeAccount)).toEqual(
+      StakeActivationState.Activated
+    )
+    const deactivateIx = StakeProgram.deactivate({
+      stakePubkey: stakeAccount,
+      authorizedPubkey: staker.publicKey,
+    })
+    await provider.sendIx([provider.wallet, staker], deactivateIx)
+    expect(await stakeActivation(provider, stakeAccount)).toEqual(
+      StakeActivationState.Deactivating
+    )
+
+    const { instruction } = await fundBondInstruction({
+      program,
+      configAccount,
+      bondAccount: bond.publicKey,
+      stakeAccount,
+      stakeAccountAuthority: withdrawer,
+    })
+    await provider.sendIx([withdrawer], instruction)
+
+    await checkStakeFundedToBond(stakeAccount)
+  })
+
+  it('fund stake just created', async () => {
+    const { stakeAccount, withdrawer } = await delegatedStakeAccount({
+      provider,
+      lamports: LAMPORTS_PER_SOL * 2,
+      voteAccountToDelegate: bond.account.voteAccount,
+    })
+
+    const { instruction } = await fundBondInstruction({
+      program,
+      configAccount,
+      bondAccount: bond.publicKey,
+      stakeAccount,
+      stakeAccountAuthority: withdrawer,
+    })
+    await provider.sendIx([withdrawer], instruction)
+
+    expect(await stakeActivation(provider, stakeAccount)).toEqual(
+      StakeActivationState.Activating
+    )
+    await checkStakeFundedToBond(stakeAccount)
   })
 
   it('cannot fund bond with lockup delegation', async () => {
@@ -204,4 +312,18 @@ describe('Validator Bonds fund bond account', () => {
       verifyError(e, Errors, 6012, 'Wrong withdrawer authority')
     }
   })
+
+  async function checkStakeFundedToBond(stakeAccount: PublicKey) {
+    const [stakeAccountDataFunded] = await getAndCheckStakeAccount(
+      provider,
+      stakeAccount,
+      StakeStates.Delegated
+    )
+    expect(stakeAccountDataFunded.Stake?.meta.authorized.withdrawer).toEqual(
+      bondWithdrawAuthority
+    )
+    expect(stakeAccountDataFunded.Stake?.meta.authorized.staker).toEqual(
+      bondWithdrawAuthority
+    )
+  }
 })

--- a/packages/validator-bonds-sdk/__tests__/utils/testTransactions.ts
+++ b/packages/validator-bonds-sdk/__tests__/utils/testTransactions.ts
@@ -514,8 +514,8 @@ export async function executeInitSettlement({
   epoch: BN
   rentCollector: PublicKey
   merkleRoot: number[] | Uint8Array | Buffer
-  maxMerkleNodes: number
-  maxTotalClaim: number
+  maxMerkleNodes: BN
+  maxTotalClaim: BN
 }> {
   const {
     instruction,
@@ -542,8 +542,8 @@ export async function executeInitSettlement({
     epoch: settlementEpoch,
     rentCollector,
     merkleRoot,
-    maxMerkleNodes: new BN(maxMerkleNodes).toNumber(),
-    maxTotalClaim: new BN(maxTotalClaim).toNumber(),
+    maxMerkleNodes: new BN(maxMerkleNodes),
+    maxTotalClaim: new BN(maxTotalClaim),
   }
 }
 

--- a/packages/validator-bonds-sdk/generated/validator_bonds.ts
+++ b/packages/validator-bonds-sdk/generated/validator_bonds.ts
@@ -4472,6 +4472,11 @@ export type ValidatorBonds = {
       "code": 6063,
       "name": "MaxStakeWantedTooLow",
       "msg": "Max stake wanted value is lower to minimum configured value"
+    },
+    {
+      "code": 6064,
+      "name": "NoStakeOrNotActivatingOrActivated",
+      "msg": "Stake account is not activating or activated"
     }
   ]
 };
@@ -8950,6 +8955,11 @@ export const IDL: ValidatorBonds = {
       "code": 6063,
       "name": "MaxStakeWantedTooLow",
       "msg": "Max stake wanted value is lower to minimum configured value"
+    },
+    {
+      "code": 6064,
+      "name": "NoStakeOrNotActivatingOrActivated",
+      "msg": "Stake account is not activating or activated"
     }
   ]
 };

--- a/programs/validator-bonds/src/error.rs
+++ b/programs/validator-bonds/src/error.rs
@@ -80,6 +80,7 @@ pub enum ErrorCode {
     #[msg("Stake is not initialized")]
     UninitializedStake, // 6024 0x1788
 
+    /// Deprecated
     #[msg("Stake account is not fully activated")]
     NoStakeOrNotFullyActivated, // 6025 0x1789
 

--- a/programs/validator-bonds/src/error.rs
+++ b/programs/validator-bonds/src/error.rs
@@ -199,5 +199,5 @@ pub enum ErrorCode {
     MaxStakeWantedTooLow, // 6063 0x17af
 
     #[msg("Stake account is not activating or activated")]
-    NoStakeOrNotActivatingOrActivated, // 6026 0x178a
+    NoStakeOrNotActivatingOrActivated, // 6064 0x17b0
 }

--- a/programs/validator-bonds/src/error.rs
+++ b/programs/validator-bonds/src/error.rs
@@ -197,4 +197,7 @@ pub enum ErrorCode {
 
     #[msg("Max stake wanted value is lower to minimum configured value")]
     MaxStakeWantedTooLow, // 6063 0x17af
+
+    #[msg("Stake account is not activating or activated")]
+    NoStakeOrNotActivatingOrActivated, // 6026 0x178a
 }

--- a/programs/validator-bonds/src/instructions/bond/fund_bond.rs
+++ b/programs/validator-bonds/src/instructions/bond/fund_bond.rs
@@ -1,6 +1,6 @@
 use crate::checks::{
-    check_stake_exist_and_fully_activated, check_stake_is_initialized_with_withdrawer_authority,
-    check_stake_is_not_locked, check_stake_valid_delegation,
+    check_stake_is_initialized_with_withdrawer_authority, check_stake_is_not_locked,
+    check_stake_valid_delegation,
 };
 use crate::error::ErrorCode;
 use crate::events::bond::FundBondEvent;
@@ -72,11 +72,9 @@ impl<'info> FundBond<'info> {
             &ctx.accounts.clock,
             "stake_account",
         )?;
-        check_stake_exist_and_fully_activated(
-            &ctx.accounts.stake_account,
-            ctx.accounts.clock.epoch,
-            &ctx.accounts.stake_history,
-        )?;
+        if ctx.accounts.stake_account.delegation().is_none() {
+            return Err(error!(ErrorCode::StakeNotDelegated).with_account_name("stake_account"));
+        }
         check_stake_valid_delegation(&ctx.accounts.stake_account, &ctx.accounts.bond.vote_account)?;
 
         // when the stake account is already "owned" by the bonds program, return OK

--- a/programs/validator-bonds/src/instructions/bond/fund_bond.rs
+++ b/programs/validator-bonds/src/instructions/bond/fund_bond.rs
@@ -1,4 +1,5 @@
 use crate::checks::{
+    check_stake_exist_and_activating_or_activated,
     check_stake_is_initialized_with_withdrawer_authority, check_stake_is_not_locked,
     check_stake_valid_delegation,
 };
@@ -72,9 +73,11 @@ impl<'info> FundBond<'info> {
             &ctx.accounts.clock,
             "stake_account",
         )?;
-        if ctx.accounts.stake_account.delegation().is_none() {
-            return Err(error!(ErrorCode::StakeNotDelegated).with_account_name("stake_account"));
-        }
+        check_stake_exist_and_activating_or_activated(
+            &ctx.accounts.stake_account,
+            ctx.accounts.clock.epoch,
+            &ctx.accounts.stake_history,
+        )?;
         check_stake_valid_delegation(&ctx.accounts.stake_account, &ctx.accounts.bond.vote_account)?;
 
         // when the stake account is already "owned" by the bonds program, return OK


### PR DESCRIPTION
Changing `fund_bond` instruction to permit to funding of any stake account that is:
* delegated 
* non-locked

Before this change, it does matter if it's activating or deactivating etc. It was permitted to get funded only fully activated stake account.

The idea behind the change is to make it easier to fund a bond for validators.
It should be possible to create a stake account and immediately fund it to the bond account without the need to wait a whole epoch to get it activated (as it is for a newly created stake account right now).

The technical presumption of the change is 

* The `fund_bond` changes the `withdraw` and `staker` authorities to a PDA `validator bonds authority` based on the program id and config address.
* The bond-funded stake account can be used to fund the Settlement. The `fund_settlement` instruction checks locking, delegation and authorities and then deactivates the stake.
* For just bond-funded stake to be used for settlement on a protected event or bidding then:

  1. The stake account is used in the next (or follow-up) epochs from the time the stake account was funded - for settlement 
funding, it's the same situation as bond funding only fully activated stake accounts.
  2. The stake account is used in the current epoch, in the same epoch as it was funded to bond - deactivation (by a matter of calling `fund_settlement`) happens when the stake is in an activating state which makes it deactivated and usable for claiming.

_Note: the current implementation does not limit the possibility of having the stake account being activated/deactivated only partially. There are timeouts of 3 epochs when Settlement is active and can be funded and can be claimed. It is "expected" that the deactivation is finished by Solana until the Settlement is closed. The deactivated stake accounts can be withdrawn._