### PR TITLE
[cli] make withdraw claim to work with stake accounts

### DIFF
--- a/packages/validator-bonds-cli/src/commands/utils.ts
+++ b/packages/validator-bonds-cli/src/commands/utils.ts
@@ -231,11 +231,30 @@ export async function getWithdrawRequestFromAddress({
   }
 
   let bondAccountAddress = address
-  const voteAccountAddress = await isVoteAccount({
+  let voteAccountAddress = await isVoteAccount({
     address,
     accountInfo,
     logger,
   })
+
+  if (
+    voteAccountAddress === null &&
+    accountInfo.owner.equals(StakeProgram.programId)
+  ) {
+    try {
+      const stakeAccountData = deserializeStakeState(accountInfo.data)
+      voteAccountAddress =
+        stakeAccountData.Stake?.stake.delegation.voterPubkey ?? null
+      if (voteAccountAddress !== null) {
+        logger.info(
+          `Address ${address.toBase58()} is a STAKE ACCOUNT delegated to vote account ` +
+            `${voteAccountAddress.toBase58()}. Using the vote account to get the withdraw request data.`
+        )
+      }
+    } catch (e) {
+      logger.debug(`Failed to decode account ${address} as stake account`, e)
+    }
+  }
 
   if (voteAccountAddress !== null) {
     if (config === undefined) {
@@ -256,7 +275,7 @@ export async function getWithdrawRequestFromAddress({
   accountInfo = await checkAccountExistence(
     program.provider.connection,
     address,
-    'type of withdrawRequest'
+    `WithdrawRequest generated from bond address ${bondAccountAddress.toBase58()} does not exist`
   )
 
   // final decoding of withdraw request account from account info
@@ -315,7 +334,9 @@ async function checkAccountExistence(
     throw new CliCommandError({
       valueName: '[address]',
       value: address.toBase58(),
-      msg: `Address does not exist at ${connection.rpcEndpoint}: ` + errorMsg,
+      msg:
+        `Address does not exist on-chain (RPC endpoint: ${connection.rpcEndpoint}): ` +
+        errorMsg,
     })
   }
   return accountInfo

--- a/packages/validator-bonds-sdk/src/orchestrators/orchestrateWithdrawRequest.ts
+++ b/packages/validator-bonds-sdk/src/orchestrators/orchestrateWithdrawRequest.ts
@@ -218,7 +218,8 @@ export async function orchestrateWithdrawDeposit({
 
   if (stakeAccountsFunded.length === 0 && amountToWithdraw > new BN(0)) {
     throw new Error(
-      'orchestrateWithdrawDeposit: cannot find any stake accounts to withdraw from'
+      'Claim withdraw request failed: No stake accounts found for bond account ' +
+        `(${bondAccount.toBase58()}) to process the withdrawal.`
     )
   }
 


### PR DESCRIPTION
Users often try to withdraw bonds not with the address of the bond or withdrawal request but (kind of logically) with the address of a stake account. This adjustment will check if the address is a stake account and derive a vote account from it that can eventually be used for the withdrawal of the bond.