### PR TITLE
[contract&test] test for fund_settlement usage of un-delegated SOLs in stake account

### DIFF
--- a/packages/validator-bonds-sdk/__tests__/utils/staking.ts
+++ b/packages/validator-bonds-sdk/__tests__/utils/staking.ts
@@ -118,6 +118,7 @@ export async function getAndCheckStakeAccount(
   }
   expect(accountInfo).toBeDefined()
   assert(accountInfo)
+  expect(accountInfo.owner).toEqual(StakeProgram.programId)
   const stakeData = deserializeStakeState(accountInfo.data)
   switch (stakeStateCheck) {
     case StakeStates.Uninitialized:


### PR DESCRIPTION
Adding tests that check the behaviour of `fund_settlement` instruction for stake account that is mostly delegated to a validator but there is some SOL that's not delegated (expected that it may happen e.g., for validators that gets MEV rewards as direct transfer of SOLs into stake account, that part of SOL is not delegated).

When such a stake account is used for (part delegated, part - smaller to 1 SOL - is not-delegated) funding a `Settlement` then the stake account will be assigned with non-delegated SOLs and then the rest will be the delegated SOLs.

This as well means that MEV rewards are just used for paying for Settlement creation and there is not a big need for any special redelegation instruction.