### PR TITLE
Pipeline better fund claim reporting

### DIFF
--- a/.buildkite/claim-settlements.yml
+++ b/.buildkite/claim-settlements.yml
@@ -159,9 +159,6 @@ steps:
      - 'buildkite-agent artifact download --include-retried-jobs "claim-execution-report.*" ./reports/ || echo "No report ERROR" > ./reports/claim-execution-report.error'
      - 'report_path="./reports/$(ls -v1 reports/ | tail -n 1)"'
      - 'cp "$$report_path" ./claiming-report.txt'
-     - 'claimable_epochs_json=$(buildkite-agent meta-data get claimable_epochs_json)'
-     - 'first_epoch=$(echo "$$claimable_epochs_json" | jq ".[0]")'
-     - '[[ -n "$$first_epoch" && "$$first_epoch" != "null" ]] && gcloud storage cp ./claiming-report.txt "$gs_bucket/$$first_epoch/claiming-report.$(date +%s).txt"'
      - 'buildkite-agent meta-data set attempts_count "$(grep -c ATTEMPT ./claiming-report.txt)"'
     artifact_paths:
     - "./claiming-report.txt"
@@ -170,6 +167,18 @@ steps:
     allow_dependency_failure: true
 
   - wait: ~
+
+  - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts Claim Settlements"
+    commands:
+    - buildkite-agent artifact download --include-retried-jobs claiming-report.txt . || echo "UNKNOWN ERROR" > claiming-report.txt
+    - claimable_epochs_json=$(buildkite-agent meta-data get claimable_epochs_json)
+    - first_epoch=$(echo "$$claimable_epochs_json" | jq ".[0]")
+    - |
+      if [[ -n "$$first_epoch" && "$$first_epoch" != "null" ]]; then
+        gcloud storage cp ./claiming-report.txt "$gs_bucket/$$first_epoch/buildkite/claiming-report.$(date +%s).txt"
+      fi
+    depends_on: "notification"
+    allow_dependency_failure: true
 
   - label: ":mega: Notification Claiming"
     commands:

--- a/.buildkite/close-settlements.yml
+++ b/.buildkite/close-settlements.yml
@@ -39,6 +39,7 @@ steps:
         echo "No found any epoch to start to load settlement JSON files"
         exit 1
       fi
+    - latest_funded_epoch=''
     - |
       for epoch in $(seq $$epochs_start_index $$epochs_end_index); do
         if [[ $$epoch -lt $$starting_epoch_contract_v2 ]]; then
@@ -49,7 +50,9 @@ steps:
           base_name=$(basename "$$merkle_tree_file")
           gcloud storage cp "$$merkle_tree_file" "./merkle-trees/$${epoch}_$${base_name}"
         done
+        latest_funded_epoch=$$epoch
       done
+    - buildkite-agent meta-data set latest_funded_epoch "$$latest_funded_epoch"
     artifact_paths:
       - "./merkle-trees/*"
 
@@ -102,18 +105,26 @@ steps:
 
   - label: ":memo: Notification setup: Close Settlements"
     commands:
-     - 'mkdir ./reports'
-     - 'buildkite-agent artifact download --include-retried-jobs "close-execution-report.*" ./reports/ || echo "No report ERROR" > ./reports/close-execution-report.error'
-     - 'report_path="./reports/$(ls -v1 reports/ | tail -n 1)"'
-     - 'cp "$$report_path" ./close-report.txt'
-     - 'buildkite-agent meta-data set attempts_count "$(grep -c ATTEMPT ./close-report.txt)"'
+    - 'mkdir ./reports'
+    - 'buildkite-agent artifact download --include-retried-jobs "close-execution-report.*" ./reports/ || echo "No report ERROR" > ./reports/close-execution-report.error'
+    - 'report_path="./reports/$(ls -v1 reports/ | tail -n 1)"'
+    - 'cp "$$report_path" ./close-report.txt'
+    - 'buildkite-agent meta-data set attempts_count "$(grep -c ATTEMPT ./close-report.txt)"'
     artifact_paths:
     - "./close-report.txt"
-    key: 'notification'
+    key: 'notification-setup-close'
     depends_on: "close-settlement"
     allow_dependency_failure: true
 
   - wait: ~
+
+  - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts Close Settlements"
+    commands:
+    - latest_funded_epoch=$(buildkite-agent meta-data get latest_funded_epoch)
+    - buildkite-agent artifact download --include-retried-jobs close-report.txt . || echo "UNKNOWN ERROR" > close-report.txt
+    - gcloud storage cp ./close-report.txt "$gs_bucket/$$latest_funded_epoch/buildkite/close-settlement-report.$(date +%s).txt"
+    depends_on: "notification-setup-close"
+    allow_dependency_failure: true
 
   - label: ":mega: Notification Closing"
     commands:
@@ -138,7 +149,7 @@ steps:
             }]
         }' \
         -F "file1=@./close-report.txt"
-    depends_on: "notification"
+    depends_on: "notification-setup-close"
     allow_dependency_failure: true
 
   - wait: ~

--- a/.buildkite/fetch-and-parse-snapshot.yml
+++ b/.buildkite/fetch-and-parse-snapshot.yml
@@ -93,7 +93,6 @@ steps:
     - 'gcloud storage cp "$$snapshot_dir/validators.json" "$gs_bucket/$$epoch/"'
     - 'gcloud storage cp "$$snapshot_dir/stakes.json" "$gs_bucket/$$epoch/"'
 
-
   - wait: ~
 
   - label: ":gear: :one: Setup trigger for prepare-protected-events"

--- a/.buildkite/fund-settlements.yml
+++ b/.buildkite/fund-settlements.yml
@@ -55,9 +55,10 @@ steps:
         current_epoch=$(curl --silent "$$RPC_URL" -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getEpochInfo"}' | jq '.result.epoch')
         epochs_start_index=$((current_epoch - past_epochs_to_load))
       else
-      current_epoch=$$epoch
+        current_epoch=$$epoch
         epochs_start_index=$$epoch
       fi
+    - latest_funded_epoch=''
     - |
       for epoch in $(seq $$epochs_start_index $$current_epoch); do
         if [[ $$epoch -lt $$starting_epoch_contract_v2 ]]; then
@@ -79,7 +80,9 @@ steps:
           gcloud storage cp "$gs_bucket/$$epoch/$${claim_type}-settlement-merkle-trees.json" "$$target_dir"
           gcloud storage cp "$gs_bucket/$$epoch/$${claim_type}-settlements.json" "$$target_dir"
         fi
+        latest_funded_epoch="$$epoch"
       done
+    - buildkite-agent meta-data set latest_funded_epoch "$$latest_funded_epoch"
     artifact_paths:
       - "./merkle-trees/**/*"
 
@@ -155,6 +158,19 @@ steps:
     allow_dependency_failure: true
 
   - wait: ~
+
+  - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts Fund Settlements"
+    commands:
+    - latest_funded_epoch=$(buildkite-agent meta-data get latest_funded_epoch)
+    - claim_type=$(buildkite-agent meta-data get claim_type)
+    - claim_type_prefix=$([[ -z "$$claim_type" ]] && echo "" || echo "$${claim_type}-")
+    - buildkite-agent artifact download --include-retried-jobs fund-report.txt . || echo "UNKNOWN ERROR" > fund-report.txt
+    - |
+      if [[ -n "$$latest_funded_epoch" ]]; then
+        gcloud storage cp ./fund-report.txt "$gs_bucket/$$latest_funded_epoch/buildkite/$${claim_type_prefix}fund-settlement-report.$(date +%s).txt"
+      fi
+    depends_on: "notification-setup-funding"
+    allow_dependency_failure: true
 
   - label: ":mega: Notification Funding"
     commands:

--- a/.buildkite/init-settlements.yml
+++ b/.buildkite/init-settlements.yml
@@ -167,14 +167,14 @@ steps:
 
   - wait: ~
 
-  - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts"
+  - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts Init Settlements"
     commands:
     - epoch=$(buildkite-agent meta-data get epoch)
     - claim_type=$(buildkite-agent meta-data get claim_type)
     - buildkite-agent artifact download --include-retried-jobs init-report.txt . || echo "UNKNOWN ERROR" > init-report.txt
-    - gcloud storage cp ./init-report.txt "$gs_bucket/$$epoch/$${claim_type}-init-settlement-report.$(date +%s).txt"
-
-  - wait: ~
+    - gcloud storage cp ./init-report.txt "$gs_bucket/$$epoch/buildkite/$${claim_type}-init-settlement-report.$(date +%s).txt"
+    depends_on: "notification-setup-init"
+    allow_dependency_failure: true
 
   - label: ":mega: Notification :fast_forward: Monitoring Initialize Settlements"
     commands:
@@ -200,6 +200,7 @@ steps:
     commands:
     - claim_type=$(buildkite-agent meta-data get claim_type)
     - epoch=$(buildkite-agent meta-data get epoch)
+
     - gcloud storage cp "$gs_bucket/$$epoch/$${claim_type}-discord-public-report.txt" "./discord-public-report.txt"
     - |
       split_command=$(which split >&2 > /dev/null && echo "split" || echo "gsplit")

--- a/.buildkite/prepare-bidding.yml
+++ b/.buildkite/prepare-bidding.yml
@@ -94,7 +94,7 @@ steps:
 
   - wait: ~
 
-  - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts"
+  - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts Prepare Bidding"
     commands:
     - epoch=$(buildkite-agent meta-data get epoch)
     - buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}-settlements.json .

--- a/.buildkite/prepare-protected-events.yml
+++ b/.buildkite/prepare-protected-events.yml
@@ -150,7 +150,7 @@ steps:
 
   - wait: ~
 
-  - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts"
+  - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts Prepare Protected Events"
     commands:
     - epoch=$(buildkite-agent meta-data get epoch)
     - buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}.json .

--- a/packages/validator-bonds-cli/__tests__/test-validator/show.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/show.spec.ts
@@ -6,9 +6,6 @@ import {
   getWithdrawRequest,
   cancelWithdrawRequestInstruction,
   bondsWithdrawerAuthority,
-  WithdrawRequest,
-  Config,
-  getConfig,
 } from '@marinade.finance/validator-bonds-sdk'
 import {
   U64_MAX,

--- a/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
+++ b/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
@@ -64,7 +64,7 @@ const VOTE_ACCOUNT_IDENTITY = Keypair.fromSecretKey(
 //       Activate and run this manually when needed.
 //       FILE='settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts' pnpm test:validator
 
-describe('Cargo CLI: Pipeline Settlement', () => {
+describe.skip('Cargo CLI: Pipeline Settlement', () => {
   let provider: AnchorExtendedProvider
   let program: ValidatorBondsProgram
 
@@ -604,7 +604,7 @@ describe('Cargo CLI: Pipeline Settlement', () => {
     ).toHaveMatchingSpawnOutput({
       code: 2,
       stderr: /All stake accounts are locked for claiming/,
-      stdout: /claimed 1[1-2][0-9][0-9][0-9] merkle nodes/,
+      stdout: /claimed 1[1-2][0-9][0-9][0-9].[0-9]+ merkle nodes/,
     })
 
     // fund is now run before claiming normally, simulating this situation here
@@ -664,7 +664,7 @@ describe('Cargo CLI: Pipeline Settlement', () => {
       code: 2,
       stderr: /already claimed merkle tree nodes 414/,
       stdout:
-        /claimed 0 merkle nodes(.|\n|\r)*No stake account found with enough SOLs to claim/,
+        /claimed 0.[0-9]+ merkle nodes(.|\n|\r)*No stake account found with enough SOLs to claim/,
     })
     previousTest = TestNames.ClaimSettlement
   })

--- a/settlement-pipelines/src/bin/claim_settlement.rs
+++ b/settlement-pipelines/src/bin/claim_settlement.rs
@@ -818,7 +818,7 @@ impl PrintReportable for ClaimSettlementsReport {
                 );
 
                 report.push(format!(
-                    "Epoch {}, settlements {} this time claimed {}/{} merkle nodes in amount of {}/{} SOLs  (not claimed reason: no target {}, no source: {})",
+                    "Epoch {}, settlements {}, this time claimed {}/{} merkle nodes in amount of {}/{} SOLs  (not claimed reason: no target {}, no source: {})",
                     epoch,
                     after_settlements_count,
                     now_claimed_nodes,

--- a/settlement-pipelines/src/bin/claim_settlement.rs
+++ b/settlement-pipelines/src/bin/claim_settlement.rs
@@ -19,6 +19,7 @@ use settlement_pipelines::stake_accounts::{
     STAKE_ACCOUNT_RENT_EXEMPTION,
 };
 use settlement_pipelines::stake_accounts_cache::StakeAccountsCache;
+use settlement_pipelines::FINALIZATION_WAIT_TIMEOUT;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::clock::Clock;
 use solana_sdk::native_token::lamports_to_sol;
@@ -770,7 +771,7 @@ impl ClaimSettlementReport {
 impl PrintReportable for ClaimSettlementsReport {
     fn get_report(&self) -> Pin<Box<dyn Future<Output = Vec<String>> + '_>> {
         Box::pin(async {
-            sleep(std::time::Duration::from_secs(8)).await; // waiting for data finalization on-chain
+            sleep(FINALIZATION_WAIT_TIMEOUT).await; // waiting for data finalization on-chain
             let after_settlements = match self.load_settlements_from_chain().await {
                 Ok(value) => value,
                 Err(e) => return vec![format!("Error reporting settlement claiming: {:?}", e)],

--- a/settlement-pipelines/src/bin/close_settlement.rs
+++ b/settlement-pipelines/src/bin/close_settlement.rs
@@ -486,7 +486,6 @@ struct CloseSettlementReport {
     withdraw_wallet: Pubkey,
     /// settlement pubkey, settlement account
     closed_settlements: Vec<(Pubkey, Settlement)>,
-
     // epoch -> settlement -> (vote account, number of stake accounts that were reset, lamports)
     reset_stake_grouped: HashMap<u64, HashMap<Pubkey, (Pubkey, u64, u64)>>,
     // epoch -> settlement -> (marinade dao wallet, number of stake accounts that were withdrawn, lamports)

--- a/settlement-pipelines/src/bin/init_settlement.rs
+++ b/settlement-pipelines/src/bin/init_settlement.rs
@@ -17,6 +17,7 @@ use settlement_pipelines::json_data::{
 use settlement_pipelines::reporting::{with_reporting, PrintReportable, ReportHandler};
 use settlement_pipelines::reporting_data::SettlementsReportData;
 use settlement_pipelines::settlement_data::SettlementRecord;
+use settlement_pipelines::FINALIZATION_WAIT_TIMEOUT;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::native_token::lamports_to_sol;
 use solana_sdk::pubkey::Pubkey;
@@ -138,7 +139,7 @@ async fn real_main(reporting: &mut ReportHandler<InitSettlementReport>) -> anyho
     .await?;
 
     // waiting for data finalization on-chain
-    sleep(std::time::Duration::from_secs(8)).await;
+    sleep(FINALIZATION_WAIT_TIMEOUT).await;
 
     upsize_settlements(
         &program,

--- a/settlement-pipelines/src/bin/init_settlement.rs
+++ b/settlement-pipelines/src/bin/init_settlement.rs
@@ -23,7 +23,7 @@ use solana_sdk::signer::Signer;
 use solana_sdk::system_program;
 use solana_transaction_builder::TransactionBuilder;
 use solana_transaction_executor::{PriorityFeePolicy, TransactionExecutor};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -401,7 +401,7 @@ struct InitSettlementReport {
     json_settlements_max_claim_sum: u64,
     json_max_merkle_nodes_sum: u64,
     // settlement_address, vote_account_address
-    created_settlements: Vec<(Pubkey, Pubkey)>,
+    created_settlements: HashSet<SettlementRecord>,
     upsized_settlements: HashMap<Pubkey, u32>,
     epoch: u64,
 }
@@ -450,10 +450,7 @@ impl InitSettlementReport {
     }
 
     fn add_created_settlement(&mut self, settlement_record: &SettlementRecord) {
-        self.created_settlements.push((
-            settlement_record.settlement_address,
-            settlement_record.vote_account_address,
-        ));
+        self.created_settlements.insert(settlement_record.clone());
     }
 
     fn add_upsized_settlement(&mut self, settlement_address: Pubkey) {

--- a/settlement-pipelines/src/lib.rs
+++ b/settlement-pipelines/src/lib.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 pub mod anchor;
 pub mod arguments;
 pub mod cli_result;
@@ -12,3 +14,5 @@ pub mod stake_accounts;
 pub mod stake_accounts_cache;
 
 pub const CONTRACT_V2_DEPLOYMENT_EPOCH: u64 = 640_u64;
+
+pub const FINALIZATION_WAIT_TIMEOUT: Duration = Duration::from_secs(8);

--- a/settlement-pipelines/src/lib.rs
+++ b/settlement-pipelines/src/lib.rs
@@ -5,6 +5,7 @@ pub mod executor;
 pub mod init;
 pub mod json_data;
 pub mod reporting;
+pub mod reporting_data;
 pub mod settlement_data;
 pub mod settlements;
 pub mod stake_accounts;

--- a/settlement-pipelines/src/reporting_data.rs
+++ b/settlement-pipelines/src/reporting_data.rs
@@ -1,0 +1,165 @@
+use crate::settlement_data::SettlementRecord;
+use log::debug;
+use protected_event_distribution::settlement_claims::SettlementReason;
+use solana_sdk::pubkey::Pubkey;
+use std::collections::{HashMap, HashSet};
+use std::fmt::Display;
+
+#[derive(Default)]
+pub struct SettlementsReportData {
+    pub settlements_count: u64,
+    pub settlements_max_claim_sum: u64,
+    pub max_merkle_nodes_sum: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum ReportingReasonSettlement {
+    ProtectedEvent,
+    Bidding,
+}
+
+impl ReportingReasonSettlement {
+    pub fn items() -> Vec<ReportingReasonSettlement> {
+        vec![
+            ReportingReasonSettlement::ProtectedEvent,
+            ReportingReasonSettlement::Bidding,
+        ]
+    }
+}
+
+impl Display for ReportingReasonSettlement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReportingReasonSettlement::ProtectedEvent => write!(f, "ProtectedEvent"),
+            ReportingReasonSettlement::Bidding => write!(f, "Bidding"),
+        }
+    }
+}
+
+impl SettlementsReportData {
+    pub fn calculate(settlement_records: &[&SettlementRecord]) -> SettlementsReportData {
+        let settlements_count = settlement_records.len() as u64;
+        let settlements_max_claim_sum = settlement_records
+            .iter()
+            .map(|s| s.max_total_claim_sum)
+            .sum();
+        let max_merkle_nodes_sum = settlement_records.iter().map(|s| s.max_total_claim).sum();
+        SettlementsReportData {
+            settlements_count,
+            settlements_max_claim_sum,
+            max_merkle_nodes_sum,
+        }
+    }
+
+    pub fn calculate_bidding(
+        settlement_records: &HashSet<SettlementRecord>,
+    ) -> SettlementsReportData {
+        Self::calculate_filter_by_reason(ReportingReasonSettlement::Bidding, settlement_records)
+    }
+
+    pub fn calculate_protected_event(
+        settlement_records: &HashSet<SettlementRecord>,
+    ) -> SettlementsReportData {
+        Self::calculate_filter_by_reason(
+            ReportingReasonSettlement::ProtectedEvent,
+            settlement_records,
+        )
+    }
+
+    fn calculate_filter_by_reason(
+        reason_match: ReportingReasonSettlement,
+        settlement_records: &HashSet<SettlementRecord>,
+    ) -> SettlementsReportData {
+        let filtered_settlement_records = settlement_records
+            .iter()
+            .filter(|s| {
+                matches!(
+                    (&reason_match, &s.reason),
+                    (
+                        ReportingReasonSettlement::ProtectedEvent,
+                        SettlementReason::ProtectedEvent(_)
+                    ) | (
+                        ReportingReasonSettlement::Bidding,
+                        SettlementReason::Bidding
+                    )
+                )
+            })
+            .collect::<Vec<&SettlementRecord>>();
+        Self::calculate(&filtered_settlement_records)
+    }
+
+    pub fn calculate_sum_amount_bidding(
+        settlement_records: &HashMap<Pubkey, (SettlementRecord, u64)>,
+    ) -> (SettlementsReportData, u64) {
+        Self::calculate_sum_amount_filter_by_reason(
+            ReportingReasonSettlement::Bidding,
+            settlement_records,
+        )
+    }
+
+    pub fn calculate_sum_amount_protected_event(
+        settlement_records: &HashMap<Pubkey, (SettlementRecord, u64)>,
+    ) -> (SettlementsReportData, u64) {
+        Self::calculate_sum_amount_filter_by_reason(
+            ReportingReasonSettlement::ProtectedEvent,
+            settlement_records,
+        )
+    }
+
+    fn calculate_sum_amount_filter_by_reason(
+        reason_match: ReportingReasonSettlement,
+        settlement_records: &HashMap<Pubkey, (SettlementRecord, u64)>,
+    ) -> (SettlementsReportData, u64) {
+        let mut sum_amount: u64 = 0;
+        let filtered_settlement_records = settlement_records
+            .iter()
+            .filter(|(_, (s, _))| {
+                matches!(
+                    (&reason_match, &s.reason),
+                    (
+                        ReportingReasonSettlement::ProtectedEvent,
+                        SettlementReason::ProtectedEvent(_)
+                    ) | (
+                        ReportingReasonSettlement::Bidding,
+                        SettlementReason::Bidding
+                    )
+                )
+            })
+            .map(|(_, (s, amount))| {
+                sum_amount += amount;
+                s
+            })
+            .collect::<Vec<&SettlementRecord>>();
+        (Self::calculate(&filtered_settlement_records), sum_amount)
+    }
+
+    /// Filter settlement records matching the provided settlement pubkeys
+    /// and group them by type.
+    pub fn group_by_reason(
+        settlement_records: &HashSet<SettlementRecord>,
+        pubkeys: &[Pubkey],
+    ) -> HashMap<ReportingReasonSettlement, HashSet<Pubkey>> {
+        let mut result: HashMap<ReportingReasonSettlement, HashSet<Pubkey>> = HashMap::new();
+        result.insert(ReportingReasonSettlement::ProtectedEvent, HashSet::new());
+        result.insert(ReportingReasonSettlement::Bidding, HashSet::new());
+
+        // Mapping provided pubkeys to type based on the settlement records
+        for pubkey in pubkeys {
+            if let Some(settlement_record) = settlement_records
+                .iter()
+                .find(|&record| &record.settlement_address == pubkey)
+            {
+                let reason_type = match settlement_record.reason {
+                    SettlementReason::ProtectedEvent(_) => {
+                        ReportingReasonSettlement::ProtectedEvent
+                    }
+                    SettlementReason::Bidding => ReportingReasonSettlement::Bidding,
+                };
+                result.get_mut(&reason_type).unwrap().insert(*pubkey);
+            } else {
+                debug!("Unknown settlement record for pubkey: {}", pubkey);
+            };
+        }
+        result
+    }
+}

--- a/settlement-pipelines/src/settlement_data.rs
+++ b/settlement-pipelines/src/settlement_data.rs
@@ -6,6 +6,7 @@ use protected_event_distribution::settlement_claims::{SettlementFunder, Settleme
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Display, Formatter};
+use std::hash::Hash;
 use validator_bonds::state::bond::Bond;
 use validator_bonds::state::settlement::{find_settlement_staker_authority, Settlement};
 
@@ -38,6 +39,23 @@ pub struct SettlementRecord {
     // The reason for the settlement (protected event, bidding...), from the JSON file
     pub reason: SettlementReason,
 }
+
+/// Two SettlementRecords are equal if they are of the same bond and have the same epoch and merkle root.
+/// That is implicitly derived within settlement address, see [`validator_bonds::state::settlement::find_settlement_address`].
+/// While there cannot be created two `Settlement` records on-chain.
+impl PartialEq for SettlementRecord {
+    fn eq(&self, other: &Self) -> bool {
+        self.settlement_address == other.settlement_address
+    }
+}
+
+impl Hash for SettlementRecord {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.settlement_address.hash(state);
+    }
+}
+
+impl Eq for SettlementRecord {}
 
 #[derive(Debug, Clone)]
 pub struct SettlementFunderValidatorBond {


### PR DESCRIPTION
Adding better reporting data from on-chain pipeline bonds processing.
It won't be perfect, but it's a step to enhance the current state.

------------------------------------

Funding **FROM**

```
Epoch 664 funded 0/77 settlements with 0/320.694193201 SOLs (before this already funded 77/77 settlements with 320.694193201/320.694193201 SOLs)
```

**TO**

```
Epoch 664 funded 0/77 settlements with 0/320.694193201 SOLs (before this already funded 77/77 settlements with 320.694193201/320.694193201 SOLs)
  - Bidding: funded 0/73 settlements with 0/316.622360817 SOLs (before this already funded 73/73 settlements with 316.622360817/316.622360817 SOLs)
  - Protected Events: funded 0/4 settlements with 0/4.071832384 SOLs (before this already funded 4/4 settlements with 4.071832384/4.071832384 SOLs)
```

------------------------------------

Claiming **FROM**

```
Epoch 664, this time claimed 12 merkle nodes
  Settlement 9jrJMxZc94jv6AeN4qhgM24qQ8CtZRnTNffVDcjp7t5s in sum claimed SOLs 9.508584054/9.522508564 SOLs, claimed merkle nodes 384/393.
    This time claimed SOLs 0, merkle nodes 0 (not claimed reason: no target 0.01392451, no source: 0)
  Settlement BAgqAAVL7yKXdtD7M8MinUQXkA79WtUrxerhTCJ8cPdy in sum claimed SOLs 8.950869632/8.973457374 SOLs, claimed merkle nodes 1072/1096.
    This time claimed SOLs 0, merkle nodes 0 (not claimed reason: no target 0.022587742, no source: 0)
  Settlement 6J7i9j7CB8pq3NYAVSeAE8FJEyiAiXaLYwWvfWQ35TJ5 in sum claimed SOLs 2.176262691/2.203610993 SOLs, claimed merkle nodes 433/440.
...
```

**TO**

```
Epoch 664, settlements 77, this time claimed 0/97345 merkle nodes in amount of 0/320.694193201 SOLs  (not claimed reason: no target 1.103180698, no source: 0)
  - before this already claimed 95285/97345 merkle nodes with 319.591012503/320.694193201 SOLs
  Reason ProtectedEvent settlements 4 with 0/7170 merkle nodes in amount of 0/0.221133216 SOLs (before already claimed 7034/7170 nodes, 0.218096734/0.221133216 SOLs)
  Reason Bidding settlements 73 with 0/90175 merkle nodes in amount of 9.458174152/0.516333511 SOLs (before already claimed 88251/90175 nodes, 0.050409974/0.516333511 SOLs)
```