### PR TITLE
Security vulnerabilities report fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "_copy-readme": "cp packages/validator-bonds-sdk/README.md build/packages/validator-bonds-sdk/ && cp packages/validator-bonds-cli/README.md build/packages/validator-bonds-cli/",
         "build": "pnpm compile && pnpm _copy-readme",
         "_test": "pnpm jest --config jest.config.test-validator.js --verbose --runInBand -- \"$FILE\"",
+        "pretest:validator": "node -e \"if (process.versions.node.split('.')[0] < 20) { console.error('Node.js 20 or higher is required for running tests (crypto module is in use)'); process.exit(1); }\"",
         "test:validator": "anchor test",
         "test:bankrun": "pnpm anchor:build && pnpm jest --config jest.config.bankrun.js --runInBand true -- \"$FILE\"",
         "test:cargo": "cargo test --features no-entrypoint -- --nocapture",
@@ -43,6 +44,10 @@
                 "jest": "29",
                 "@coral-xyz/anchor": "0.29"
             }
+        },
+        "overrides": {
+            "cross-spawn": "7.0.5",
+            "braces": "3.0.3"
         }
     },
     "engines": {

--- a/packages/validator-bonds-cli/package.json
+++ b/packages/validator-bonds-cli/package.json
@@ -42,6 +42,7 @@
     "yaml": "^2.4.5"
   },
   "devDependencies": {
+    "crypto-js": "^4.2.0",
     "@marinade.finance/jest-utils": "=2.4.12"
   },
   "engines": {

--- a/packages/validator-bonds-sdk/__tests__/bankrun/cancelWithdrawRequest.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/cancelWithdrawRequest.spec.ts
@@ -25,6 +25,7 @@ import assert from 'assert'
 import { createUserAndFund, pubkey } from '@marinade.finance/web3js-common'
 import { verifyError } from '@marinade.finance/anchor-common'
 import { initBankrunTest } from './bankrun'
+import { getSecureRandomInt } from '../utils/helpers'
 
 describe('Validator Bonds cancel withdraw request', () => {
   let provider: BankrunExtendedProvider
@@ -34,7 +35,7 @@ describe('Validator Bonds cancel withdraw request', () => {
   let bondAuthority: Keypair
   let validatorIdentity: Keypair
   let withdrawRequestAccount: PublicKey
-  const startUpEpoch = Math.floor(Math.random() * 100) + 100
+  const startUpEpoch = getSecureRandomInt(100, 200)
 
   beforeAll(async () => {
     ;({ provider, program } = await initBankrunTest())

--- a/packages/validator-bonds-sdk/__tests__/bankrun/claimWithdrawRequest.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/claimWithdrawRequest.spec.ts
@@ -38,6 +38,7 @@ import {
 } from '@marinade.finance/web3js-common'
 import { verifyError } from '@marinade.finance/anchor-common'
 import { initBankrunTest, delegateAndFund } from './bankrun'
+import { getSecureRandomInt } from '../utils/helpers'
 
 // TODO: test the merging stake accounts through the orchestrate withdraw request, i.e., test orchestrators/orchestrateWithdrawRequest.ts
 
@@ -49,7 +50,7 @@ describe('Validator Bonds claim withdraw request', () => {
   let validatorIdentity: Keypair
   let bondAuthority: Keypair
   let voteAccount: PublicKey
-  const startUpEpoch = Math.floor(Math.random() * 100) + 100
+  const startUpEpoch = getSecureRandomInt(100, 200)
   const withdrawLockupEpochs = 1
 
   beforeAll(async () => {

--- a/packages/validator-bonds-sdk/__tests__/bankrun/fundBond.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/fundBond.spec.ts
@@ -37,6 +37,7 @@ import {
   delegatedStakeAccount,
   getAndCheckStakeAccount,
 } from '../utils/staking'
+import { getSecureRandomInt } from '../utils/helpers'
 
 describe('Validator Bonds fund bond account', () => {
   let provider: BankrunExtendedProvider
@@ -45,7 +46,7 @@ describe('Validator Bonds fund bond account', () => {
   let bond: ProgramAccount<Bond>
   let bondAuthority: Keypair
   let bondWithdrawAuthority: PublicKey
-  const startUpEpoch = Math.floor(Math.random() * 100) + 100
+  const startUpEpoch = getSecureRandomInt(100, 200)
 
   beforeAll(async () => {
     ;({ provider, program } = await initBankrunTest())

--- a/packages/validator-bonds-sdk/__tests__/bankrun/initSettlement.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/initSettlement.spec.ts
@@ -28,6 +28,7 @@ import { createVoteAccount } from '../utils/staking'
 import { verifyError } from '@marinade.finance/anchor-common'
 import { initBankrunTest } from './bankrun'
 import { isInitialized } from '../../src/settlementClaims'
+import { getRandomByte } from '../utils/helpers'
 
 // maximum increase in account size per instruction
 //   see https://github.com/anza-xyz/agave/blob/v2.0.1/sdk/program/src/entrypoint.rs#L263
@@ -81,7 +82,7 @@ describe('Validator Bonds init settlement', () => {
 
   it('init settlement', async () => {
     const merkleRoot = Buffer.from(
-      Array.from({ length: 32 }, () => Math.floor(Math.random() * 256)),
+      Array.from({ length: 32 }, () => getRandomByte()),
     )
     const epochNow = await currentEpoch(provider)
     const rentCollector = Keypair.generate().publicKey
@@ -163,7 +164,7 @@ describe('Validator Bonds init settlement', () => {
 
   it('cannot init settlement with wrong buffer size', async () => {
     const merkleRoot = Buffer.from(
-      Array.from({ length: 30 }, () => Math.floor(Math.random() * 256)),
+      Array.from({ length: 30 }, () => getRandomByte()),
     )
     const { instruction, settlementAccount } = await initSettlementInstruction({
       program,

--- a/packages/validator-bonds-sdk/__tests__/bankrun/initWithdrawRequest.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/initWithdrawRequest.spec.ts
@@ -26,6 +26,7 @@ import {
 } from '@marinade.finance/web3js-common'
 import { verifyError } from '@marinade.finance/anchor-common'
 import { initBankrunTest } from './bankrun'
+import { getSecureRandomInt } from '../utils/helpers'
 
 describe('Validator Bonds init withdraw request', () => {
   let provider: BankrunExtendedProvider
@@ -38,7 +39,7 @@ describe('Validator Bonds init withdraw request', () => {
 
   beforeAll(async () => {
     ;({ provider, program } = await initBankrunTest())
-    const startUpEpochPlus = Math.floor(Math.random() * 100) + 100
+    const startUpEpochPlus = getSecureRandomInt(100, 200)
     const currentEpoch = Number(
       (await provider.context.banksClient.getClock()).epoch,
     )

--- a/packages/validator-bonds-sdk/__tests__/bankrun/mergeStake.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/mergeStake.spec.ts
@@ -44,13 +44,14 @@ import {
 import { pubkey, signer } from '@marinade.finance/web3js-common'
 import { verifyError } from '@marinade.finance/anchor-common'
 import { initBankrunTest } from './bankrun'
+import { getSecureRandomInt } from '../utils/helpers'
 
 describe('Staking merge verification/investigation', () => {
   let provider: BankrunExtendedProvider
   let program: ValidatorBondsProgram
   let configAccount: PublicKey
   let operatorAuthority: Keypair
-  const startUpEpoch = Math.floor(Math.random() * 100) + 100
+  const startUpEpoch = getSecureRandomInt(100, 200)
 
   beforeAll(async () => {
     ;({ provider, program } = await initBankrunTest())

--- a/packages/validator-bonds-sdk/__tests__/test-validator/apiStakeAccount.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/test-validator/apiStakeAccount.spec.ts
@@ -29,6 +29,7 @@ import { initTest } from './testValidator'
 import { rand } from '@marinade.finance/ts-common'
 import { BN } from 'bn.js'
 import { pubkey, signer } from '@marinade.finance/web3js-common'
+import { getSecureRandomInt } from '../utils/helpers'
 
 describe('Validator Bonds api call to stake accounts', () => {
   const NUMBER_OF_BONDS = 100
@@ -72,10 +73,8 @@ describe('Validator Bonds api call to stake accounts', () => {
     }
     ;(await Promise.all(promiseBonds)).forEach(bond => {
       const count = rand(5)
-      const randomLamports = [...Array(count)].map(
-        () =>
-          2 * LAMPORTS_PER_SOL +
-          Math.floor(Math.random() * 100 * LAMPORTS_PER_SOL),
+      const randomLamports = [...Array(count)].map(() =>
+        getSecureRandomInt(2 * LAMPORTS_PER_SOL, 100 * LAMPORTS_PER_SOL),
       )
       inputData.push({
         bondAccount: bond.bondAccount,

--- a/packages/validator-bonds-sdk/__tests__/test-validator/initSettlement.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/test-validator/initSettlement.spec.ts
@@ -145,9 +145,7 @@ describe('Validator Bonds init settlement', () => {
       .epoch
     const buffers: Buffer[] = []
     for (let i = 1; i <= numberOfSettlements; i++) {
-      const buffer = Buffer.from(
-        Array.from({ length: 32 }, () => Math.floor(Math.random() * 256)),
-      )
+      const buffer = Buffer.from(crypto.getRandomValues(new Uint8Array(32)))
       buffers.push(buffer)
       const { instruction } = await initSettlementInstruction({
         program,

--- a/packages/validator-bonds-sdk/__tests__/test-validator/initWithdrawRequest.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/test-validator/initWithdrawRequest.spec.ts
@@ -35,6 +35,7 @@ import {
   getAnchorValidatorInfo,
 } from '@marinade.finance/anchor-common'
 import assert from 'assert'
+import { getSecureRandomInt } from '../utils/helpers'
 
 describe('Validator Bonds init withdraw request', () => {
   let provider: AnchorExtendedProvider
@@ -137,7 +138,7 @@ describe('Validator Bonds init withdraw request', () => {
         program,
         configAccount,
         bondAuthority: bondAuthority.publicKey,
-        cpmpe: Math.floor(Math.random() * 100),
+        cpmpe: getSecureRandomInt(1, 100),
         voteAccount,
         validatorIdentity,
       })

--- a/packages/validator-bonds-sdk/__tests__/utils/helpers.ts
+++ b/packages/validator-bonds-sdk/__tests__/utils/helpers.ts
@@ -9,6 +9,7 @@ import {
 } from '@solana/web3.js'
 import { checkErrorMessage } from '@marinade.finance/ts-common'
 import assert from 'assert'
+import CryptoJS from 'crypto-js'
 
 export async function executeTxWithError(
   provider: ExtendedProvider,
@@ -49,4 +50,25 @@ export async function getRentExempt(
   return await provider.connection.getMinimumBalanceForRentExemption(
     accountInfo.data.length,
   )
+}
+
+export function getSecureRandomInt(min: number, max: number): number {
+  const range = max - min + 1
+  const bitsNeeded = Math.ceil(Math.log2(range))
+  const bytesNeeded = Math.ceil(bitsNeeded / 8)
+  const mask = (1 << bitsNeeded) - 1
+
+  let result: number
+  do {
+    const wordArray = CryptoJS.lib.WordArray.random(bytesNeeded)
+    result = wordArray.words[0] >>> 0 // Convert to unsigned 32-bit
+    result = result & mask // Apply mask to get required bits
+  } while (result >= range)
+
+  return min + result
+}
+
+export function getRandomByte() {
+  const wordArray = CryptoJS.lib.WordArray.random(1)
+  return wordArray.words[0] & 0xff
 }

--- a/packages/validator-bonds-sdk/__tests__/utils/helpers.ts
+++ b/packages/validator-bonds-sdk/__tests__/utils/helpers.ts
@@ -52,6 +52,10 @@ export async function getRentExempt(
   )
 }
 
+/**
+ * Generate a random number in the range [min, max] using a secure random number generator.
+ * The range is inclusive.
+ */
 export function getSecureRandomInt(min: number, max: number): number {
   const range = max - min + 1
   const bitsNeeded = Math.ceil(Math.log2(range))

--- a/packages/validator-bonds-sdk/__tests__/utils/testTransactions.ts
+++ b/packages/validator-bonds-sdk/__tests__/utils/testTransactions.ts
@@ -22,6 +22,7 @@ import { createVoteAccount, createVoteAccountWithIdentity } from './staking'
 import BN from 'bn.js'
 import assert from 'assert'
 import { pubkey, signer } from '@marinade.finance/web3js-common'
+import { getRandomByte, getSecureRandomInt } from './helpers'
 
 export async function executeWithdraw(
   provider: ExtendedProvider,
@@ -60,9 +61,9 @@ export async function executeWithdraw(
 export async function executeInitConfigInstruction({
   program,
   provider,
-  epochsToClaimSettlement = Math.floor(Math.random() * 10) + 1,
+  epochsToClaimSettlement = getSecureRandomInt(1, 10),
   slotsToStartSettlementClaiming = 0,
-  withdrawLockupEpochs = Math.floor(Math.random() * 10) + 1,
+  withdrawLockupEpochs = getSecureRandomInt(1, 10),
   adminAuthority,
   operatorAuthority,
   configAccountKeypair,
@@ -180,7 +181,7 @@ export async function executeInitBondInstruction({
   bondAuthority,
   voteAccount,
   validatorIdentity,
-  cpmpe = Math.floor(Math.random() * 100) + 1,
+  cpmpe = getSecureRandomInt(1, 100),
   maxStakeWanted = 0,
 }: {
   program: ValidatorBondsProgram
@@ -489,12 +490,10 @@ export async function executeInitSettlement({
   voteAccount,
   operatorAuthority,
   currentEpoch,
-  merkleRoot = Buffer.from(
-    Array.from({ length: 32 }, () => Math.floor(Math.random() * 256)),
-  ),
+  merkleRoot = Buffer.from(Array.from({ length: 32 }, () => getRandomByte())),
   rentCollector = Keypair.generate().publicKey,
-  maxMerkleNodes = Math.floor(Math.random() * 100) + 1,
-  maxTotalClaim = Math.floor(Math.random() * 100) + 1,
+  maxMerkleNodes = getSecureRandomInt(1, 100),
+  maxTotalClaim = getSecureRandomInt(1, 100),
 }: {
   program: ValidatorBondsProgram
   provider: ExtendedProvider

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  cross-spawn: 7.0.5
+  braces: 3.0.3
+
 importers:
 
   .:
@@ -99,6 +103,9 @@ importers:
       '@marinade.finance/jest-utils':
         specifier: '=2.4.12'
         version: 2.4.12(@jest/globals@29.7.0)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(jest-shell-matchers@1.0.2(jest@29.7.0(@types/node@22.10.7)(ts-node@10.9.2(@types/node@22.10.7)(typescript@5.4.5))))
+      crypto-js:
+        specifier: ^4.2.0
+        version: 4.2.0
 
   packages/validator-bonds-sdk:
     devDependencies:
@@ -1160,8 +1167,8 @@ packages:
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
-  braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
   browserslist@4.23.0:
@@ -1311,8 +1318,8 @@ packages:
   cross-fetch@3.1.8:
     resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
 
-  cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+  cross-spawn@7.0.5:
+    resolution: {integrity: sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==}
     engines: {node: '>= 8'}
 
   crypto-hash@1.3.0:
@@ -1637,8 +1644,8 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
-  fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
   find-up@4.1.0:
@@ -4211,9 +4218,9 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  braces@3.0.2:
+  braces@3.0.3:
     dependencies:
-      fill-range: 7.0.1
+      fill-range: 7.1.1
 
   browserslist@4.23.0:
     dependencies:
@@ -4363,7 +4370,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  cross-spawn@7.0.3:
+  cross-spawn@7.0.5:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -4535,7 +4542,7 @@ snapshots:
       '@ungap/structured-clone': 1.2.0
       ajv: 6.12.6
       chalk: 4.1.2
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.5
       debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
@@ -4598,7 +4605,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.5
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -4674,7 +4681,7 @@ snapshots:
 
   file-uri-to-path@1.0.0: {}
 
-  fill-range@7.0.1:
+  fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
 
@@ -5360,7 +5367,7 @@ snapshots:
 
   micromatch@4.0.5:
     dependencies:
-      braces: 3.0.2
+      braces: 3.0.3
       picomatch: 2.3.1
 
   mimic-fn@2.1.0: {}

--- a/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
+++ b/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
@@ -210,7 +210,7 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
 
     const randomMerkleTree =
       loadedJson.merkle_trees[
-        getSecureRandomInt(0, loadedJson.merkle_trees.length)
+        getSecureRandomInt(0, loadedJson.merkle_trees.length - 1)
       ]
     currentEpoch = (await program.provider.connection.getEpochInfo()).epoch
     await executeInitSettlement({

--- a/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
+++ b/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
@@ -37,6 +37,7 @@ import path from 'path'
 import { createDelegatedStakeAccount } from '../../../packages/validator-bonds-sdk/__tests__/utils/staking'
 import BN from 'bn.js'
 import assert from 'assert'
+import { getSecureRandomInt } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/helpers'
 
 const JEST_TIMEOUT_MS = 3000_000
 jest.setTimeout(JEST_TIMEOUT_MS)
@@ -209,7 +210,7 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
 
     const randomMerkleTree =
       loadedJson.merkle_trees[
-        Math.floor(Math.random() * loadedJson.merkle_trees.length)
+        getSecureRandomInt(0, loadedJson.merkle_trees.length)
       ]
     currentEpoch = (await program.provider.connection.getEpochInfo()).epoch
     await executeInitSettlement({
@@ -695,9 +696,8 @@ export async function chunkedCreateInitializedStakeAccounts({
   let signers: Keypair[] = []
   let counter = 0
   let futures: Promise<void>[] = []
-  const lockedAccounts = Array.from(
-    { length: 20 },
-    () => Math.floor(Math.random() * combined.length) + 1,
+  const lockedAccounts = Array.from({ length: 20 }, () =>
+    getSecureRandomInt(1, combined.length),
   )
   for (const { staker, withdrawer, keypair } of combined) {
     counter++


### PR DESCRIPTION
Fixing some of the dependabot security warnings for typescript.

This PR is a follow-up to https://github.com/marinade-finance/validator-bonds/pull/168
(what is relevant to this PR is the `[security] ...` commit)