### PR TITLE
Fix for funding bin cli pipeline

### DIFF
--- a/protected-event-distribution/src/settlement_claims.rs
+++ b/protected-event-distribution/src/settlement_claims.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+
 use crate::{
     protected_events::ProtectedEvent,
     settlement_config::{build_protected_event_matcher, SettlementConfig},
@@ -6,6 +7,7 @@ use crate::{
 };
 use log::{debug, info};
 use solana_sdk::pubkey::Pubkey;
+use std::fmt::Display;
 
 use {
     crate::protected_events::ProtectedEventCollection,
@@ -30,6 +32,15 @@ pub struct SettlementClaim {
 pub enum SettlementReason {
     ProtectedEvent(Box<ProtectedEvent>),
     Bidding,
+}
+
+impl Display for SettlementReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SettlementReason::ProtectedEvent(_) => write!(f, "ProtectedEvent"),
+            SettlementReason::Bidding => write!(f, "Bidding"),
+        }
+    }
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, Eq, PartialEq, Hash, utoipa::ToSchema)]

--- a/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
+++ b/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
@@ -64,7 +64,7 @@ const VOTE_ACCOUNT_IDENTITY = Keypair.fromSecretKey(
 //       Activate and run this manually when needed.
 //       FILE='settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts' pnpm test:validator
 
-describe.skip('Cargo CLI: Pipeline Settlement', () => {
+describe('Cargo CLI: Pipeline Settlement', () => {
   let provider: AnchorExtendedProvider
   let program: ValidatorBondsProgram
 
@@ -467,7 +467,7 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any
     ).toHaveMatchingSpawnOutput({
-      code: 0,
+      code: 2,
       stdout: /funded 9.10 settlements/,
       stderr:
         /will be funded with 2 stake accounts(.|\n|\r)*9 executed successfully/,

--- a/settlement-pipelines/src/json_data.rs
+++ b/settlement-pipelines/src/json_data.rs
@@ -65,9 +65,10 @@ pub fn load_json(
             false
         }
     }) {
-        let mut loaded_merkle_tree: MerkleTreeLoadedData = MerkleTreeLoadedData::default();
-        load_json_data_to_merkle_tree(path1, &mut loaded_merkle_tree)?;
-        load_json_data_to_merkle_tree(path2, &mut loaded_merkle_tree)?;
+        let mut loaded_merkle_tree: MerkleTreeSettlementLoadedData =
+            MerkleTreeSettlementLoadedData::default();
+        load_json_merkle_tree_settlement(path1, &mut loaded_merkle_tree)?;
+        load_json_merkle_tree_settlement(path2, &mut loaded_merkle_tree)?;
         claiming_data.push(resolve_combined_optional(loaded_merkle_tree)?);
     }
     claiming_data.sort_by_key(|c| c.epoch);
@@ -92,13 +93,13 @@ pub fn load_json(
 }
 
 #[derive(Default)]
-struct MerkleTreeLoadedData {
+struct MerkleTreeSettlementLoadedData {
     merkle_tree_collection: Option<MerkleTreeCollection>,
     settlement_collection: Option<SettlementCollection>,
 }
 
-fn insert_merkle_tree_parsed_data(
-    loaded_data: &mut MerkleTreeLoadedData,
+fn insert_json_parsed_data(
+    loaded_data: &mut MerkleTreeSettlementLoadedData,
     merkle_tree_collection: Option<MerkleTreeCollection>,
     settlement_collection: Option<SettlementCollection>,
 ) -> anyhow::Result<()> {
@@ -129,15 +130,19 @@ fn insert_merkle_tree_parsed_data(
     Ok(())
 }
 
-fn load_json_data_to_merkle_tree(
+fn load_json_merkle_tree_settlement(
     path: &PathBuf,
-    loaded_data: &mut MerkleTreeLoadedData,
+    loaded_data: &mut MerkleTreeSettlementLoadedData,
 ) -> Result<(), CliError> {
     debug!("Loading data from file: {:?}", path);
     let json_loading_result = if let Ok(merkle_tree_collection) = read_from_json_file(path) {
-        insert_merkle_tree_parsed_data(loaded_data, Some(merkle_tree_collection), None)
+        let result = insert_json_parsed_data(loaded_data, Some(merkle_tree_collection), None);
+        debug!("Loaded merkle tree collection from file: {:?}", path);
+        result
     } else if let Ok(settlement_collection) = read_from_json_file(path) {
-        insert_merkle_tree_parsed_data(loaded_data, None, Some(settlement_collection))
+        let result = insert_json_parsed_data(loaded_data, None, Some(settlement_collection));
+        debug!("Loaded settlement collection from file: {:?}", path);
+        result
     } else {
         Err(anyhow!("Cannot load JSON data from file: {:?}", path))
     };
@@ -149,7 +154,7 @@ fn load_json_data_to_merkle_tree(
 }
 
 fn resolve_combined_optional(
-    loaded_data: MerkleTreeLoadedData,
+    loaded_data: MerkleTreeSettlementLoadedData,
 ) -> anyhow::Result<CombinedMerkleTreeSettlementCollections> {
     let merkle_tree_collection = loaded_data.merkle_tree_collection;
     let settlement_collection = loaded_data.settlement_collection;

--- a/settlement-pipelines/src/settlement_data.rs
+++ b/settlement-pipelines/src/settlement_data.rs
@@ -2,7 +2,7 @@ use crate::json_data::{CombinedMerkleTreeSettlementCollections, MerkleTreeMetaSe
 use anchor_client::anchor_lang::prelude::Pubkey;
 use anyhow::anyhow;
 use merkle_tree::psr_claim::TreeNode;
-use protected_event_distribution::settlement_claims::SettlementFunder;
+use protected_event_distribution::settlement_claims::{SettlementFunder, SettlementReason};
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -33,8 +33,10 @@ pub struct SettlementRecord {
     pub max_total_claim_sum: u64,
     // The maximum total claims (number of merkle nodes) that can be claimed from the settlement
     pub max_total_claim: u64,
-    // The funder of the settlement, information loaded from the JSON file
+    // The funder of the settlement, from the JSON file
     pub funder: SettlementFunderType,
+    // The reason for the settlement (protected event, bidding...), from the JSON file
+    pub reason: SettlementReason,
 }
 
 #[derive(Debug, Clone)]
@@ -116,6 +118,7 @@ pub fn parse_settlements_from_json(
                     max_total_claim_sum: merkle_tree.max_total_claim_sum,
                     max_total_claim: merkle_tree.max_total_claims as u64,
                     funder: SettlementFunderType::new(&settlement.meta.funder),
+                    reason: settlement.reason.clone(),
                     bond_account: None,
                     settlement_account: None,
                 } ;

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -148,6 +148,7 @@ pub fn filter_settlement_funded(
 
 /// Preparing instructions to merge stake accounts from stake_accounts_to_merge into destination_stake
 /// Returning list of stake accounts addresses that cannot be merged.
+/// Prepared transactions are passed from the function through mutable referecne of `transaction_builder`.
 #[allow(clippy::too_many_arguments)]
 pub async fn prepare_merge_instructions(
     stake_accounts_to_merge: Vec<&CollectedStakeAccount>,


### PR DESCRIPTION
The PR covers small refactoring of naming, adding a little bit of logging info for the fund pipeline to have better insight into what happened and mostly fixes an issue of failing pipeline on funding when the same stake account could be taken for two different settlement of the same vote account.  As for wrong calculation in the pipeline, it could happen that after funding there is not enough left for the financing of the other. When both such fundings are placed into the same transaction the transaction fails and nothing is funded.

The issue fix is the change of the if statement
https://github.com/marinade-finance/validator-bonds/compare/pipelines-more-info-logging?expand=1#diff-ed4510b215e1a2a295acd1b99614e0b3b95c79d5fcea050225b08cd2afcad716L400