### PR TITLE
[tests] fix hardcoded 1 SOL in tests; failing when init minimumStakeLamports is defined

### DIFF
--- a/packages/validator-bonds-sdk/__tests__/bankrun/fundSettlement.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/fundSettlement.spec.ts
@@ -224,7 +224,7 @@ describe('Validator Bonds fund settlement', () => {
       provider,
       lamports: LAMPORTS_PER_SOL,
     })
-    const lamportsToFund = maxTotalClaim + LAMPORTS_PER_SOL
+    const lamportsToFund = maxTotalClaim + stakeAccountMinimalAmount - rentExemptStake
     const stakeAccount =
       await createBondsFundedStakeAccountActivated(lamportsToFund)
 
@@ -404,6 +404,7 @@ describe('Validator Bonds fund settlement', () => {
     const { stakeAccount, staker, withdrawer } = await delegatedStakeAccount({
       provider,
       voteAccountToDelegate: voteAccount,
+      lamports: stakeAccountMinimalAmount + 1
     })
     const deactivateIx = StakeProgram.deactivate({
       stakePubkey: stakeAccount,
@@ -441,8 +442,8 @@ describe('Validator Bonds fund settlement', () => {
       instruction
     )
     const settlementData = await getSettlement(program, settlementAccount)
-    // nothing funded as the lamports of the stake account is exactly min lamports for stake account (1 SOL) + rent exempt
-    expect(settlementData.lamportsFunded).toEqual(0)
+    // funded only 1 lamport; the lamports of the stake account is min lamports + rent exempt + 1 lamport
+    expect(settlementData.lamportsFunded).toEqual(1)
     await assertNotExist(provider, pubkey(splitStakeAccount))
     stakeAccountInfo = await provider.connection.getAccountInfo(stakeAccount)
     stakeAccountData = deserializeStakeState(stakeAccountInfo?.data)


### PR DESCRIPTION
Fix the `fundSettlement` test that does not work when defining a different configuration for a minimum stake[1].
By default, we have defined 1 SOL as we thought the feature flag `9onWzzvCzNC2jfhxxeqRgs5q7nFAAKpCUvkj6T6GJK9i`/`Raise minimum stake delegation to 1.0 SOL #24357`  will be activated but it seems it's not in the short term planned for Solana. So I tried to run the tests with the value of `0` and two tests failed as there was a hardcoded expectation to work with 1 SOL as minimum.
This change fixes that value being hardcoded in the test.


```
    await executeConfigureConfigInstruction({
      program,
      provider,
      configAccount,
      adminAuthority,
      // no minimum amount to work with stake accounts when splitting (e.g., fund settlement)
      newMinimumStakeLamports: 0,
    })
```