### PR TITLE
Reporting claim fix

### DIFF
--- a/packages/validator-bonds-cli/src/commands/address.ts
+++ b/packages/validator-bonds-cli/src/commands/address.ts
@@ -9,6 +9,7 @@ import { setProgramIdOrDefault } from '../context'
 import {
   MARINADE_CONFIG_ADDRESS,
   bondAddress,
+  withdrawRequestAddress,
 } from '@marinade.finance/validator-bonds-sdk'
 import { ProgramAccount } from '@coral-xyz/anchor'
 
@@ -65,8 +66,16 @@ async function showBondAddress({
       'Deriving bond account address from vote account: ' +
         `${address.toBase58()}, config: ${config.toBase58()}, programId: ${program.programId.toBase58()}`
     )
+    const [withdrawRequestAddr, withdrawRequestBump] = withdrawRequestAddress(
+      bondAddr,
+      program.programId
+    )
+    logger.debug(
+      'Deriving withdraw request account address from bond account: ' +
+        `${bondAddr.toBase58()}, programId: ${program.programId.toBase58()}`
+    )
     console.log(
-      `Bond account address: ${bondAddr.toBase58()} [bump: ${bondBump}]`
+      `Bond account address: ${bondAddr.toBase58()} [bump: ${bondBump}], withdraw request address: ${withdrawRequestAddr.toBase58()} [bump: ${withdrawRequestBump}]`
     )
   } catch (err) {
     throw new CliCommandError({

--- a/protected-event-distribution/src/bin/cli.rs
+++ b/protected-event-distribution/src/bin/cli.rs
@@ -11,7 +11,9 @@ use protected_event_distribution::{
     protected_events::generate_protected_event_collection,
     utils::{read_from_json_file, write_to_json_file},
 };
-use snapshot_parser_types::{stake_meta::StakeMetaCollection, validator_meta::ValidatorMetaCollection};
+use snapshot_parser_types::{
+    stake_meta::StakeMetaCollection, validator_meta::ValidatorMetaCollection,
+};
 use solana_sdk::pubkey::Pubkey;
 use std::collections::HashSet;
 use {clap::Parser, log::info};

--- a/settlement-pipelines/src/reporting_data.rs
+++ b/settlement-pipelines/src/reporting_data.rs
@@ -158,7 +158,10 @@ impl SettlementsReportData {
                 };
                 result.get_mut(&reason_type).unwrap().insert(*pubkey);
             } else {
-                debug!("Unknown settlement record for pubkey: {}", pubkey);
+                debug!(
+                    "group by reason: unknown settlement record for pubkey: {}",
+                    pubkey
+                );
             };
         }
         result


### PR DESCRIPTION
Two minor updates combined:

* CLI to show bond address showing withdraw request address as well
* claiming report was showing wrong value for lamports, an error in `fold` function caused that