### PR TITLE
[pipelines] using stake accounts with biggest non-delegated part first on settlement funding

### DIFF
--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -65,14 +65,14 @@ pub enum StakeAccountStateType {
 }
 
 pub fn get_stake_state_type(
-    stake_account: &StakeStateV2,
+    stake_account_state: &StakeStateV2,
     clock: &Clock,
     stake_history: &StakeHistory,
 ) -> StakeAccountStateType {
-    if let StakeStateV2::Initialized(_) = stake_account {
+    if let StakeStateV2::Initialized(_) = stake_account_state {
         // stake account is initialized and not delegated, it can be delegated just now
         StakeAccountStateType::Initialized
-    } else if let Some(delegation) = stake_account.delegation() {
+    } else if let Some(delegation) = stake_account_state.delegation() {
         // stake account was delegated, verification of the delegation state
         let StakeHistoryEntry {
             effective,
@@ -94,6 +94,23 @@ pub fn get_stake_state_type(
         }
     } else {
         StakeAccountStateType::NonAuthorized
+    }
+}
+
+pub fn get_delegated_amount(
+    stake_account_state: &StakeStateV2,
+    clock: &Clock,
+    stake_history: &StakeHistory,
+) -> u64 {
+    if let Some(delegation) = stake_account_state.delegation() {
+        let StakeHistoryEntry {
+            effective,
+            deactivating,
+            activating,
+        } = delegation.stake_activating_and_deactivating(clock.epoch, Some(stake_history), None);
+        effective + deactivating + activating
+    } else {
+        0
     }
 }
 


### PR DESCRIPTION
The perspective of this change is to re-define the way stake accounts are considered for funding-created settlements.
Up to now (with the context of having the issue in the contract for some time until October 2024 - https://github.com/marinade-finance/validator-bonds/pull/77) the funding pipeline was taking the biggest stake account to be used for funding the settlement.

This change prioritised using the stake accounts with the biggest part of undelegated lamports. Those can be directly used for claiming the settlements while the split part is left delegated and not claimed.