### PR TITLE
Contract v2.1.0 deploy update main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## contract release v2.1.0 (2024-10-03)
+
+* address: [`vBoNdEvzMrSai7is21XgVYik65mqtaKXuSdMBJ1xkW4`](https://explorer.solana.com/address/vBoNdEvzMrSai7is21XgVYik65mqtaKXuSdMBJ1xkW4)
+* tag: [`contract-v2.1.0`](https://github.com/marinade-finance/validator-bonds/releases/tag/contract-v2.1.0), commit: [`4a5b009`](https://github.com/marinade-finance/validator-bonds/commit/4a5b009),
+* tx: [`5Thoyave21LckBdbVDsAehaVHcR43werbJsz6QJurFxux3tnpqKfVKY2T5Ytc7B8L6cSq29U5pRjK8L8sRtQqMG9`](https://explorer.solana.com/tx/5Thoyave21LckBdbVDsAehaVHcR43werbJsz6QJurFxux3tnpqKfVKY2T5Ytc7B8L6cSq29U5pRjK8L8sRtQqMG9)
+* anchor verify command:
+  ```
+  git checkout 4a5b009 &&\
+  anchor verify  --provider.cluster mainnet -p validator_bonds \
+    --env "GIT_REV=`git rev-parse --short HEAD`" --env 'GIT_REV_NAME=v2.1.0' vBoNdEvzMrSai7is21XgVYik65mqtaKXuSdMBJ1xkW4
+  ```
+
+### Breaking updates
+
+* Removal of instructions related to version `v1`: 
+  `closeSettlement`, `closeSettlementClaim`, `claimSettlement` ([PR#109](https://github.com/marinade-finance/validator-bonds/pull/109))
+* Update `FundSettlement` instruction to handle non-delegated lamports. Input accounts were changed. ([PR#77](https://github.com/marinade-finance/validator-bonds/pull/77))
+
+
 ## TS CLI&SDK [2.0.3](https://github.com/marinade-finance/validator-bonds/compare/v2.0.2...v2.0.3) (2024-08-30)
 
 ### Updates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7265,7 +7265,7 @@ dependencies = [
 
 [[package]]
 name = "validator-bonds"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/packages/validator-bonds-sdk/__tests__/bankrun/fundSettlement.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/fundSettlement.spec.ts
@@ -726,6 +726,275 @@ describe('Validator Bonds fund settlement', () => {
     )
   })
 
+  it.each([50, 0.5, 0.1])(
+    'fund settlement non-delegated split: %d',
+    async totalClaim => {
+      const maxTotalClaim = totalClaim * LAMPORTS_PER_SOL
+      const { settlementAccount } = await executeInitSettlement({
+        configAccount,
+        program,
+        provider,
+        voteAccount,
+        operatorAuthority,
+        currentEpoch: settlementEpoch,
+        maxTotalClaim,
+      })
+
+      const lamportsToFund = 4444 * LAMPORTS_PER_SOL
+      const stakeAccount =
+        await createBondsFundedStakeAccountActivated(lamportsToFund)
+      let stakeAccountData =
+        await provider.connection.getAccountInfo(stakeAccount)
+      expect(stakeAccountData?.lamports).toEqual(lamportsToFund)
+      // adding some more lamports to stake account that are not delegated
+      // when the amount of non-delegated lamports is bigger
+      const stakeAccountTransferredLamports =
+        maxTotalClaim + rentExemptStake + 1
+      const transferIx = SystemProgram.transfer({
+        fromPubkey: provider.wallet.publicKey,
+        toPubkey: stakeAccount,
+        lamports: stakeAccountTransferredLamports,
+      })
+      await provider.sendIx([], transferIx)
+      await getAndCheckStakeAccount(
+        provider,
+        stakeAccount,
+        StakeStates.Delegated
+      )
+      stakeAccountData = await provider.connection.getAccountInfo(stakeAccount)
+      expect(stakeAccountData?.lamports).toEqual(
+        lamportsToFund + stakeAccountTransferredLamports
+      )
+
+      let settlementData = await getSettlement(program, settlementAccount)
+      expect(settlementData.lamportsFunded).toEqual(0)
+
+      const { instruction, splitStakeAccount } =
+        await fundSettlementInstruction({
+          program,
+          settlementAccount,
+          stakeAccount: stakeAccount,
+        })
+      await provider.sendIx(
+        [signer(splitStakeAccount), operatorAuthority],
+        instruction
+      )
+
+      settlementData = await getSettlement(program, settlementAccount)
+      stakeAccountData = await provider.connection.getAccountInfo(stakeAccount)
+      const splitStakeAccountData = await provider.connection.getAccountInfo(
+        pubkey(splitStakeAccount)
+      )
+
+      expect(stakeAccountData?.lamports).toEqual(
+        maxTotalClaim +
+          2 * rentExemptStake + // rent for stake account + for returning rent exempt for split stake account
+          config.minimumStakeLamports.toNumber()
+      )
+      expect(splitStakeAccountData?.lamports).toEqual(
+        lamportsToFund +
+          stakeAccountTransferredLamports -
+          maxTotalClaim -
+          config.minimumStakeLamports.toNumber() -
+          rentExemptStake
+      )
+      expect(settlementData.lamportsFunded).toEqual(maxTotalClaim)
+    }
+  )
+
+  it.each([50, 0.5, 0.1])(
+    'fund settlement minimum delegated amount: %d',
+    async totalClaim => {
+      const maxTotalClaim = totalClaim * LAMPORTS_PER_SOL
+      const { settlementAccount } = await executeInitSettlement({
+        configAccount,
+        program,
+        provider,
+        voteAccount,
+        operatorAuthority,
+        currentEpoch: settlementEpoch,
+        maxTotalClaim,
+      })
+
+      const lamportsToFund =
+        config.minimumStakeLamports.toNumber() + rentExemptStake
+      const stakeAccount =
+        await createBondsFundedStakeAccountActivated(lamportsToFund)
+      let stakeAccountData =
+        await provider.connection.getAccountInfo(stakeAccount)
+      expect(stakeAccountData?.lamports).toEqual(lamportsToFund)
+      const stakeAccountTransferredLamports = 500 * LAMPORTS_PER_SOL
+      const transferIx = SystemProgram.transfer({
+        fromPubkey: provider.wallet.publicKey,
+        toPubkey: stakeAccount,
+        lamports: stakeAccountTransferredLamports,
+      })
+      await provider.sendIx([], transferIx)
+      await getAndCheckStakeAccount(
+        provider,
+        stakeAccount,
+        StakeStates.Delegated
+      )
+      stakeAccountData = await provider.connection.getAccountInfo(stakeAccount)
+      expect(stakeAccountData?.lamports).toEqual(
+        lamportsToFund + stakeAccountTransferredLamports
+      )
+
+      let settlementData = await getSettlement(program, settlementAccount)
+      expect(settlementData.lamportsFunded).toEqual(0)
+
+      const { instruction, splitStakeAccount } =
+        await fundSettlementInstruction({
+          program,
+          settlementAccount,
+          stakeAccount: stakeAccount,
+        })
+      await provider.sendIx(
+        [signer(splitStakeAccount), operatorAuthority],
+        instruction
+      )
+
+      settlementData = await getSettlement(program, settlementAccount)
+      stakeAccountData = await provider.connection.getAccountInfo(stakeAccount)
+      const splitStakeAccountData = await provider.connection.getAccountInfo(
+        pubkey(splitStakeAccount)
+      )
+
+      expect(stakeAccountData?.lamports).toEqual(
+        maxTotalClaim +
+          2 * rentExemptStake + // rent for stake account + for returning rent exempt for split stake account
+          config.minimumStakeLamports.toNumber()
+      )
+      expect(splitStakeAccountData?.lamports).toEqual(
+        lamportsToFund +
+          stakeAccountTransferredLamports -
+          maxTotalClaim -
+          config.minimumStakeLamports.toNumber() -
+          rentExemptStake
+      )
+      expect(settlementData.lamportsFunded).toEqual(maxTotalClaim)
+      await getAndCheckStakeAccount(
+        provider,
+        pubkey(splitStakeAccount),
+        StakeStates.Delegated
+      )
+    }
+  )
+
+  it('double fund settlement minimum delegated amount', async () => {
+    const maxTotalClaim = 50 * LAMPORTS_PER_SOL
+    const { settlementAccount } = await executeInitSettlement({
+      configAccount,
+      program,
+      provider,
+      voteAccount,
+      operatorAuthority,
+      currentEpoch: settlementEpoch,
+      maxTotalClaim,
+    })
+    let settlementData = await getSettlement(program, settlementAccount)
+    expect(settlementData.lamportsFunded).toEqual(0)
+
+    // 1st stake account
+    const lamportsToFund =
+      config.minimumStakeLamports.toNumber() + rentExemptStake
+    const stakeAccount1 =
+      await createBondsFundedStakeAccountActivated(lamportsToFund)
+    let stakeAccountData1 =
+      await provider.connection.getAccountInfo(stakeAccount1)
+    expect(stakeAccountData1?.lamports).toEqual(lamportsToFund)
+    const stakeAccountTransferredLamports1 = 10 * LAMPORTS_PER_SOL
+    const transferIx1 = SystemProgram.transfer({
+      fromPubkey: provider.wallet.publicKey,
+      toPubkey: stakeAccount1,
+      lamports: stakeAccountTransferredLamports1,
+    })
+    await provider.sendIx([], transferIx1)
+    await getAndCheckStakeAccount(
+      provider,
+      stakeAccount1,
+      StakeStates.Delegated
+    )
+    stakeAccountData1 = await provider.connection.getAccountInfo(stakeAccount1)
+    expect(stakeAccountData1?.lamports).toEqual(
+      lamportsToFund + stakeAccountTransferredLamports1
+    )
+
+    // 2nd stake account
+    const stakeAccount2 =
+      await createBondsFundedStakeAccountActivated(lamportsToFund)
+    let stakeAccountData2 =
+      await provider.connection.getAccountInfo(stakeAccount2)
+    expect(stakeAccountData2?.lamports).toEqual(lamportsToFund)
+    const stakeAccountTransferredLamports2 = 100 * LAMPORTS_PER_SOL
+    const transferIx2 = SystemProgram.transfer({
+      fromPubkey: provider.wallet.publicKey,
+      toPubkey: stakeAccount2,
+      lamports: stakeAccountTransferredLamports2,
+    })
+    await provider.sendIx([], transferIx2)
+    await getAndCheckStakeAccount(
+      provider,
+      stakeAccount2,
+      StakeStates.Delegated
+    )
+    stakeAccountData2 = await provider.connection.getAccountInfo(stakeAccount2)
+    expect(stakeAccountData2?.lamports).toEqual(
+      lamportsToFund + stakeAccountTransferredLamports2
+    )
+
+    const { instruction: ixFund1, splitStakeAccount: split1 } =
+      await fundSettlementInstruction({
+        program,
+        settlementAccount,
+        stakeAccount: stakeAccount1,
+      })
+    await provider.sendIx([signer(split1), operatorAuthority], ixFund1)
+    assertNotExist(provider, pubkey(split1))
+    settlementData = await getSettlement(program, settlementAccount)
+    expect(settlementData.lamportsFunded).toEqual(
+      stakeAccountTransferredLamports1
+    )
+
+    const { instruction: ixFund2, splitStakeAccount: split2 } =
+      await fundSettlementInstruction({
+        program,
+        settlementAccount,
+        stakeAccount: stakeAccount2,
+      })
+    await provider.sendIx([signer(split2), operatorAuthority], ixFund2)
+
+    settlementData = await getSettlement(program, settlementAccount)
+    expect(settlementData.lamportsFunded).toEqual(maxTotalClaim)
+
+    stakeAccountData1 = await provider.connection.getAccountInfo(stakeAccount1)
+    stakeAccountData2 = await provider.connection.getAccountInfo(stakeAccount2)
+    const splitStakeAccountData2 = await provider.connection.getAccountInfo(
+      pubkey(split2)
+    )
+
+    expect(stakeAccountData1?.lamports).toEqual(
+      stakeAccountTransferredLamports1 +
+        rentExemptStake + // no split, just rent for stake account
+        config.minimumStakeLamports.toNumber()
+    )
+    expect(stakeAccountData2?.lamports).toEqual(
+      maxTotalClaim -
+        stakeAccountTransferredLamports1 +
+        2 * rentExemptStake + // rent for stake account + for returning rent exempt for split stake account
+        config.minimumStakeLamports.toNumber()
+    )
+    expect(splitStakeAccountData2?.lamports).toEqual(
+      stakeAccountTransferredLamports2 -
+        (maxTotalClaim - stakeAccountTransferredLamports1)
+    )
+    await getAndCheckStakeAccount(
+      provider,
+      pubkey(split2),
+      StakeStates.Delegated
+    )
+  })
+
   async function createBondsFundedStakeAccountActivated(
     lamports: number
   ): Promise<PublicKey> {

--- a/packages/validator-bonds-sdk/generated/validator_bonds.ts
+++ b/packages/validator-bonds-sdk/generated/validator_bonds.ts
@@ -1484,14 +1484,19 @@ export type ValidatorBonds = {
               {
                 "kind": "account",
                 "type": "publicKey",
-                "account": "Bond",
-                "path": "bond.vote_account"
+                "path": "vote_account"
               }
             ]
           },
           "relations": [
-            "config"
+            "config",
+            "vote_account"
           ]
+        },
+        {
+          "name": "voteAccount",
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "settlement",
@@ -1640,6 +1645,11 @@ export type ValidatorBonds = {
         },
         {
           "name": "stakeProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "stakeConfig",
           "isMut": false,
           "isSigner": false
         },
@@ -6116,14 +6126,19 @@ export const IDL: ValidatorBonds = {
               {
                 "kind": "account",
                 "type": "publicKey",
-                "account": "Bond",
-                "path": "bond.vote_account"
+                "path": "vote_account"
               }
             ]
           },
           "relations": [
-            "config"
+            "config",
+            "vote_account"
           ]
+        },
+        {
+          "name": "voteAccount",
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "settlement",
@@ -6272,6 +6287,11 @@ export const IDL: ValidatorBonds = {
         },
         {
           "name": "stakeProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "stakeConfig",
           "isMut": false,
           "isSigner": false
         },

--- a/packages/validator-bonds-sdk/generated/validator_bonds.ts
+++ b/packages/validator-bonds-sdk/generated/validator_bonds.ts
@@ -1,5 +1,5 @@
 export type ValidatorBonds = {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "name": "validator_bonds",
   "constants": [
     {
@@ -4641,7 +4641,7 @@ export type ValidatorBonds = {
 };
 
 export const IDL: ValidatorBonds = {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "name": "validator_bonds",
   "constants": [
     {

--- a/packages/validator-bonds-sdk/src/instructions/fundSettlement.ts
+++ b/packages/validator-bonds-sdk/src/instructions/fundSettlement.ts
@@ -7,6 +7,7 @@ import {
   Keypair,
   Signer,
   SYSVAR_RENT_PUBKEY,
+  STAKE_CONFIG_ID,
 } from '@solana/web3.js'
 import { ValidatorBondsProgram, bondAddress } from '../sdk'
 import { getBond, getConfig, getSettlement } from '../api'
@@ -56,9 +57,10 @@ export async function fundSettlementInstruction({
     bondAccount = settlementData.bond
   }
 
-  if (configAccount === undefined) {
+  if (configAccount === undefined || voteAccount === undefined) {
     const bondData = await getBond(program, bondAccount)
     configAccount = bondData.config
+    voteAccount = bondData.voteAccount
   }
 
   if (operatorAuthority === undefined) {
@@ -86,6 +88,7 @@ export async function fundSettlementInstruction({
       bond: bondAccount,
       settlement: settlementAccount,
       operatorAuthority: operatorAuthorityPubkey,
+      voteAccount: voteAccount,
       stakeAccount,
       splitStakeAccount: splitStakeAccountPubkey,
       splitStakeRentPayer: splitStakeRentPayerPubkey,
@@ -93,6 +96,7 @@ export async function fundSettlementInstruction({
       rent: SYSVAR_RENT_PUBKEY,
       clock: SYSVAR_CLOCK_PUBKEY,
       stakeProgram: StakeProgram.programId,
+      stakeConfig: STAKE_CONFIG_ID,
     })
     .instruction()
   return {

--- a/programs/validator-bonds/Cargo.toml
+++ b/programs/validator-bonds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator-bonds"
-version = "2.0.0"
+version = "2.1.0"
 description = "Marinade validator bonds program protecting validators performance"
 edition = "2021"
 license = "Apache-2.0"

--- a/resources/idl/validator_bonds.json
+++ b/resources/idl/validator_bonds.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "name": "validator_bonds",
   "constants": [
     {
@@ -1484,14 +1484,19 @@
               {
                 "kind": "account",
                 "type": "publicKey",
-                "account": "Bond",
-                "path": "bond.vote_account"
+                "path": "vote_account"
               }
             ]
           },
           "relations": [
-            "config"
+            "config",
+            "vote_account"
           ]
+        },
+        {
+          "name": "voteAccount",
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "settlement",
@@ -1640,6 +1645,11 @@
         },
         {
           "name": "stakeProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "stakeConfig",
           "isMut": false,
           "isSigner": false
         },
@@ -2409,414 +2419,6 @@
           "name": "claimSettlementArgs",
           "type": {
             "defined": "ClaimSettlementV2Args"
-          }
-        }
-      ]
-    },
-    {
-      "name": "closeSettlement",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "bond",
-          "isMut": false,
-          "isSigner": false,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "type": "string",
-                "value": "bond_account"
-              },
-              {
-                "kind": "account",
-                "type": "publicKey",
-                "account": "Config",
-                "path": "config"
-              },
-              {
-                "kind": "account",
-                "type": "publicKey",
-                "account": "Bond",
-                "path": "bond.vote_account"
-              }
-            ]
-          },
-          "relations": [
-            "config"
-          ]
-        },
-        {
-          "name": "settlement",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "settlement to close when expired"
-          ],
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "type": "string",
-                "value": "settlement_account"
-              },
-              {
-                "kind": "account",
-                "type": "publicKey",
-                "account": "Bond",
-                "path": "bond"
-              },
-              {
-                "kind": "account",
-                "type": {
-                  "array": [
-                    "u8",
-                    32
-                  ]
-                },
-                "account": "Settlement",
-                "path": "settlement.merkle_root"
-              },
-              {
-                "kind": "account",
-                "type": "u64",
-                "account": "Settlement",
-                "path": "settlement.epoch_created_for"
-              }
-            ]
-          },
-          "relations": [
-            "bond",
-            "rent_collector"
-          ]
-        },
-        {
-          "name": "bondsWithdrawerAuthority",
-          "isMut": false,
-          "isSigner": false,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "type": "string",
-                "value": "bonds_authority"
-              },
-              {
-                "kind": "account",
-                "type": "publicKey",
-                "account": "Config",
-                "path": "config"
-              }
-            ]
-          }
-        },
-        {
-          "name": "rentCollector",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "splitRentCollector",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "splitRentRefundAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The stake account is funded to the settlement and credited to the bond's validator vote account.",
-            "The lamports are utilized to pay back the rent exemption of the split_stake_account, which can be created upon funding the settlement."
-          ]
-        },
-        {
-          "name": "clock",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "stakeProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "stakeHistory",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "type": "string",
-                "value": "__event_authority"
-              }
-            ]
-          }
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "closeSettlementClaim",
-      "accounts": [
-        {
-          "name": "settlement",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "settlementClaim",
-          "isMut": true,
-          "isSigner": false,
-          "relations": [
-            "rent_collector",
-            "settlement"
-          ]
-        },
-        {
-          "name": "rentCollector",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "type": "string",
-                "value": "__event_authority"
-              }
-            ]
-          }
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "claimSettlement",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "the config account under which the settlement was created"
-          ]
-        },
-        {
-          "name": "bond",
-          "isMut": false,
-          "isSigner": false,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "type": "string",
-                "value": "bond_account"
-              },
-              {
-                "kind": "account",
-                "type": "publicKey",
-                "account": "Config",
-                "path": "config"
-              },
-              {
-                "kind": "account",
-                "type": "publicKey",
-                "account": "Bond",
-                "path": "bond.vote_account"
-              }
-            ]
-          },
-          "relations": [
-            "config"
-          ]
-        },
-        {
-          "name": "settlement",
-          "isMut": true,
-          "isSigner": false,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "type": "string",
-                "value": "settlement_account"
-              },
-              {
-                "kind": "account",
-                "type": "publicKey",
-                "account": "Bond",
-                "path": "bond"
-              },
-              {
-                "kind": "account",
-                "type": {
-                  "array": [
-                    "u8",
-                    32
-                  ]
-                },
-                "account": "Settlement",
-                "path": "settlement.merkle_root"
-              },
-              {
-                "kind": "account",
-                "type": "u64",
-                "account": "Settlement",
-                "path": "settlement.epoch_created_for"
-              }
-            ]
-          },
-          "relations": [
-            "bond"
-          ]
-        },
-        {
-          "name": "settlementClaim",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "deduplication, merkle tree record cannot be claimed twice"
-          ],
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "type": "string",
-                "value": "claim_account"
-              },
-              {
-                "kind": "account",
-                "type": "publicKey",
-                "account": "Settlement",
-                "path": "settlement"
-              },
-              {
-                "kind": "arg",
-                "type": {
-                  "defined": "ClaimSettlementArgs"
-                },
-                "path": "params.tree_node_hash"
-              }
-            ]
-          }
-        },
-        {
-          "name": "stakeAccountFrom",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "a stake account that will be withdrawn"
-          ]
-        },
-        {
-          "name": "stakeAccountTo",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "a stake account that will receive the funds"
-          ]
-        },
-        {
-          "name": "bondsWithdrawerAuthority",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "authority that manages (owns == by being withdrawer authority) all stakes account under the bonds program"
-          ],
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "type": "string",
-                "value": "bonds_authority"
-              },
-              {
-                "kind": "account",
-                "type": "publicKey",
-                "account": "Config",
-                "path": "config"
-              }
-            ]
-          }
-        },
-        {
-          "name": "rentPayer",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "upon claiming, a claim account is created to confirm the occurrence of the claim",
-            "when the settlement withdrawal window expires, the claim account is closed, and the rent is refunded here"
-          ]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "stakeHistory",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "clock",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "stakeProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "type": "string",
-                "value": "__event_authority"
-              }
-            ]
-          }
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "claimSettlementArgs",
-          "type": {
-            "defined": "ClaimSettlementArgs"
           }
         }
       ]
@@ -3672,58 +3274,6 @@
           {
             "name": "settlement",
             "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ClaimSettlementArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "proof",
-            "docs": [
-              "proof that the claim is appropriate"
-            ],
-            "type": {
-              "vec": {
-                "array": [
-                  "u8",
-                  32
-                ]
-              }
-            }
-          },
-          {
-            "name": "treeNodeHash",
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "stakeAccountStaker",
-            "docs": [
-              "staker authority of the stake_account_to; merkle root verification"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "stakeAccountWithdrawer",
-            "docs": [
-              "withdrawer authority of the stake_account_to; merkle root verification"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "claim",
-            "docs": [
-              "claim amount; merkle root verification"
-            ],
-            "type": "u64"
           }
         ]
       }

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -26,6 +26,7 @@ use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::clock::Clock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
+use solana_sdk::stake::config::ID as stake_config_id;
 use solana_sdk::stake::instruction::create_account as create_stake_account_instructions;
 use solana_sdk::stake::program::ID as stake_program_id;
 use solana_sdk::sysvar::{
@@ -605,6 +606,7 @@ async fn fund_settlements(
                         .accounts(validator_bonds::accounts::FundSettlement {
                             config: *config_address,
                             bond: settlement_record.bond_address,
+                            vote_account: settlement_record.vote_account_address,
                             stake_account: *stake_account_to_fund,
                             bonds_withdrawer_authority: withdrawer_authority,
                             operator_authority: operator_authority.pubkey(),
@@ -618,6 +620,7 @@ async fn fund_settlements(
                             stake_history: stake_history_sysvar_id,
                             clock: clock_sysvar_id,
                             stake_program: stake_program_id,
+                            stake_config: stake_config_id,
                             program: validator_bonds_id,
                             event_authority: find_event_authority().0,
                         })


### PR DESCRIPTION
Update the `main` branch from the https://github.com/marinade-finance/validator-bonds/tree/contract-v2.1.0-deploy that is the branch with program deployed on-chain. Plus adding changelog and idl updates related to the contract release.