### PR TITLE
[pipeline] fail when no sam data available

### DIFF
--- a/.buildkite/prepare-bidding.yml
+++ b/.buildkite/prepare-bidding.yml
@@ -51,6 +51,10 @@ steps:
     - epoch=$(buildkite-agent meta-data get epoch)
     - |
       curl -s "${MARINADE_SCORING_API_URL}/scores/sam?epoch=$$epoch" -o sam-scores.json
+      if [ $(jq '. | length' ./sam-scores.json) -eq 0 ]; then
+        echo "No SAM scores found for epoch $$epoch"
+        exit 1
+      fi
       gcloud storage cp "$gs_bucket/$$epoch/stakes.json" "."
     key: 'download-json'
     artifact_paths:


### PR DESCRIPTION
A small update on prepare bidding pipeline to fail when no SAM data is received (i.e., the array is empty as for any unknown epoch `curl  "https://scoring.marinade.finance/api/v1/scores/sam?epoch=1000000"` the result is `[]`.