### PR TITLE
[rpc retry] adding functionality to retry until all pubkeys are fetched

### DIFF
--- a/settlement-pipelines/src/bin/init_settlement.rs
+++ b/settlement-pipelines/src/bin/init_settlement.rs
@@ -301,6 +301,7 @@ async fn upsize_settlements(
             .collect::<Vec<Pubkey>>(),
         get_settlements_for_pubkeys,
         None,
+        true,
     )
     .await
     .context("Failed to reload Settlements data based of pubkeys");


### PR DESCRIPTION
Enhancing the retry rpc functionality to have a chance to force all pub keys are expected to have a record onchain. This is follow-up to https://github.com/marinade-finance/validator-bonds/pull/151