### PR TITLE
[contract] fund settlement with non-delegated lamports

### DIFF
--- a/packages/validator-bonds-sdk/__tests__/bankrun/fundSettlement.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/fundSettlement.spec.ts
@@ -724,6 +724,275 @@ describe('Validator Bonds fund settlement', () => {
     )
   })
 
+  it.each([50, 0.5, 0.1])(
+    'fund settlement non-delegated split: %d',
+    async totalClaim => {
+      const maxTotalClaim = totalClaim * LAMPORTS_PER_SOL
+      const { settlementAccount } = await executeInitSettlement({
+        configAccount,
+        program,
+        provider,
+        voteAccount,
+        operatorAuthority,
+        currentEpoch: settlementEpoch,
+        maxTotalClaim,
+      })
+
+      const lamportsToFund = 4444 * LAMPORTS_PER_SOL
+      const stakeAccount =
+        await createBondsFundedStakeAccountActivated(lamportsToFund)
+      let stakeAccountData =
+        await provider.connection.getAccountInfo(stakeAccount)
+      expect(stakeAccountData?.lamports).toEqual(lamportsToFund)
+      // adding some more lamports to stake account that are not delegated
+      // when the amount of non-delegated lamports is bigger
+      const stakeAccountTransferredLamports =
+        maxTotalClaim + rentExemptStake + 1
+      const transferIx = SystemProgram.transfer({
+        fromPubkey: provider.wallet.publicKey,
+        toPubkey: stakeAccount,
+        lamports: stakeAccountTransferredLamports,
+      })
+      await provider.sendIx([], transferIx)
+      await getAndCheckStakeAccount(
+        provider,
+        stakeAccount,
+        StakeStates.Delegated
+      )
+      stakeAccountData = await provider.connection.getAccountInfo(stakeAccount)
+      expect(stakeAccountData?.lamports).toEqual(
+        lamportsToFund + stakeAccountTransferredLamports
+      )
+
+      let settlementData = await getSettlement(program, settlementAccount)
+      expect(settlementData.lamportsFunded).toEqual(0)
+
+      const { instruction, splitStakeAccount } =
+        await fundSettlementInstruction({
+          program,
+          settlementAccount,
+          stakeAccount: stakeAccount,
+        })
+      await provider.sendIx(
+        [signer(splitStakeAccount), operatorAuthority],
+        instruction
+      )
+
+      settlementData = await getSettlement(program, settlementAccount)
+      stakeAccountData = await provider.connection.getAccountInfo(stakeAccount)
+      const splitStakeAccountData = await provider.connection.getAccountInfo(
+        pubkey(splitStakeAccount)
+      )
+
+      expect(stakeAccountData?.lamports).toEqual(
+        maxTotalClaim +
+          2 * rentExemptStake + // rent for stake account + for returning rent exempt for split stake account
+          config.minimumStakeLamports.toNumber()
+      )
+      expect(splitStakeAccountData?.lamports).toEqual(
+        lamportsToFund +
+          stakeAccountTransferredLamports -
+          maxTotalClaim -
+          config.minimumStakeLamports.toNumber() -
+          rentExemptStake
+      )
+      expect(settlementData.lamportsFunded).toEqual(maxTotalClaim)
+    }
+  )
+
+  it.each([50, 0.5, 0.1])(
+    'fund settlement minimum delegated amount: %d',
+    async totalClaim => {
+      const maxTotalClaim = totalClaim * LAMPORTS_PER_SOL
+      const { settlementAccount } = await executeInitSettlement({
+        configAccount,
+        program,
+        provider,
+        voteAccount,
+        operatorAuthority,
+        currentEpoch: settlementEpoch,
+        maxTotalClaim,
+      })
+
+      const lamportsToFund =
+        config.minimumStakeLamports.toNumber() + rentExemptStake
+      const stakeAccount =
+        await createBondsFundedStakeAccountActivated(lamportsToFund)
+      let stakeAccountData =
+        await provider.connection.getAccountInfo(stakeAccount)
+      expect(stakeAccountData?.lamports).toEqual(lamportsToFund)
+      const stakeAccountTransferredLamports = 500 * LAMPORTS_PER_SOL
+      const transferIx = SystemProgram.transfer({
+        fromPubkey: provider.wallet.publicKey,
+        toPubkey: stakeAccount,
+        lamports: stakeAccountTransferredLamports,
+      })
+      await provider.sendIx([], transferIx)
+      await getAndCheckStakeAccount(
+        provider,
+        stakeAccount,
+        StakeStates.Delegated
+      )
+      stakeAccountData = await provider.connection.getAccountInfo(stakeAccount)
+      expect(stakeAccountData?.lamports).toEqual(
+        lamportsToFund + stakeAccountTransferredLamports
+      )
+
+      let settlementData = await getSettlement(program, settlementAccount)
+      expect(settlementData.lamportsFunded).toEqual(0)
+
+      const { instruction, splitStakeAccount } =
+        await fundSettlementInstruction({
+          program,
+          settlementAccount,
+          stakeAccount: stakeAccount,
+        })
+      await provider.sendIx(
+        [signer(splitStakeAccount), operatorAuthority],
+        instruction
+      )
+
+      settlementData = await getSettlement(program, settlementAccount)
+      stakeAccountData = await provider.connection.getAccountInfo(stakeAccount)
+      const splitStakeAccountData = await provider.connection.getAccountInfo(
+        pubkey(splitStakeAccount)
+      )
+
+      expect(stakeAccountData?.lamports).toEqual(
+        maxTotalClaim +
+          2 * rentExemptStake + // rent for stake account + for returning rent exempt for split stake account
+          config.minimumStakeLamports.toNumber()
+      )
+      expect(splitStakeAccountData?.lamports).toEqual(
+        lamportsToFund +
+          stakeAccountTransferredLamports -
+          maxTotalClaim -
+          config.minimumStakeLamports.toNumber() -
+          rentExemptStake
+      )
+      expect(settlementData.lamportsFunded).toEqual(maxTotalClaim)
+      await getAndCheckStakeAccount(
+        provider,
+        pubkey(splitStakeAccount),
+        StakeStates.Delegated
+      )
+    }
+  )
+
+  it('double fund settlement minimum delegated amount', async () => {
+    const maxTotalClaim = 50 * LAMPORTS_PER_SOL
+    const { settlementAccount } = await executeInitSettlement({
+      configAccount,
+      program,
+      provider,
+      voteAccount,
+      operatorAuthority,
+      currentEpoch: settlementEpoch,
+      maxTotalClaim,
+    })
+    let settlementData = await getSettlement(program, settlementAccount)
+    expect(settlementData.lamportsFunded).toEqual(0)
+
+    // 1st stake account
+    const lamportsToFund =
+      config.minimumStakeLamports.toNumber() + rentExemptStake
+    const stakeAccount1 =
+      await createBondsFundedStakeAccountActivated(lamportsToFund)
+    let stakeAccountData1 =
+      await provider.connection.getAccountInfo(stakeAccount1)
+    expect(stakeAccountData1?.lamports).toEqual(lamportsToFund)
+    const stakeAccountTransferredLamports1 = 10 * LAMPORTS_PER_SOL
+    const transferIx1 = SystemProgram.transfer({
+      fromPubkey: provider.wallet.publicKey,
+      toPubkey: stakeAccount1,
+      lamports: stakeAccountTransferredLamports1,
+    })
+    await provider.sendIx([], transferIx1)
+    await getAndCheckStakeAccount(
+      provider,
+      stakeAccount1,
+      StakeStates.Delegated
+    )
+    stakeAccountData1 = await provider.connection.getAccountInfo(stakeAccount1)
+    expect(stakeAccountData1?.lamports).toEqual(
+      lamportsToFund + stakeAccountTransferredLamports1
+    )
+
+    // 2nd stake account
+    const stakeAccount2 =
+      await createBondsFundedStakeAccountActivated(lamportsToFund)
+    let stakeAccountData2 =
+      await provider.connection.getAccountInfo(stakeAccount2)
+    expect(stakeAccountData2?.lamports).toEqual(lamportsToFund)
+    const stakeAccountTransferredLamports2 = 100 * LAMPORTS_PER_SOL
+    const transferIx2 = SystemProgram.transfer({
+      fromPubkey: provider.wallet.publicKey,
+      toPubkey: stakeAccount2,
+      lamports: stakeAccountTransferredLamports2,
+    })
+    await provider.sendIx([], transferIx2)
+    await getAndCheckStakeAccount(
+      provider,
+      stakeAccount2,
+      StakeStates.Delegated
+    )
+    stakeAccountData2 = await provider.connection.getAccountInfo(stakeAccount2)
+    expect(stakeAccountData2?.lamports).toEqual(
+      lamportsToFund + stakeAccountTransferredLamports2
+    )
+
+    const { instruction: ixFund1, splitStakeAccount: split1 } =
+      await fundSettlementInstruction({
+        program,
+        settlementAccount,
+        stakeAccount: stakeAccount1,
+      })
+    await provider.sendIx([signer(split1), operatorAuthority], ixFund1)
+    assertNotExist(provider, pubkey(split1))
+    settlementData = await getSettlement(program, settlementAccount)
+    expect(settlementData.lamportsFunded).toEqual(
+      stakeAccountTransferredLamports1
+    )
+
+    const { instruction: ixFund2, splitStakeAccount: split2 } =
+      await fundSettlementInstruction({
+        program,
+        settlementAccount,
+        stakeAccount: stakeAccount2,
+      })
+    await provider.sendIx([signer(split2), operatorAuthority], ixFund2)
+
+    settlementData = await getSettlement(program, settlementAccount)
+    expect(settlementData.lamportsFunded).toEqual(maxTotalClaim)
+
+    stakeAccountData1 = await provider.connection.getAccountInfo(stakeAccount1)
+    stakeAccountData2 = await provider.connection.getAccountInfo(stakeAccount2)
+    const splitStakeAccountData2 = await provider.connection.getAccountInfo(
+      pubkey(split2)
+    )
+
+    expect(stakeAccountData1?.lamports).toEqual(
+      stakeAccountTransferredLamports1 +
+        rentExemptStake + // no split, just rent for stake account
+        config.minimumStakeLamports.toNumber()
+    )
+    expect(stakeAccountData2?.lamports).toEqual(
+      maxTotalClaim -
+        stakeAccountTransferredLamports1 +
+        2 * rentExemptStake + // rent for stake account + for returning rent exempt for split stake account
+        config.minimumStakeLamports.toNumber()
+    )
+    expect(splitStakeAccountData2?.lamports).toEqual(
+      stakeAccountTransferredLamports2 -
+        (maxTotalClaim - stakeAccountTransferredLamports1)
+    )
+    await getAndCheckStakeAccount(
+      provider,
+      pubkey(split2),
+      StakeStates.Delegated
+    )
+  })
+
   async function createBondsFundedStakeAccountActivated(
     lamports: number
   ): Promise<PublicKey> {

--- a/packages/validator-bonds-sdk/generated/validator_bonds.ts
+++ b/packages/validator-bonds-sdk/generated/validator_bonds.ts
@@ -1484,14 +1484,19 @@ export type ValidatorBonds = {
               {
                 "kind": "account",
                 "type": "publicKey",
-                "account": "Bond",
-                "path": "bond.vote_account"
+                "path": "vote_account"
               }
             ]
           },
           "relations": [
-            "config"
+            "config",
+            "vote_account"
           ]
+        },
+        {
+          "name": "voteAccount",
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "settlement",
@@ -1640,6 +1645,11 @@ export type ValidatorBonds = {
         },
         {
           "name": "stakeProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "stakeConfig",
           "isMut": false,
           "isSigner": false
         },
@@ -6576,14 +6586,19 @@ export const IDL: ValidatorBonds = {
               {
                 "kind": "account",
                 "type": "publicKey",
-                "account": "Bond",
-                "path": "bond.vote_account"
+                "path": "vote_account"
               }
             ]
           },
           "relations": [
-            "config"
+            "config",
+            "vote_account"
           ]
+        },
+        {
+          "name": "voteAccount",
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "settlement",
@@ -6732,6 +6747,11 @@ export const IDL: ValidatorBonds = {
         },
         {
           "name": "stakeProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "stakeConfig",
           "isMut": false,
           "isSigner": false
         },

--- a/packages/validator-bonds-sdk/src/instructions/fundSettlement.ts
+++ b/packages/validator-bonds-sdk/src/instructions/fundSettlement.ts
@@ -7,6 +7,7 @@ import {
   Keypair,
   Signer,
   SYSVAR_RENT_PUBKEY,
+  STAKE_CONFIG_ID,
 } from '@solana/web3.js'
 import { ValidatorBondsProgram, bondAddress } from '../sdk'
 import { getBond, getConfig, getSettlement } from '../api'
@@ -56,9 +57,10 @@ export async function fundSettlementInstruction({
     bondAccount = settlementData.bond
   }
 
-  if (configAccount === undefined) {
+  if (configAccount === undefined || voteAccount === undefined) {
     const bondData = await getBond(program, bondAccount)
     configAccount = bondData.config
+    voteAccount = bondData.voteAccount
   }
 
   if (operatorAuthority === undefined) {
@@ -86,6 +88,7 @@ export async function fundSettlementInstruction({
       bond: bondAccount,
       settlement: settlementAccount,
       operatorAuthority: operatorAuthorityPubkey,
+      voteAccount: voteAccount,
       stakeAccount,
       splitStakeAccount: splitStakeAccountPubkey,
       splitStakeRentPayer: splitStakeRentPayerPubkey,
@@ -93,6 +96,7 @@ export async function fundSettlementInstruction({
       rent: SYSVAR_RENT_PUBKEY,
       clock: SYSVAR_CLOCK_PUBKEY,
       stakeProgram: StakeProgram.programId,
+      stakeConfig: STAKE_CONFIG_ID,
     })
     .instruction()
   return {

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -25,6 +25,7 @@ use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::clock::Clock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
+use solana_sdk::stake::config::ID as stake_config_id;
 use solana_sdk::stake::instruction::create_account as create_stake_account_instructions;
 use solana_sdk::stake::program::ID as stake_program_id;
 use solana_sdk::sysvar::{
@@ -559,6 +560,7 @@ async fn fund_settlements(
                         .accounts(validator_bonds::accounts::FundSettlement {
                             config: *config_address,
                             bond: settlement_record.bond_address,
+                            vote_account: settlement_record.vote_account_address,
                             stake_account: *stake_account_to_fund,
                             bonds_withdrawer_authority: withdrawer_authority,
                             operator_authority: operator_authority.pubkey(),
@@ -572,6 +574,7 @@ async fn fund_settlements(
                             stake_history: stake_history_sysvar_id,
                             clock: clock_sysvar_id,
                             stake_program: stake_program_id,
+                            stake_config: stake_config_id,
                             program: validator_bonds_id,
                             event_authority: find_event_authority().0,
                         })


### PR DESCRIPTION
Currently when one tries to fund the Settlement with a stake account containing the larger amount of non-delegated lamports (bigger to funded amount + stake account rent) then the instruction fails.
It's because the stake program `split` instruction places all non-delegate lamports into the origin stake account and the rest is moved into a split. If the amount of non-delegated lamports is so many that the original stake account won't be a valid delegated stake account (a valid stake account needs to have delegated to a minimum of 1 SOL, at least per expected feature gate) then it ends failing.

I do propose a PR to fix the issue of funding Settlements with non-delegated lamports (when more of them available in a stake account).

But I'm not fully happy with the current result. I realized I needed to combine manual withdrawal with split and delegate to get the wanted behaviour. The fund settlement instruction started to be even more complicated than before, and I failed to make it somehow more readable.

Any input is appreciated.
(and I assume the task not being of the highest priority)
