### PR TITLE
Non sam events compatibity fix

### DIFF
--- a/.buildkite/claim-settlements.yml
+++ b/.buildkite/claim-settlements.yml
@@ -71,7 +71,7 @@ steps:
         for merkle_tree_file in $(gcloud storage ls "$gs_bucket/$$epoch/*settlement-merkle-trees.json"); do
           base_name=$(basename "$$merkle_tree_file")
           prefix_name="$${base_name%settlement-merkle-trees.json}"
-          target_dir="./merkle-trees/$${epoch}_$${prefix_name}/"
+          target_dir="./merkle-trees/$${epoch}_$${prefix_name%%-*}/"
           mkdir -p "$$target_dir"
           gcloud storage cp "$gs_bucket/$$epoch/$${prefix_name}settlement-merkle-trees.json" "$$target_dir"
           gcloud storage cp "$gs_bucket/$$epoch/$${prefix_name}settlements.json" "$$target_dir"

--- a/protected-event-distribution/src/settlement_config.rs
+++ b/protected-event-distribution/src/settlement_config.rs
@@ -16,8 +16,8 @@ pub enum SettlementConfig {
         /// range of bps that are covered by the settlement, usually differentiated by type of funder
         covered_range_bps: [u64; 2],
     },
-    /// configuration for protected event [protected_events::ProtectedEvent::CommissionIncrease]
-    CommissionIncreaseSettlement {
+    /// configuration for protected event [protected_events::ProtectedEvent::CommissionSamIncrease]
+    CommissionSamIncreaseSettlement {
         meta: SettlementMeta,
         min_settlement_lamports: u64,
         grace_increase_bps: Option<u64>,
@@ -29,7 +29,7 @@ impl SettlementConfig {
     pub fn meta(&self) -> &SettlementMeta {
         match self {
             SettlementConfig::DowntimeRevenueImpactSettlement { meta, .. } => meta,
-            SettlementConfig::CommissionIncreaseSettlement { meta, .. } => meta,
+            SettlementConfig::CommissionSamIncreaseSettlement { meta, .. } => meta,
         }
     }
     pub fn covered_range_bps(&self) -> &[u64; 2] {
@@ -37,7 +37,7 @@ impl SettlementConfig {
             SettlementConfig::DowntimeRevenueImpactSettlement {
                 covered_range_bps, ..
             } => covered_range_bps,
-            SettlementConfig::CommissionIncreaseSettlement {
+            SettlementConfig::CommissionSamIncreaseSettlement {
                 covered_range_bps, ..
             } => covered_range_bps,
         }
@@ -48,7 +48,7 @@ impl SettlementConfig {
                 min_settlement_lamports,
                 ..
             } => min_settlement_lamports,
-            SettlementConfig::CommissionIncreaseSettlement {
+            SettlementConfig::CommissionSamIncreaseSettlement {
                 min_settlement_lamports,
                 ..
             } => min_settlement_lamports,
@@ -80,16 +80,16 @@ pub fn build_protected_event_matcher(
                 }
             }
             (
-                SettlementConfig::CommissionIncreaseSettlement {
+                SettlementConfig::CommissionSamIncreaseSettlement {
                     grace_increase_bps, ..
                 },
-                ProtectedEvent::CommissionIncrease { epr_loss_bps, .. },
+                ProtectedEvent::CommissionSamIncrease { epr_loss_bps, .. },
             ) => {
                 if *epr_loss_bps > grace_increase_bps.unwrap_or_default() {
                     true
                 } else {
                     debug!(
-                        "CommissionIncrease event vote account {} with epr_loss_bps: {} is under grace period: {}",
+                        "CommissionSamIncrease event vote account {} with epr_loss_bps: {} is under grace period: {}",
                         protected_event.vote_account(),
                         epr_loss_bps,
                         grace_increase_bps.unwrap_or_default()

--- a/settlement-config.yaml
+++ b/settlement-config.yaml
@@ -11,7 +11,7 @@
       funder: Marinade
     min_settlement_lamports: 100000000 # 0.1 SOL
     covered_range_bps: [2000, 10000] # 20 % - 100 %
-- CommissionIncreaseSettlement:
+- CommissionSamIncreaseSettlement:
     meta:
       funder: ValidatorBond
     min_settlement_lamports: 10000000 # 0.01 SOL


### PR DESCRIPTION
I found an issue around backwards compatibility and the ability to work with old JSON data within the project.
The closing, funding etc. needs to be able to work with old and new data (I started to use v1 - not with sam and v2 - with some, but if there is better naming please propose)

With that the protected event of new name is `CommissionSamIncrease` and placing back the other types of protected events from v1.