### PR TITLE
[protected-event] using Decimal instead of f64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,6 +3882,7 @@ dependencies = [
  "env_logger 0.10.1",
  "log",
  "merkle-tree",
+ "rust_decimal",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",

--- a/protected-event-distribution/Cargo.toml
+++ b/protected-event-distribution/Cargo.toml
@@ -14,6 +14,7 @@ clap = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
 merkle-tree = { workspace = true }
+rust_decimal = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/protected-event-distribution/src/revenue_expectation_meta.rs
+++ b/protected-event-distribution/src/revenue_expectation_meta.rs
@@ -1,3 +1,4 @@
+use rust_decimal::Decimal;
 use solana_sdk::clock::Epoch;
 use solana_sdk::pubkey::Pubkey;
 
@@ -15,7 +16,6 @@ pub struct RevenueExpectationMetaCollection {
     pub revenue_expectations: Vec<RevenueExpectationMeta>,
 }
 
-// TODO: should not be used bigdecimal instead of f64?
 /// A struct that represents the expected and actual revenue for a staker.
 /// PMPE stands for "cost per mille per epoch"
 /// which is a number of lamports to be paid for staked 1000 SOLs
@@ -25,29 +25,20 @@ pub struct RevenueExpectationMeta {
     #[serde(with = "pubkey_string_conversion")]
     pub vote_account: Pubkey,
     /// changes in inflation and MEV commissions
-    pub expected_inflation_commission: f64,
-    pub actual_inflation_commission: f64,
-    pub expected_mev_commission: Option<f64>,
-    pub actual_mev_commission: Option<f64>,
+    pub expected_inflation_commission: Decimal,
+    pub actual_inflation_commission: Decimal,
+    pub expected_mev_commission: Option<Decimal>,
+    pub actual_mev_commission: Option<Decimal>,
     /// expected PMPE in SOLs for part of stake that is not part of SAM (e.g., MNDE part, (calculated from `1-samStakeShare`)
     /// how many SOLs was expected to be paid by validator for get stake of 1000 SOLs
-    pub expected_non_bid_pmpe: f64,
-    pub actual_non_bid_pmpe: f64,
+    pub expected_non_bid_pmpe: Decimal,
+    pub actual_non_bid_pmpe: Decimal,
     /// expected PMPE in SOLs for part of stake that is part of SAM (calculated from `samStakeShare`)
-    pub expected_sam_pmpe: f64,
+    pub expected_sam_pmpe: Decimal,
     /// max sam stake in SOLs
-    pub max_sam_stake: Option<f64>,
+    pub max_sam_stake: Option<Decimal>,
     /// in bps; used to find what part of the stake is part of SAM
-    pub sam_stake_share: f64,
+    pub sam_stake_share: Decimal,
     /// loss of lamports per 1 SOL for commission change
-    pub loss_per_stake: f64,
-}
-
-impl RevenueExpectationMeta {
-    /// Sanityt check if calculation on Non bid pmpe fits loss per stake data
-    pub fn check_commission_loss_per_stake(&self) {
-        let loss_per_stake =
-            ((self.expected_non_bid_pmpe - self.actual_non_bid_pmpe) / 1000.0).max(0.0);
-        assert_eq!(loss_per_stake, self.loss_per_stake);
-    }
+    pub loss_per_stake: Decimal,
 }

--- a/protected-event-distribution/src/utils.rs
+++ b/protected-event-distribution/src/utils.rs
@@ -1,3 +1,5 @@
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 use serde::{de::DeserializeOwned, Serialize};
 use std::path::Path;
 use std::{
@@ -49,16 +51,18 @@ pub fn bps(value: u64, max: u64) -> u64 {
     10000 * value / max
 }
 
-pub fn bps_f64(value: f64, max: f64) -> u64 {
+pub fn bps_decimal(value: Decimal, max: Decimal) -> u64 {
     assert!(
-        max > 0.0,
+        max > Decimal::ZERO,
         "Cannot calculute bps from values: {value}, {max}"
     );
-    (10000.0 * value / max).round() as u64
+    (Decimal::from(10000) * value / max)
+        .to_u64()
+        .expect("bps_decimal: cannot convert to u64")
 }
 
-pub fn bps_to_fraction(value: u64) -> f64 {
-    value as f64 / 10000.0
+pub fn bps_to_fraction(value: u64) -> Decimal {
+    Decimal::from(value) / Decimal::from(10000)
 }
 
 pub fn file_error<'a>(


### PR DESCRIPTION
I change the protected event settlement engine to work with Decimal instead of `f64`. The calculation comes with a bit different results (when comparing f64 and Decimal calculation of settlements amount side by side) but difference is in lower units. From that it seems to me Decimal should be used here rather than f64.