### PR TITLE
[pipelines] fix fund pipeline reporting

### DIFF
--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -778,6 +778,7 @@ impl FundSettlementsReport {
     fn add_already_fully_funded_settlement(&mut self, record: &SettlementRecord) {
         self.add_already_funded_settlement(record, record.max_total_claim_sum);
     }
+
     fn add_already_funded_settlement(&mut self, record: &SettlementRecord, funded_amount: u64) {
         let report = self.mut_ref(record.epoch);
         report
@@ -808,6 +809,11 @@ impl PrintReportable for FundSettlementsReport {
                         .iter()
                         .collect::<Vec<&SettlementRecord>>(),
                 );
+                let already_funded_count = funded_data
+                    .already_funded_settlements
+                    .iter()
+                    .filter(|(_, (_, amount))| *amount > 0)
+                    .count();
                 report.push(format!(
                     "Epoch {} funded {}/{} settlements with {}/{} SOLs (before this already funded {}/{} settlements with {}/{} SOLs)",
                     epoch,
@@ -815,7 +821,7 @@ impl PrintReportable for FundSettlementsReport {
                     json_loaded.settlements_count,
                     lamports_to_sol(funded_data.funded_amount()),
                     lamports_to_sol(json_loaded.settlements_max_claim_sum),
-                    funded_data.already_funded_settlements.len(),
+                    already_funded_count,
                     json_loaded.settlements_count,
                     lamports_to_sol(funded_data.already_funded_amount()),
                     lamports_to_sol(json_loaded.settlements_max_claim_sum),

--- a/settlement-pipelines/src/reporting_data.rs
+++ b/settlement-pipelines/src/reporting_data.rs
@@ -113,6 +113,7 @@ impl SettlementsReportData {
         let mut sum_amount: u64 = 0;
         let filtered_settlement_records = settlement_records
             .iter()
+            .filter(|(_, (_, amount))| *amount > 0)
             .filter(|(_, (s, _))| {
                 matches!(
                     (&reason_match, &s.reason),


### PR DESCRIPTION
`fund-settlement` reports wrong data about the number of already funded settlements. The calculation (filter) was done wrongly and those settlements that were not funded were summed to ones that were funded with some value.