### PR TITLE
Adjusting buildkite pipelines

### DIFF
--- a/.buildkite/fund-settlements.yml
+++ b/.buildkite/fund-settlements.yml
@@ -12,6 +12,17 @@ steps:
 
   - wait: ~
 
+  - label: ":black_nib: Env variables setup"
+    commands:
+    - |          
+      claim_type=${CLAIM_TYPE:-$(buildkite-agent meta-data get claim_type || "")}
+      buildkite-agent meta-data set claim_type "$$claim_type"
+    - |
+      epoch=${EPOCH:-$(buildkite-agent meta-data get epoch || "")}
+      buildkite-agent meta-data set epoch "$$epoch"
+
+  - wait: ~
+
   - label: ":hammer_and_wrench: :rust: Build fund-settlement"
     commands:
     - '. "$HOME/.cargo/env"'
@@ -32,24 +43,38 @@ steps:
         echo "Merkle trees already downloaded"
         exit 0
       fi
-    - |
-      current_epoch=$(curl --silent "$$RPC_URL" -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getEpochInfo"}' | jq '.result.epoch')
-      epochs_start_index=$((current_epoch - past_epochs_to_load))
     - 'mkdir ./merkle-trees/'
+    - claim_type=$(buildkite-agent meta-data get claim_type)
+    - epoch=$(buildkite-agent meta-data get epoch)
+    - |
+      if [[ -z "$$epoch" ]]; then
+        current_epoch=$(curl --silent "$$RPC_URL" -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getEpochInfo"}' | jq '.result.epoch')
+        epochs_start_index=$((current_epoch - past_epochs_to_load))
+      else
+      current_epoch=$$epoch
+        epochs_start_index=$$epoch
+      fi
     - |
       for epoch in $(seq $$epochs_start_index $$current_epoch); do
         if [[ $$epoch -lt $$starting_epoch_contract_v2 ]]; then
           echo "Skipping epoch $$epoch, because it's before the contract v2 deployment epoch $$starting_epoch_contract_v2"
           continue
         fi
-        for merkle_tree_file in $(gcloud storage ls "$gs_bucket/$$epoch/*settlement-merkle-trees.json"); do
-          base_name=$(basename "$$merkle_tree_file")
-          prefix_name="$${base_name%settlement-merkle-trees.json}"
-          target_dir="./merkle-trees/$${epoch}_$${prefix_name}/"
+        if [[ -z "$$claim_type" ]]; then
+          for merkle_tree_file in $(gcloud storage ls "$gs_bucket/$$epoch/*settlement-merkle-trees.json"); do
+            base_name=$(basename "$$merkle_tree_file")
+            prefix_name="$${base_name%settlement-merkle-trees.json}"
+            target_dir="./merkle-trees/$${epoch}_$${prefix_name}/"
+            mkdir -p "$$target_dir"
+            gcloud storage cp "$gs_bucket/$$epoch/$${prefix_name}settlement-merkle-trees.json" "$$target_dir"
+            gcloud storage cp "$gs_bucket/$$epoch/$${prefix_name}settlements.json" "$$target_dir"
+          done
+        else
+          target_dir="./merkle-trees/$${epoch}_$${claim_type}/"
           mkdir -p "$$target_dir"
-          gcloud storage cp "$gs_bucket/$$epoch/$${prefix_name}settlement-merkle-trees.json" "$$target_dir"
-          gcloud storage cp "$gs_bucket/$$epoch/$${prefix_name}settlements.json" "$$target_dir"
-        done
+          gcloud storage cp "$gs_bucket/$$epoch/$${claim_type}-settlement-merkle-trees.json" "$$target_dir"
+          gcloud storage cp "$gs_bucket/$$epoch/$${claim_type}-settlements.json" "$$target_dir"
+        fi
       done
     artifact_paths:
       - "./merkle-trees/**/*"

--- a/.buildkite/init-settlements.yml
+++ b/.buildkite/init-settlements.yml
@@ -3,7 +3,6 @@ agents:
 
 env:
   gs_bucket: gs://marinade-validator-bonds-mainnet
-  NOTIFY_PSR_FEED: false
 
 steps:
   # epoch number provided in ENV and then waiting for confirmation to proceed
@@ -30,7 +29,7 @@ steps:
 
   - wait: ~
 
-  - label: ":mega: Notification initializing settlements"
+  - label: ":black_nib: Env variables setup"
     commands:
     - |
       discord_webhook="${DISCORD_WEBHOOK:-$$DISCORD_WEBHOOK_VALIDATOR_BONDS}"
@@ -42,8 +41,15 @@ steps:
       claim_type=${CLAIM_TYPE:-$(buildkite-agent meta-data get claim_type)}
       buildkite-agent meta-data set claim_type "$$claim_type"
     - 'echo "Epoch: $$epoch", Claim Type: $$claim_type'
+
+  - wait: ~
+
+  - label: ":mega: Notification initializing settlements"
+    commands:
+    - epoch=$(buildkite-agent meta-data get epoch)
+    - claim_type=$(buildkite-agent meta-data get claim_type)
     - |
-      curl "$$discord_webhook" \
+      curl "$(buildkite-agent meta-data get discord_webhook)" \
         -H "Content-Type: application/json" -d '{
         "embeds": [
           {
@@ -170,16 +176,15 @@ steps:
 
   - wait: ~
 
-  - label: ":mega: Notification Initializing Settlements"
+  - label: ":mega: Notification :fast_forward: Monitoring Initialize Settlements"
     commands:
     - epoch=$(buildkite-agent meta-data get epoch)
-    - discord_webhook=$(buildkite-agent meta-data get discord_webhook)
     - notification_result=$(buildkite-agent meta-data get notification_result || echo "UNKNOWN")
     - notification_color=$(buildkite-agent meta-data get notification_color || echo "15158332")
     - attempts_count=$(buildkite-agent meta-data get attempts_count || echo "UNKNOWN")
     - buildkite-agent artifact download --include-retried-jobs init-report.txt . || echo "UNKNOWN ERROR" > init-report.txt
     - |
-        curl "$$discord_webhook" \
+        curl "$(buildkite-agent meta-data get discord_webhook)" \
         -F 'payload_json={
             "embeds":[{
               "title": "Init Settlements '"$notification_result"' for Validator Bonds ('"$$epoch"') after '"$$attempts_count"' attempts",
@@ -191,7 +196,7 @@ steps:
     depends_on: "notification-setup-init"
     allow_dependency_failure: true
 
-  - label: ":mega: Notification PSR feed"
+  - label: ":mega: Notification :fast_forward: PSR feed"
     commands:
     - claim_type=$(buildkite-agent meta-data get claim_type)
     - epoch=$(buildkite-agent meta-data get epoch)
@@ -206,7 +211,7 @@ steps:
       done
     depends_on: "notification-setup-init"
     allow_dependency_failure: true
-    if: "build.env('NOTIFY_PSR_FEED') == 'true'"
+    if: "build.env('NOTIFY_PSR_FEED') != null"
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/init-settlements.yml
+++ b/.buildkite/init-settlements.yml
@@ -3,6 +3,7 @@ agents:
 
 env:
   gs_bucket: gs://marinade-validator-bonds-mainnet
+  NOTIFY_PSR_FEED: false
 
 steps:
   # epoch number provided in ENV and then waiting for confirmation to proceed
@@ -189,6 +190,23 @@ steps:
         -F "file1=@./init-report.txt"
     depends_on: "notification-setup-init"
     allow_dependency_failure: true
+
+  - label: ":mega: Notification PSR feed"
+    commands:
+    - claim_type=$(buildkite-agent meta-data get claim_type)
+    - epoch=$(buildkite-agent meta-data get epoch)
+    - gcloud storage cp "$gs_bucket/$$epoch/$${claim_type}-discord-public-report.txt" "./discord-public-report.txt"
+    - |
+      split_command=$(which split >&2 > /dev/null && echo "split" || echo "gsplit")
+      # discord max message length is 2000 characters
+      $$split_command -C 2000 "./discord-public-report.txt" './discord-public-report.txt.chunk-'
+      for report_chunk in './discord-public-report.txt.chunk-'*; do
+        report=$(cat "$$report_chunk")
+        curl "$$DISCORD_WEBHOOK_PSR_FEED" -H "Content-Type: application/json" -d "$(jq -n --arg report "$$report" '{"content": ("```\n"+$$report+"```"), "embeds": null, "attachments": []}')"
+      done
+    depends_on: "notification-setup-init"
+    allow_dependency_failure: true
+    if: "build.env('NOTIFY_PSR_FEED') == 'true'"
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/init-settlements.yml
+++ b/.buildkite/init-settlements.yml
@@ -195,9 +195,10 @@ steps:
 
   - label: ":gear: Upload and trigger fund-settlements pipeline"
     commands:
-      - 'epoch=$(buildkite-agent meta-data get epoch)'
-      - 'echo "Epoch: $$epoch"'
-      - 'buildkite-agent pipeline upload .buildkite/fund-settlements.yml'
+      - epoch=$(buildkite-agent meta-data get epoch)
+      - claim_type=$(buildkite-agent meta-data get claim_type)
+      - 'echo "Epoch: $$epoch, Claim type: $$claim_type"'
+      - buildkite-agent pipeline upload .buildkite/fund-settlements.yml
     depends_on: "init-settlement"
     allow_dependency_failure: true
 

--- a/.buildkite/prepare-bidding.yml
+++ b/.buildkite/prepare-bidding.yml
@@ -3,7 +3,8 @@ agents:
 
 env:
   gs_bucket: gs://marinade-validator-bonds-mainnet
-  claim_type: "bidding"
+  MARINADE_SCORING_API_URL: https://scoring.marinade.finance/api/v1
+  CLAIM_TYPE: "bidding"
   MARINADE_FEE_BPS: 2500
   MARINADE_FEE_STAKE_AUTHORITY: 89SrbjbuNyqSqAALKBsKBqMSh463eLvzS4iVWCeArBgB
   MARINADE_FEE_WITHDRAW_AUTHORITY: 89SrbjbuNyqSqAALKBsKBqMSh463eLvzS4iVWCeArBgB
@@ -34,13 +35,22 @@ steps:
 
   - wait: ~
 
-  - label: ":floppy_disk: :arrow_left: :cloud: Downloading Settlements JSON data"
+  - label: ":black_nib: Env variables setup"
     commands:
     - |
       epoch=${EPOCH:-$(buildkite-agent meta-data get epoch)}
       buildkite-agent meta-data set epoch "$$epoch"
     - |
-      curl -s "https://scoring.marinade.finance/api/v1/scores/sam?epoch=$$epoch" -o sam-scores.json
+      discord_webhook="${DISCORD_WEBHOOK:-$$DISCORD_WEBHOOK_VALIDATOR_BONDS}"
+      buildkite-agent meta-data set discord_webhook "$$discord_webhook"
+
+  - wait: ~
+
+  - label: ":floppy_disk: :arrow_left: :cloud: Downloading Settlements JSON data"
+    commands:
+    - epoch=$(buildkite-agent meta-data get epoch)
+    - |
+      curl -s "${MARINADE_SCORING_API_URL}/scores/sam?epoch=$$epoch" -o sam-scores.json
       gcloud storage cp "$gs_bucket/$$epoch/stakes.json" "."
     key: 'download-json'
     artifact_paths:
@@ -63,21 +73,21 @@ steps:
         --marinade-fee-bps ${MARINADE_FEE_BPS} \
         --marinade-fee-stake-authority ${MARINADE_FEE_STAKE_AUTHORITY} \
         --marinade-fee-withdraw-authority ${MARINADE_FEE_WITHDRAW_AUTHORITY} \
-        --output-settlement-collection "./${claim_type}-settlements.json" \
-        --output-merkle-tree-collection "./${claim_type}-settlement-merkle-trees.json"
+        --output-settlement-collection "./${CLAIM_TYPE}-settlements.json" \
+        --output-merkle-tree-collection "./${CLAIM_TYPE}-settlement-merkle-trees.json"
     artifact_paths:
-    - "./${claim_type}*.json"
+    - "./${CLAIM_TYPE}*.json"
 
   - wait: ~
 
   - label: "📓 Generating report"
     commands:
-    - 'buildkite-agent artifact download --include-retried-jobs ${claim_type}-settlements.json .'
+    - 'buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}-settlements.json .'
     - |
       if [[ "$MARINADE_FEE_BPS" == "10000" ]]; then
-        ./scripts/generate-discord-public-report.bash "./${claim_type}-settlements.json" "Bidding" > "./discord-public-report.txt"
+        ./scripts/generate-discord-public-report.bash "./${CLAIM_TYPE}-settlements.json" "Bidding" > "./discord-public-report.txt"
       else
-        ./scripts/generate-discord-public-report.bash "./${claim_type}-settlements.json" "Bidding" true > "./discord-public-report.txt"
+        ./scripts/generate-discord-public-report.bash "./${CLAIM_TYPE}-settlements.json" "Bidding" true > "./discord-public-report.txt"
       fi
     artifact_paths:
       - "./discord-public-report.txt"
@@ -87,12 +97,12 @@ steps:
   - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts"
     commands:
     - epoch=$(buildkite-agent meta-data get epoch)
-    - buildkite-agent artifact download --include-retried-jobs ${claim_type}-settlements.json .
-    - buildkite-agent artifact download --include-retried-jobs ${claim_type}-settlement-merkle-trees.json .
+    - buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}-settlements.json .
+    - buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}-settlement-merkle-trees.json .
     - buildkite-agent artifact download --include-retried-jobs discord-public-report.txt .
-    - gcloud storage cp "./${claim_type}-settlements.json" "$gs_bucket/$$epoch/"
-    - gcloud storage cp "./${claim_type}-settlement-merkle-trees.json" "$gs_bucket/$$epoch/"
-    - gcloud storage cp "./discord-public-report.txt" "$gs_bucket/$$epoch/${claim_type}-discord-public-report.txt"
+    - gcloud storage cp "./${CLAIM_TYPE}-settlements.json" "$gs_bucket/$$epoch/"
+    - gcloud storage cp "./${CLAIM_TYPE}-settlement-merkle-trees.json" "$gs_bucket/$$epoch/"
+    - gcloud storage cp "./discord-public-report.txt" "$gs_bucket/$$epoch/${CLAIM_TYPE}-discord-public-report.txt"
 
   - wait: ~
 
@@ -100,10 +110,10 @@ steps:
     commands:
     - |
       epoch=$(buildkite-agent meta-data get epoch)
-      curl "$$DISCORD_WEBHOOK_VALIDATOR_BONDS" -H "Content-Type: application/json" -d '{
+      curl "$(buildkite-agent meta-data get discord_webhook)" -H "Content-Type: application/json" -d '{
         "embeds": [
           {
-            "title": "Claims for Validator Bonds ('"${claim_type}"') generated ('"$$epoch"').",
+            "title": "Claims for Validator Bonds ('"${CLAIM_TYPE}"') generated ('"$$epoch"').",
             "url": "'"$$BUILDKITE_BUILD_URL"'",
             "color": "52224"
           }
@@ -119,13 +129,14 @@ steps:
       cat <<EOF | buildkite-agent pipeline upload
       steps:
         - trigger: "init-settlements"
-          label: ":rocket: Trigger: Init settlements ($$epoch)/($claim_type)"
+          label: ":rocket: Trigger: Init settlements ($$epoch)/($CLAIM_TYPE)"
           async: true
           build:
             branch: $$BUILDKITE_BRANCH
             env:
               EPOCH: $$epoch
-              CLAIM_TYPE: $claim_type
+              CLAIM_TYPE: $CLAIM_TYPE
+              DISCORD_WEBHOOK: $(buildkite-agent meta-data get discord_webhook)
               NOTIFY_PSR_FEED: true
               gs_bucket: $gs_bucket
       EOF

--- a/.buildkite/prepare-bidding.yml
+++ b/.buildkite/prepare-bidding.yml
@@ -110,19 +110,6 @@ steps:
         ]
       }'
 
-  - label: ":mega: PSR feed"
-    commands:
-    - buildkite-agent artifact download --include-retried-jobs discord-public-report.txt .
-    - epoch=$(buildkite-agent meta-data get epoch)
-    - |
-      split_command=$(which split >&2 > /dev/null && echo "split" || echo "gsplit")
-      # discord max message length is 2000 characters
-      $$split_command -C 2000 "./discord-public-report.txt" './discord-public-report.txt.chunk-'
-      for report_chunk in './discord-public-report.txt.chunk-'*; do
-        report=$(cat "$$report_chunk")
-        curl "$$DISCORD_WEBHOOK_PSR_FEED" -H "Content-Type: application/json" -d "$(jq -n --arg report "$$report" '{"content": ("```\n"+$$report+"```"), "embeds": null, "attachments": []}')"
-      done
-
   - wait: ~
 
   - label: ":gear: Setup init-settlements trigger"
@@ -139,6 +126,7 @@ steps:
             env:
               EPOCH: $$epoch
               CLAIM_TYPE: $claim_type
+              NOTIFY_PSR_FEED: true
               gs_bucket: $gs_bucket
       EOF
 

--- a/.buildkite/prepare-protected-events.yml
+++ b/.buildkite/prepare-protected-events.yml
@@ -171,19 +171,6 @@ steps:
         ]
       }'
 
-  - label: ":mega: PSR feed"
-    commands:
-    - buildkite-agent artifact download --include-retried-jobs discord-public-report.txt .
-    - epoch=$(buildkite-agent meta-data get epoch)
-    - |
-      split_command=$(which split >&2 > /dev/null && echo "split" || echo "gsplit")
-      # discord max message length is 2000 characters
-      $$split_command -C 2000 "./discord-public-report.txt" './discord-public-report.txt.chunk-'
-      for report_chunk in './discord-public-report.txt.chunk-'*; do
-        report=$(cat "$$report_chunk")
-        curl "$$DISCORD_WEBHOOK_PSR_FEED" -H "Content-Type: application/json" -d "$(jq -n --arg report "$$report" '{"content": ("```\n"+$$report+"```"), "embeds": null, "attachments": []}')"
-      done
-
   - wait: ~
 
   - label: ":gear: Setup init-settlements trigger"
@@ -200,6 +187,7 @@ steps:
             env:
               EPOCH: $$epoch
               CLAIM_TYPE: $claim_type
+              NOTIFY_PSR_FEED: true
               gs_bucket: $gs_bucket
       EOF
 

--- a/.buildkite/prepare-protected-events.yml
+++ b/.buildkite/prepare-protected-events.yml
@@ -3,7 +3,7 @@ agents:
 
 env:
   gs_bucket: gs://marinade-validator-bonds-mainnet
-  claim_type: "protected-events"
+  CLAIM_TYPE: "protected-events"
   ds_sam_auction_github_api_link: "https://api.github.com/repos/marinade-finance/ds-sam-pipeline/contents/auctions/"
   ds_sam_auction_download_link: "https://raw.githubusercontent.com/marinade-finance/ds-sam-pipeline/main/auctions/"
 
@@ -33,11 +33,19 @@ steps:
 
   - wait: ~
 
-  - label: ":cloud: :arrow_right: :floppy_disk: Downloading Settlements JSON data"
+  - label: ":black_nib: Env variables setup"
     commands:
     - |
       epoch=${EPOCH:-$(buildkite-agent meta-data get epoch)}
       buildkite-agent meta-data set epoch "$$epoch"
+    - |
+      discord_webhook="${DISCORD_WEBHOOK:-$$DISCORD_WEBHOOK_VALIDATOR_BONDS}"
+      buildkite-agent meta-data set discord_webhook "$$discord_webhook"
+
+  - wait: ~
+
+  - label: ":cloud: :arrow_right: :floppy_disk: Downloading Settlements JSON data"
+    commands:
     - |
       gcloud storage cp "$gs_bucket/$$epoch/validators.json" "."
       gcloud storage cp "$gs_bucket/$$epoch/stakes.json" "."
@@ -124,18 +132,18 @@ steps:
         --validator-meta-collection "./validators.json" \
         --stake-meta-collection "./stakes.json" \
         --revenue-expectation-collection "./evaluation.json" \
-        --output-protected-event-collection "./${claim_type}.json" \
-        --output-settlement-collection "./${claim_type}-settlements.json" \
-        --output-merkle-tree-collection "./${claim_type}-settlement-merkle-trees.json"
+        --output-protected-event-collection "./${CLAIM_TYPE}.json" \
+        --output-settlement-collection "./${CLAIM_TYPE}-settlements.json" \
+        --output-merkle-tree-collection "./${CLAIM_TYPE}-settlement-merkle-trees.json"
     artifact_paths:
-        - "./${claim_type}*.json"
+        - "./${CLAIM_TYPE}*.json"
 
   - wait: ~
 
   - label: "📓 Generating report"
     commands:
-    - 'buildkite-agent artifact download --include-retried-jobs ${claim_type}-settlements.json .'
-    - './scripts/generate-discord-public-report.bash "./${claim_type}-settlements.json" "Protected Events" > "./discord-public-report.txt"'
+    - 'buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}-settlements.json .'
+    - './scripts/generate-discord-public-report.bash "./${CLAIM_TYPE}-settlements.json" "Protected Events" > "./discord-public-report.txt"'
     artifact_paths:
       - "./discord-public-report.txt"
 
@@ -144,16 +152,16 @@ steps:
   - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts"
     commands:
     - epoch=$(buildkite-agent meta-data get epoch)
-    - buildkite-agent artifact download --include-retried-jobs ${claim_type}.json .
-    - buildkite-agent artifact download --include-retried-jobs ${claim_type}-settlements.json .
-    - buildkite-agent artifact download --include-retried-jobs ${claim_type}-settlement-merkle-trees.json .
+    - buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}.json .
+    - buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}-settlements.json .
+    - buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}-settlement-merkle-trees.json .
     - buildkite-agent artifact download --include-retried-jobs discord-public-report.txt .
     - buildkite-agent artifact download --include-retried-jobs evaluation.json .
-    - gcloud storage cp "./${claim_type}.json" "$gs_bucket/$$epoch/"
-    - gcloud storage cp "./${claim_type}-settlements.json" "$gs_bucket/$$epoch/"
-    - gcloud storage cp "./${claim_type}-settlement-merkle-trees.json" "$gs_bucket/$$epoch/"
-    - gcloud storage cp "./discord-public-report.txt" "$gs_bucket/$$epoch/${claim_type}-discord-public-report.txt"
-    - gcloud storage cp "./evaluation.json" "$gs_bucket/$$epoch/${claim_type}-evaluation.json"
+    - gcloud storage cp "./${CLAIM_TYPE}.json" "$gs_bucket/$$epoch/"
+    - gcloud storage cp "./${CLAIM_TYPE}-settlements.json" "$gs_bucket/$$epoch/"
+    - gcloud storage cp "./${CLAIM_TYPE}-settlement-merkle-trees.json" "$gs_bucket/$$epoch/"
+    - gcloud storage cp "./discord-public-report.txt" "$gs_bucket/$$epoch/${CLAIM_TYPE}-discord-public-report.txt"
+    - gcloud storage cp "./evaluation.json" "$gs_bucket/$$epoch/${CLAIM_TYPE}-evaluation.json"
 
   - wait: ~
 
@@ -161,10 +169,10 @@ steps:
     commands:
     - |
       epoch=$(buildkite-agent meta-data get epoch)
-      curl "$$DISCORD_WEBHOOK_VALIDATOR_BONDS" -H "Content-Type: application/json" -d '{
+      curl "$(buildkite-agent meta-data get discord_webhook)" -H "Content-Type: application/json" -d '{
         "embeds": [
           {
-            "title": "Claims for Validator Bonds ('"${claim_type}"') generated ('"$$epoch"').",
+            "title": "Claims for Validator Bonds ('"${CLAIM_TYPE}"') generated ('"$$epoch"').",
             "url": "'"$$BUILDKITE_BUILD_URL"'",
             "color": "52224"
           }
@@ -180,13 +188,14 @@ steps:
       cat <<EOF | buildkite-agent pipeline upload
       steps:
         - trigger: "init-settlements"
-          label: ":rocket: Trigger: Init settlements ($$epoch)/($claim_type)"
+          label: ":rocket: Trigger: Init settlements ($$epoch)/($CLAIM_TYPE)"
           async: true
           build:
             branch: $$BUILDKITE_BRANCH
             env:
               EPOCH: $$epoch
-              CLAIM_TYPE: $claim_type
+              CLAIM_TYPE: $CLAIM_TYPE
+              DISCORD_WEBHOOK: $(buildkite-agent meta-data get discord_webhook)
               NOTIFY_PSR_FEED: true
               gs_bucket: $gs_bucket
       EOF


### PR DESCRIPTION
Two things adjusted here:

1. Prepare bidding/protected-events pipeline to fund only newly created settlements (avoiding race conditions on not existing settlements from in parallel running pipeline of the other type)
2. PSR feed is updated only after initialization is executed (not immediately after JSON data is created and not before an operator manually permits init settlement processing)