### PR TITLE
Decrease parallel execution speed

### DIFF
--- a/.buildkite/fund-settlements.yml
+++ b/.buildkite/fund-settlements.yml
@@ -40,25 +40,26 @@ steps:
       # epoch when the contract v2 was deployed, using different structure of merkle tree than v1
       starting_epoch_contract_v2: 640
     commands:
-    - |
-      set -x
-      merkle_trees=$(buildkite-agent artifact search "merkle-trees/*" || echo "")
-      if [[ "x$$merkle_trees" != "x" && ! "$$merkle_trees" =~ 'fatal' ]]; then
-        echo "Merkle trees already downloaded"
-        exit 0
-      fi
-    - 'mkdir ./merkle-trees/'
     - claim_type=$(buildkite-agent meta-data get claim_type) || true
     - epoch=$(buildkite-agent meta-data get epoch) || true
     - |
       if [[ -z "$$epoch" ]]; then
         current_epoch=$(curl --silent "$$RPC_URL" -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getEpochInfo"}' | jq '.result.epoch')
         epochs_start_index=$((current_epoch - past_epochs_to_load))
+        latest_funded_epoch=$((current_epoch - 1))
       else
         current_epoch=$$epoch
         epochs_start_index=$$epoch
+        latest_funded_epoch=$$epoch
       fi
-    - latest_funded_epoch=''
+    - buildkite-agent meta-data set latest_funded_epoch "$$latest_funded_epoch"
+    - |
+      merkle_trees=$(buildkite-agent artifact search "merkle-trees/*" || echo "")
+      if [[ "x$$merkle_trees" != "x" && ! "$$merkle_trees" =~ 'fatal' ]]; then
+        echo "Merkle trees already downloaded"
+        exit 0
+      fi
+    - 'mkdir ./merkle-trees/'
     - |
       for epoch in $(seq $$epochs_start_index $$current_epoch); do
         if [[ $$epoch -lt $$starting_epoch_contract_v2 ]]; then
@@ -80,9 +81,7 @@ steps:
           gcloud storage cp "$gs_bucket/$$epoch/$${claim_type}-settlement-merkle-trees.json" "$$target_dir"
           gcloud storage cp "$gs_bucket/$$epoch/$${claim_type}-settlements.json" "$$target_dir"
         fi
-        latest_funded_epoch="$$epoch"
       done
-    - buildkite-agent meta-data set latest_funded_epoch "$$latest_funded_epoch"
     artifact_paths:
       - "./merkle-trees/**/*"
 
@@ -161,8 +160,8 @@ steps:
 
   - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts Fund Settlements"
     commands:
-    - latest_funded_epoch=$(buildkite-agent meta-data get latest_funded_epoch)
-    - claim_type=$(buildkite-agent meta-data get claim_type)
+    - latest_funded_epoch=$(buildkite-agent meta-data get latest_funded_epoch) || true
+    - claim_type=$(buildkite-agent meta-data get claim_type) || true
     - claim_type_prefix=$([[ -z "$$claim_type" ]] && echo "" || echo "$${claim_type}-")
     - buildkite-agent artifact download --include-retried-jobs fund-report.txt . || echo "UNKNOWN ERROR" > fund-report.txt
     - |

--- a/settlement-pipelines/src/bin/claim_settlement.rs
+++ b/settlement-pipelines/src/bin/claim_settlement.rs
@@ -7,7 +7,7 @@ use settlement_pipelines::arguments::{
     init_from_opts, GlobalOpts, InitializedGlobalOpts, PriorityFeePolicyOpts, TipPolicyOpts,
 };
 use settlement_pipelines::cli_result::{CliError, CliResult};
-use settlement_pipelines::executor::{execute_parallel, execute_parallel_with_rate};
+use settlement_pipelines::executor::execute_parallel;
 use settlement_pipelines::init::{get_executor, init_log};
 use settlement_pipelines::json_data::load_json;
 use settlement_pipelines::reporting::{with_reporting, PrintReportable, ReportHandler};
@@ -428,12 +428,11 @@ async fn claim_settlement<'a>(
         )?;
     }
 
-    let execution_result = execute_parallel_with_rate(
+    let execution_result = execute_parallel(
         rpc_client.clone(),
         transaction_executor.clone(),
         transaction_builder,
         priority_fee_policy,
-        300,
     )
     .await;
     reporting.add_tx_execution_result(

--- a/settlement-pipelines/src/executor.rs
+++ b/settlement-pipelines/src/executor.rs
@@ -6,7 +6,7 @@ use solana_transaction_builder_executor::{
 use solana_transaction_executor::{PriorityFeePolicy, TransactionExecutor};
 use std::sync::Arc;
 
-const PARALLEL_EXECUTION_RATE_DEFAULT: usize = 100;
+const PARALLEL_EXECUTION_RATE_DEFAULT: usize = 30;
 
 pub async fn execute_parallel(
     rpc_client: Arc<RpcClient>,


### PR DESCRIPTION
Pipelines

* Fixing an error on uploading artifacts to gcloud from funding 
* Decreasing parallelism for claiming from 300 in parallel to 30 (tested that default 100 is still too much) to not getting many `429` errors