### PR TITLE
[contract] fix claim withdraw request splitting

### DIFF
--- a/packages/validator-bonds-sdk/generated/validator_bonds.ts
+++ b/packages/validator-bonds-sdk/generated/validator_bonds.ts
@@ -1061,6 +1061,16 @@ export type ValidatorBonds = {
           "isSigner": false
         },
         {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "stakeConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
           "name": "eventAuthority",
           "isMut": false,
           "isSigner": false,
@@ -4636,6 +4646,11 @@ export type ValidatorBonds = {
       "code": 6070,
       "name": "SettlementAlreadyClaimed",
       "msg": "Settlement has been already claimed"
+    },
+    {
+      "code": 6071,
+      "name": "StakeAccountNotBigEnoughToWithdrawOrSplit",
+      "msg": "Stake account is not big process with withdraw or split"
     }
   ]
 };
@@ -5703,6 +5718,16 @@ export const IDL: ValidatorBonds = {
           "isSigner": false
         },
         {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "stakeConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
           "name": "eventAuthority",
           "isMut": false,
           "isSigner": false,
@@ -9278,6 +9303,11 @@ export const IDL: ValidatorBonds = {
       "code": 6070,
       "name": "SettlementAlreadyClaimed",
       "msg": "Settlement has been already claimed"
+    },
+    {
+      "code": 6071,
+      "name": "StakeAccountNotBigEnoughToWithdrawOrSplit",
+      "msg": "Stake account is not big process with withdraw or split"
     }
   ]
 };

--- a/packages/validator-bonds-sdk/src/instructions/claimWithdrawRequest.ts
+++ b/packages/validator-bonds-sdk/src/instructions/claimWithdrawRequest.ts
@@ -1,6 +1,8 @@
 import {
   Keypair,
   PublicKey,
+  STAKE_CONFIG_ID,
+  SYSVAR_RENT_PUBKEY,
   SYSVAR_STAKE_HISTORY_PUBKEY,
   Signer,
   StakeProgram,
@@ -139,6 +141,8 @@ export async function claimWithdrawRequestInstruction({
       splitStakeRentPayer,
       stakeHistory: SYSVAR_STAKE_HISTORY_PUBKEY,
       stakeProgram: StakeProgram.programId,
+      rent: SYSVAR_RENT_PUBKEY,
+      stakeConfig: STAKE_CONFIG_ID,
     })
     .instruction()
   return {

--- a/programs/validator-bonds/src/error.rs
+++ b/programs/validator-bonds/src/error.rs
@@ -218,4 +218,7 @@ pub enum ErrorCode {
 
     #[msg("Settlement has been already claimed")]
     SettlementAlreadyClaimed, // 6070 0x17b6
+
+    #[msg("Stake account is not big process with withdraw or split")]
+    StakeAccountNotBigEnoughToWithdrawOrSplit, // 6071 0x17b7
 }

--- a/programs/validator-bonds/src/utils/stake.rs
+++ b/programs/validator-bonds/src/utils/stake.rs
@@ -1,7 +1,13 @@
+use crate::checks::get_delegation;
+use crate::constants::BONDS_WITHDRAWER_AUTHORITY_SEED;
+use crate::error::ErrorCode;
 use crate::state::config::Config;
 use anchor_lang::prelude::*;
+use anchor_lang::solana_program::program::{invoke, invoke_signed};
+use anchor_lang::solana_program::stake;
 use anchor_lang::solana_program::stake::state::Meta;
 use anchor_spl::stake::{withdraw, Stake, StakeAccount, Withdraw};
+use std::cmp::{max, min};
 
 /// This method serves to close/remove the stake account that has been just created
 /// and it's not initialized.
@@ -33,4 +39,173 @@ pub fn return_unused_split_stake_account_rent<'info>(
 
 pub fn minimal_size_stake_account(stake_meta: &Meta, config: &Config) -> u64 {
     stake_meta.rent_exempt_reserve + config.minimum_stake_lamports
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn split_stake<'info>(
+    stake_account: &Account<'info, StakeAccount>,
+    // amount that is about to be left within stake account (defined by business logic)
+    // while the rest is moved into split stake account (has to be made in state of "delegated")
+    amount_wanted: u64,
+    split_stake_account: &Account<'info, StakeAccount>,
+    vote_account: &UncheckedAccount<'info>,
+    config: &Account<'info, Config>,
+    bonds_withdrawer_authority: &UncheckedAccount<'info>,
+    stake_program: &Program<'info, Stake>,
+    stake_history: &Sysvar<'info, StakeHistory>,
+    stake_config: &UncheckedAccount<'info>,
+    clock: &Sysvar<'info, Clock>,
+    rent: &Sysvar<'info, Rent>,
+) -> Result<()> {
+    // this case should be handled by the caller
+    require_gt!(
+        stake_account.get_lamports(),
+        amount_wanted,
+        ErrorCode::StakeAccountNotBigEnoughToWithdrawOrSplit
+    );
+    let delegated_lamports = get_delegation(stake_account)?
+        .ok_or(ErrorCode::StakeNotDelegated)?
+        .stake;
+    let stake_meta = stake_account.meta().ok_or(ErrorCode::UninitializedStake)?;
+
+    // For the 'stake_account' to stay in the "delegated" state, a minimum stake must remain delegated.
+    // A portion of the undelegated lamports may need to be withdrawn to the split account before splitting.
+    // See: https://github.com/anza-xyz/agave/blob/v2.0.9/programs/stake/src/stake_state.rs#L504
+    let non_delegated_lamports = stake_account
+        .get_lamports()
+        .saturating_sub(delegated_lamports);
+    // considering the config `minimum_stake_lamports` will be setup based on the on-chain state
+    let minimum_delegation = config.minimum_stake_lamports;
+    let stake_rent_exempt = stake_meta.rent_exempt_reserve;
+
+    // the "non delegated part" left and used by business logic within stake account
+    // has to be at least of value rent_exempt
+    // then the "delegated part" has to be at least of value minimum_delegation (working with a delegated stake)
+    // the calculation requires to consider that when considering what is the whole "wanted amount"
+    let amount_non_delegated = max(
+        stake_rent_exempt,
+        min(
+            amount_wanted.saturating_sub(minimum_delegation),
+            non_delegated_lamports,
+        ),
+    );
+    let amount_delegated = amount_wanted - amount_non_delegated;
+    assert!(amount_non_delegated >= stake_rent_exempt);
+    assert!(amount_delegated >= minimum_delegation);
+
+    let split_amount_by_withdrawing = non_delegated_lamports - amount_non_delegated;
+    let split_amount_by_splitting = delegated_lamports - amount_delegated;
+    assert_eq!(
+        amount_delegated
+            + amount_non_delegated
+            + split_amount_by_splitting
+            + split_amount_by_withdrawing,
+        stake_account.get_lamports()
+    );
+    assert_eq!(amount_delegated + amount_non_delegated, amount_wanted,);
+
+    //  required to withdraw to avoid `InsufficientDelegation` error
+    // see https://github.com/anza-xyz/agave/blob/v2.0.9/programs/stake/src/stake_state.rs#L527C24-L527C71
+    if split_amount_by_withdrawing > 0 {
+        withdraw(
+            CpiContext::new_with_signer(
+                stake_program.to_account_info(),
+                Withdraw {
+                    stake: stake_account.to_account_info(),
+                    withdrawer: bonds_withdrawer_authority.to_account_info(),
+                    to: split_stake_account.to_account_info(),
+                    stake_history: stake_history.to_account_info(),
+                    clock: clock.to_account_info(),
+                },
+                &[&[
+                    BONDS_WITHDRAWER_AUTHORITY_SEED,
+                    &config.key().as_ref(),
+                    &[config.bonds_withdrawer_authority_bump],
+                ]],
+            ),
+            split_amount_by_withdrawing,
+            None,
+        )?;
+    }
+
+    if split_amount_by_splitting > 0 {
+        // Sufficient delegated lamports are available for splitting.
+        msg!(
+            "Splitting lamports {} to stake account {}",
+            split_stake_account.key(),
+            split_amount_by_splitting
+        );
+        let split_instruction = stake::instruction::split(
+            stake_account.to_account_info().key,
+            bonds_withdrawer_authority.key,
+            split_amount_by_splitting,
+            &split_stake_account.key(),
+        )
+        .last()
+        .unwrap()
+        .clone();
+        invoke_signed(
+            &split_instruction,
+            &[
+                stake_program.to_account_info(),
+                stake_account.to_account_info(),
+                split_stake_account.to_account_info(),
+                bonds_withdrawer_authority.to_account_info(),
+            ],
+            &[&[
+                BONDS_WITHDRAWER_AUTHORITY_SEED,
+                &config.key().as_ref(),
+                &[config.bonds_withdrawer_authority_bump],
+            ]],
+        )?;
+    } else {
+        // Insufficient delegated lamports for splitting.
+        //   Splitting would ensure the resulted stake account preserves delegation.
+        //   As splitting cannot be process we need manually initialize and delegate instead.
+        msg!(
+            "Delegating stake account {} to vote account {} with lamports {}",
+            split_stake_account.key(),
+            vote_account.key(),
+            split_stake_account.get_lamports()
+        );
+        let initialize_instruction = stake::instruction::initialize(
+            split_stake_account.to_account_info().key,
+            &stake::state::Authorized {
+                staker: bonds_withdrawer_authority.key(),
+                withdrawer: bonds_withdrawer_authority.key(),
+            },
+            &stake::state::Lockup::default(),
+        );
+        invoke(
+            &initialize_instruction,
+            &[
+                stake_program.to_account_info(),
+                split_stake_account.to_account_info(),
+                rent.to_account_info(),
+            ],
+        )?;
+        let delegate_instruction = &stake::instruction::delegate_stake(
+            &split_stake_account.key(),
+            &bonds_withdrawer_authority.key(),
+            &vote_account.key(),
+        );
+        invoke_signed(
+            delegate_instruction,
+            &[
+                stake_program.to_account_info(),
+                split_stake_account.to_account_info(),
+                bonds_withdrawer_authority.to_account_info(),
+                vote_account.to_account_info(),
+                clock.to_account_info(),
+                stake_history.to_account_info(),
+                stake_config.to_account_info(),
+            ],
+            &[&[
+                BONDS_WITHDRAWER_AUTHORITY_SEED,
+                &config.key().as_ref(),
+                &[config.bonds_withdrawer_authority_bump],
+            ]],
+        )?;
+    }
+    Ok(())
 }

--- a/resources/idl/validator_bonds.json
+++ b/resources/idl/validator_bonds.json
@@ -1061,6 +1061,16 @@
           "isSigner": false
         },
         {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "stakeConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
           "name": "eventAuthority",
           "isMut": false,
           "isSigner": false,

--- a/trident-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
+++ b/trident-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
@@ -1160,6 +1160,8 @@ pub mod validator_bonds_fuzz_instructions {
                 system_program: solana_sdk::system_program::ID,
                 stake_history: solana_sdk::sysvar::stake_history::ID,
                 clock: solana_sdk::sysvar::clock::ID,
+                rent: solana_sdk::sysvar::rent::ID,
+                stake_config: solana_sdk::stake::config::ID,
                 event_authority: find_event_authority().0,
                 program: validator_bonds::ID,
             }


### PR DESCRIPTION
As for the issue of non-delegated lamports troubles the funding settlement of the same issue was left as part of the claim withdrawal request.

This is a minor issue as it does not permit the withdraw request in some cases (if the stake account has got a bigger number of undelegated lamports). A workaround is to delete the withdraw request and create a new one with a bigger amount.

This PR adds the logic of withdrawing non-delegated lamports into the split account before calling split instruction.

Missing parts:

* tests for claim withdraw request with non-delegated lamports
* considering if the changed ix signature should not be made of version V2 and leaving the old signature within the directory `v1` for the ix would be parsable in future