### PR TITLE
[api] fix wrong calculation of bonds funding

### DIFF
--- a/common-rs/src/funded_bonds.rs
+++ b/common-rs/src/funded_bonds.rs
@@ -39,7 +39,7 @@ pub async fn collect_validator_bonds_with_funds(
     log::info!("Found witdraw requests: {}", witdraw_requests.len());
     log::info!("Found settlements: {}", settlements.len());
 
-    for (pubkey, _, stake_account) in stake_accounts {
+    for (pubkey, lamports_available, stake_account) in stake_accounts {
         if let Some(lockup) = stake_account.lockup() {
             if lockup.is_in_force(&clock, None) {
                 log::warn!("Lockup is in force {pubkey}");
@@ -47,8 +47,8 @@ pub async fn collect_validator_bonds_with_funds(
         }
         if let Some(delegation) = stake_account.delegation() {
             let funded_bond = validator_funds.entry(delegation.voter_pubkey).or_default();
-            funded_bond.funded_amount += delegation.stake;
-            funded_bond.effective_amount += delegation.stake;
+            funded_bond.funded_amount += lamports_available;
+            funded_bond.effective_amount += lamports_available;
         }
     }
 


### PR DESCRIPTION
The collector for bond data miscalculates bond funding. Instead of using available lamports in stake accounts assigned to Bond it works with SDK field `Delegated Stake (SOL)` (i.e., `Delegation.stake`) that stands for `activated stake amount, set at delegate() time`.
It means the stake accounts that are part of a Settlement and are claimed during the time and decrease their value in SOL are reported in API with the amount of the initial Settlement creation.

![image](https://github.com/user-attachments/assets/3cf08fc8-278a-4271-9d19-c31a739c91f3)

With that, we report in API and PSR dashboard pretty bigger numbers for big bidders than is reality on the chain (and that's why probably so many validators' doubts on Bond funding)