### PR TITLE
[protected events] evaluate commission increase not covered by bidding

### DIFF
--- a/.buildkite/prepare-protected-events.yml
+++ b/.buildkite/prepare-protected-events.yml
@@ -143,10 +143,12 @@ steps:
     - buildkite-agent artifact download --include-retried-jobs ${claim_type}-settlements.json .
     - buildkite-agent artifact download --include-retried-jobs ${claim_type}-settlement-merkle-trees.json .
     - buildkite-agent artifact download --include-retried-jobs discord-public-report.txt .
+    - buildkite-agent artifact download --include-retried-jobs evaluation.json .
     - gcloud storage cp "./${claim_type}.json" "$gs_bucket/$$epoch/"
     - gcloud storage cp "./${claim_type}-settlements.json" "$gs_bucket/$$epoch/"
     - gcloud storage cp "./${claim_type}-settlement-merkle-trees.json" "$gs_bucket/$$epoch/"
     - gcloud storage cp "./discord-public-report.txt" "$gs_bucket/$$epoch/${claim_type}-discord-public-report.txt"
+    - gcloud storage cp "./evaluation.json" "$gs_bucket/$$epoch/${claim_type}-evaluation.json"
 
   - wait: ~
 

--- a/protected-event-distribution/src/revenue_expectation_meta.rs
+++ b/protected-event-distribution/src/revenue_expectation_meta.rs
@@ -27,8 +27,11 @@ pub struct RevenueExpectationMeta {
     /// changes in inflation and MEV commissions
     pub expected_inflation_commission: Decimal,
     pub actual_inflation_commission: Decimal,
+    /// data of inflation take from previous epoch compared to the current one
+    pub past_inflation_commission: Decimal,
     pub expected_mev_commission: Option<Decimal>,
     pub actual_mev_commission: Option<Decimal>,
+    pub past_mev_commission: Option<Decimal>,
     /// expected PMPE in SOLs for part of stake that is not part of SAM (e.g., MNDE part, (calculated from `1-samStakeShare`)
     /// how many SOLs was expected to be paid by validator for get stake of 1000 SOLs
     pub expected_non_bid_pmpe: Decimal,
@@ -41,4 +44,7 @@ pub struct RevenueExpectationMeta {
     pub sam_stake_share: Decimal,
     /// loss of lamports per 1 SOL for commission change
     pub loss_per_stake: Decimal,
+    /// validator increased commission and the commission is not covered in the bidding part
+    /// when increase is in bidding not necessary to add it to protected event payment
+    pub non_bid_commission_increase_pmpe: Decimal,
 }

--- a/scripts/generate-discord-public-report.bash
+++ b/scripts/generate-discord-public-report.bash
@@ -48,13 +48,9 @@ do
       case $protected_event_code in
           # ---- V2 SAM events ----
           CommissionSamIncrease)
-            expected_commission_pmpe=$(<<<"$protected_event_attributes" jq '.expected_inflation_commission')
+            past_inflation_commission=$(<<<"$protected_event_attributes" jq '.past_inflation_commission')
             actual_inflation_commission=$(<<<"$protected_event_attributes" jq '.actual_inflation_commission')
-            expected_mev_commission=$(<<<"$protected_event_attributes" jq '.expected_mev_commission')
-            [[ $expected_mev_commission == "null" ]] && expected_mev_commission=0
-            actual_mev_commission=$(<<<"$protected_event_attributes" jq '.actual_mev_commission')
-            [[ $actual_mev_commission == "null" ]] && actual_mev_commission=0
-            reason="Commiss.pmpe $(bc <<<"scale=2; $expected_commission_pmpe + $expected_mev_commission") -> $(bc <<<"scale=2; $actual_inflation_commission + $actual_mev_commission")"
+            reason="Commission $(bc <<<"scale=2; $past_inflation_commission*100")% -> $(bc <<<"scale=2; $actual_inflation_commission*100")%"
             ;;
 
           DowntimeRevenueImpact)


### PR DESCRIPTION
Using non bid commission increase value from `ds-sam` to evaluate commission increase not covered by bidding.

This depends on PR: https://github.com/marinade-finance/ds-sam/pull/7