### PR TITLE
[cli] handle errors when bond or withdraw request exists on chain

### DIFF
--- a/packages/validator-bonds-cli/src/commands/manage/fundBond.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/fundBond.ts
@@ -147,8 +147,12 @@ async function manageFundBond({
       confirmWaitTime,
       sendOpts: { skipPreflight },
     })
+    logger.info(
+      `Bond account ${bondAccount.toBase58()} successfully funded ` +
+        `with stake account ${stakeAccount.toBase58()}`
+    )
   } catch (err) {
-    return failIfUnexpectedError({
+    failIfUnexpectedError({
       err,
       logger,
       provider,
@@ -158,10 +162,6 @@ async function manageFundBond({
       bondAccount,
     })
   }
-  logger.info(
-    `Bond account ${bondAccount.toBase58()} successfully funded ` +
-      `with stake account ${stakeAccount.toBase58()}`
-  )
 }
 
 async function failIfUnexpectedError({
@@ -187,7 +187,7 @@ async function failIfUnexpectedError({
       'wrong withdrawer authority of the stake account'
     )
   ) {
-    // it could be already funded account, let's check it
+    // it could be a stake account that's already funded, let's check it
     const [bondsWithdrawerAuth] = bondsWithdrawerAuthority(config, programId)
     const stakeAccountData = await getStakeAccount(
       provider.connection,

--- a/packages/validator-bonds-cli/src/commands/show.ts
+++ b/packages/validator-bonds-cli/src/commands/show.ts
@@ -28,11 +28,10 @@ import {
   withdrawRequestAddress,
 } from '@marinade.finance/validator-bonds-sdk'
 import { ProgramAccount } from '@coral-xyz/anchor'
-import { getBondFromAddress, formatToSol, formatUnit } from './utils'
+import { getBondFromAddress, formatUnit, formatToSolWithAll } from './utils'
 import BN from 'bn.js'
 import {
   ProgramAccountInfoNullable,
-  U64_MAX,
   VoteAccount,
   getMultipleAccounts,
   getVoteAccountFromData,
@@ -617,14 +616,7 @@ function reformatBond(key: string, value: any): ReformatAction {
     }
   }
   if (key === 'requestedAmount') {
-    if (new BN(value).eq(U64_MAX)) {
-      return {
-        type: 'UseExclusively',
-        records: [{ key, value: '<ALL>' }],
-      }
-    } else {
-      return format_sol_exclusive(key, value)
-    }
+    return format_sol_exclusive(key, value)
   }
   if (
     key.startsWith('amount') ||
@@ -654,7 +646,7 @@ function format_sol_exclusive(key: string, value: BN): ReformatAction {
     records: [
       {
         key,
-        value: `${formatToSol(value)}`,
+        value: `${formatToSolWithAll(value)}`,
       },
     ],
   }

--- a/packages/validator-bonds-cli/src/commands/utils.ts
+++ b/packages/validator-bonds-cli/src/commands/utils.ts
@@ -14,6 +14,7 @@ import {
   ProgramAccountInfo,
   getVoteAccountFromData,
   ExecutionError,
+  U64_MAX,
 } from '@marinade.finance/web3js-common'
 import {
   AccountInfo,
@@ -274,6 +275,14 @@ export async function getWithdrawRequestFromAddress({
       msg: 'Failed to fetch withdraw request account data',
       cause: e as Error,
     })
+  }
+}
+
+export function formatToSolWithAll(value: BN | number | BigInt): string {
+  if (new BN(value.toString()).eq(U64_MAX)) {
+    return '<ALL>'
+  } else {
+    return `${formatLamportsToSol(value)} ${formatUnit(value, 'SOL')}`
   }
 }
 


### PR DESCRIPTION
When user wants to create a bonds or withdraw request via CLI and such account exists, it should be just info and not an error.