### PR TITLE
[pipeline] fix prefix stripping in pipeline

### DIFF
--- a/.buildkite/claim-settlements.yml
+++ b/.buildkite/claim-settlements.yml
@@ -71,7 +71,7 @@ steps:
         for merkle_tree_file in $(gcloud storage ls "$gs_bucket/$$epoch/*settlement-merkle-trees.json"); do
           base_name=$(basename "$$merkle_tree_file")
           prefix_name="$${base_name%settlement-merkle-trees.json}"
-          target_dir="./merkle-trees/$${epoch}_$${prefix_name%%-*}/"
+          target_dir="./merkle-trees/$${epoch}_$${prefix_name%-*}/"
           mkdir -p "$$target_dir"
           gcloud storage cp "$gs_bucket/$$epoch/$${prefix_name}settlement-merkle-trees.json" "$$target_dir"
           gcloud storage cp "$gs_bucket/$$epoch/$${prefix_name}settlements.json" "$$target_dir"

--- a/.buildkite/fund-settlements.yml
+++ b/.buildkite/fund-settlements.yml
@@ -70,7 +70,7 @@ steps:
           for merkle_tree_file in $(gcloud storage ls "$gs_bucket/$$epoch/*settlement-merkle-trees.json"); do
             base_name=$(basename "$$merkle_tree_file")
             prefix_name="$${base_name%settlement-merkle-trees.json}"
-            target_dir="./merkle-trees/$${epoch}_$${prefix_name}/"
+            target_dir="./merkle-trees/$${epoch}_$${prefix_name%-*}/"
             mkdir -p "$$target_dir"
             gcloud storage cp "$gs_bucket/$$epoch/$${prefix_name}settlement-merkle-trees.json" "$$target_dir"
             gcloud storage cp "$gs_bucket/$$epoch/$${prefix_name}settlements.json" "$$target_dir"


### PR DESCRIPTION
Pipeline failure

```
error: unexpected argument './merkle-trees/732_bid/bid-psr-distribution-settlement-merkle-trees.json' found
```

Happens due to the program considers only two files being part of one directory to be loaded for claiming/funding.
Those are file for settlements and for merkle tree.

As the prefix was stripped too much multiple files are downloaded to one directory and program fails^^ to run.