### PR TITLE
[dependency] Anchor toml to use solana 1.17.22 as Cargo.toml

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,6 +1,6 @@
 [toolchain]
 anchor_version = "0.29.0"
-solana_version = "1.16.18"
+solana_version = "1.17.22"
 
 [workspace]
 types = "packages/validator-bonds-sdk/generated/"


### PR DESCRIPTION
Aligning `Anchor.toml`  Solana version to 1.17.x as the all dependencies are specified in `Cargo.toml` workspace.