### PR TITLE
[MIP.10] removal of stake wanted, increase TVL cap to 4%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## TS CLI&SDK [2.1.3](https://github.com/marinade-finance/validator-bonds/compare/v2.1.2...v2.1.3) (2025-02-20)
+## TS CLI&SDK [2.1.3](https://github.com/marinade-finance/validator-bonds/compare/v2.1.2...v2.1.3) (2025-02-19)
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## TS CLI&SDK [2.1.3](https://github.com/marinade-finance/validator-bonds/compare/v2.1.2...v2.1.3) (2025-02-20)
+
+### Updates
+
+* cli: `configure-bond`, `init-bond`, `show-bond` removal of `--max-stake-wanted` parameter
+  as the bidding auction stopped supporting this option
+
 ## TS CLI&SDK [2.1.2](https://github.com/marinade-finance/validator-bonds/compare/v2.1.1...v2.1.2) (2025-02-04)
 
 ### Updates

--- a/packages/validator-bonds-cli-core/package.json
+++ b/packages/validator-bonds-cli-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-core",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Common CLI Core of the validator bonds contract",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   "main": "src/index",
   "devDependencies": {
     "@marinade.finance/jest-utils": "^2.4.9",
-    "@marinade.finance/validator-bonds-sdk": "^2.1.2",
+    "@marinade.finance/validator-bonds-sdk": "workspace: ^2.1.3",
     "@coral-xyz/anchor": "^0.29.0",
     "@marinade.finance/anchor-common": "=2.4.13",
     "@marinade.finance/cli-common": "=2.4.13",
@@ -40,7 +40,7 @@
     "yaml": "^2.4.5"
   },
   "peerDependencies": {
-    "@marinade.finance/validator-bonds-sdk": "^2.1.2",
+    "@marinade.finance/validator-bonds-sdk": "workspace: ^2.1.3",
     "@coral-xyz/anchor": "^0.29.0",
     "@marinade.finance/anchor-common": "=2.4.13",
     "@marinade.finance/cli-common": "=2.4.13",

--- a/packages/validator-bonds-cli-core/package.json
+++ b/packages/validator-bonds-cli-core/package.json
@@ -22,7 +22,7 @@
   "main": "src/index",
   "devDependencies": {
     "@marinade.finance/jest-utils": "^2.4.9",
-    "@marinade.finance/validator-bonds-sdk": "workspace: ^2.1.3",
+    "@marinade.finance/validator-bonds-sdk": "^2.1.3",
     "@coral-xyz/anchor": "^0.29.0",
     "@marinade.finance/anchor-common": "=2.4.13",
     "@marinade.finance/cli-common": "=2.4.13",
@@ -40,7 +40,7 @@
     "yaml": "^2.4.5"
   },
   "peerDependencies": {
-    "@marinade.finance/validator-bonds-sdk": "workspace: ^2.1.3",
+    "@marinade.finance/validator-bonds-sdk": "^2.1.3",
     "@coral-xyz/anchor": "^0.29.0",
     "@marinade.finance/anchor-common": "=2.4.13",
     "@marinade.finance/cli-common": "=2.4.13",

--- a/packages/validator-bonds-cli-core/src/commands/manage/configureBond.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/configureBond.ts
@@ -57,12 +57,13 @@ export function configureConfigureBond(program: Command): Command {
       'New value of cost per mille per epoch, in lamports. The maximum amount of lamports the validator desires to pay for each 1000 delegated SOLs per epoch.',
       value => toBN(value),
     )
-    .option(
-      '--max-stake-wanted <number>',
-      'New value of maximum stake amount, in lamports, the validator wants to be delegated to them. ' +
-        'The actual amount delegated will depend on the auction and may be equal to or less than this value.',
-      value => toBN(value),
-    )
+  // MIP.10 removed maxStakeWanted from bidding auction, institutional staking does not support this option
+  // .option(
+  //   '--max-stake-wanted <number>',
+  //   'New value of maximum stake amount, in lamports, the validator wants to be delegated to them. ' +
+  //     'The actual amount delegated will depend on the auction and may be equal to or less than this value.',
+  //   value => toBN(value),
+  // )
 }
 
 export async function manageConfigureBond({

--- a/packages/validator-bonds-cli-core/src/commands/manage/initBond.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/initBond.ts
@@ -56,11 +56,12 @@ export function configureInitBond(program: Command): Command {
       'Cost per mille per epoch, in lamports. The maximum amount of lamports the validator desires to pay for each 1000 delegated SOLs per epoch. (default: 0)',
       value => toBN(value),
     )
-    .option(
-      '--max-stake-wanted <number>',
-      'The maximum stake amount, in lamports, that the validator wants to be delegated to them (default: 0).',
-      value => toBN(value),
-    )
+  // MIP.10 removed maxStakeWanted from bidding auction, institutional staking does not support this option
+  // .option(
+  //   '--max-stake-wanted <number>',
+  //   'The maximum stake amount, in lamports, that the validator wants to be delegated to them (default: 0).',
+  //   value => toBN(value),
+  // )
 }
 
 export async function manageInitBond({
@@ -78,7 +79,7 @@ export async function manageInitBond({
   bondAuthority: PublicKey
   rentPayer?: WalletInterface | PublicKey
   cpmpe: BN
-  maxStakeWanted: BN
+  maxStakeWanted?: BN
 }) {
   const {
     program,

--- a/packages/validator-bonds-cli-institutional/README.md
+++ b/packages/validator-bonds-cli-institutional/README.md
@@ -25,7 +25,7 @@ To get info on available commands
 ```sh
 # to verify installed version
 validator-bonds-institutional --version
-2.1.2
+2.1.3
 
 # get reference of available commands
 validator-bonds-institutional --help

--- a/packages/validator-bonds-cli-institutional/__tests__/test-validator/configureBondInstitutional.spec.ts
+++ b/packages/validator-bonds-cli-institutional/__tests__/test-validator/configureBondInstitutional.spec.ts
@@ -198,8 +198,6 @@ describe('Configure bond account using CLI (institutional)', () => {
           newBondAuthority.toBase58(),
           '--cpmpe',
           2,
-          '--max-stake-wanted',
-          999000000000,
           '--with-token',
           '--confirmation-finality',
           'confirmed',
@@ -215,6 +213,5 @@ describe('Configure bond account using CLI (institutional)', () => {
     const bondsData = await getBond(program, bondAccount)
     expect(bondsData.authority).toEqual(newBondAuthority)
     expect(bondsData.cpmpe).toEqual(2)
-    expect(bondsData.maxStakeWanted).toEqual(999 * LAMPORTS_PER_SOL)
   })
 })

--- a/packages/validator-bonds-cli-institutional/__tests__/test-validator/configureBondInstitutional.spec.ts
+++ b/packages/validator-bonds-cli-institutional/__tests__/test-validator/configureBondInstitutional.spec.ts
@@ -4,7 +4,7 @@ import {
   pubkey,
 } from '@marinade.finance/web3js-common'
 import { shellMatchers } from '@marinade.finance/jest-utils'
-import { Keypair, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js'
+import { Keypair, PublicKey } from '@solana/web3.js'
 import {
   ValidatorBondsProgram,
   bondAddress,

--- a/packages/validator-bonds-cli-institutional/__tests__/test-validator/initBondInstitutional.spec.ts
+++ b/packages/validator-bonds-cli-institutional/__tests__/test-validator/initBondInstitutional.spec.ts
@@ -91,8 +91,6 @@ describe('CLI init bond account (institutional)', () => {
           rentPayerPath,
           '--cpmpe',
           33,
-          '--max-stake-wanted',
-          1000_000_000_000,
           '--confirmation-finality',
           'confirmed',
         ],
@@ -114,7 +112,6 @@ describe('CLI init bond account (institutional)', () => {
     expect(bondsData.voteAccount).toEqual(voteAccount)
     expect(bondsData.authority).toEqual(bondAuthority.publicKey)
     expect(bondsData.cpmpe).toEqual(33)
-    expect(bondsData.maxStakeWanted).toEqual(1000 * LAMPORTS_PER_SOL)
     expect(bondsData.bump).toEqual(bump)
     await expect(
       await provider.connection.getBalance(rentPayerKeypair.publicKey),

--- a/packages/validator-bonds-cli-institutional/package.json
+++ b/packages/validator-bonds-cli-institutional/package.json
@@ -24,8 +24,8 @@
   ],
   "main": "src/index",
   "dependencies": {
-    "@marinade.finance/validator-bonds-sdk": "workspace: ^2.1.3",
-    "@marinade.finance/validator-bonds-cli-core": "workspace: ^2.1.3",
+    "@marinade.finance/validator-bonds-sdk": "^2.1.3",
+    "@marinade.finance/validator-bonds-cli-core": "^2.1.3",
     "@coral-xyz/anchor": "^0.29.0",
     "@marinade.finance/anchor-common": "=2.4.13",
     "@marinade.finance/cli-common": "=2.4.13",

--- a/packages/validator-bonds-cli-institutional/package.json
+++ b/packages/validator-bonds-cli-institutional/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-institutional",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "CLI of the validator bonds contract streamlined for institutional users",
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
   ],
   "main": "src/index",
   "dependencies": {
-    "@marinade.finance/validator-bonds-sdk": "^2.1.2",
-    "@marinade.finance/validator-bonds-cli-core": "^2.1.2",
+    "@marinade.finance/validator-bonds-sdk": "workspace: ^2.1.3",
+    "@marinade.finance/validator-bonds-cli-core": "workspace: ^2.1.3",
     "@coral-xyz/anchor": "^0.29.0",
     "@marinade.finance/anchor-common": "=2.4.13",
     "@marinade.finance/cli-common": "=2.4.13",

--- a/packages/validator-bonds-cli-institutional/src/commands/manage/configureBond.ts
+++ b/packages/validator-bonds-cli-institutional/src/commands/manage/configureBond.ts
@@ -18,14 +18,12 @@ export function installConfigureBond(program: Command) {
         withToken,
         bondAuthority,
         cpmpe,
-        maxStakeWanted,
       }: {
         voteAccount?: Promise<PublicKey>
         authority?: Promise<WalletInterface | PublicKey>
         withToken: boolean
         bondAuthority?: Promise<PublicKey>
         cpmpe?: BN
-        maxStakeWanted?: BN
       },
     ) => {
       await manageConfigureBond({
@@ -36,7 +34,7 @@ export function installConfigureBond(program: Command) {
         withToken,
         newBondAuthority: await bondAuthority,
         cpmpe,
-        maxStakeWanted,
+        maxStakeWanted: undefined,
       })
     },
   )

--- a/packages/validator-bonds-cli-institutional/src/commands/manage/initBond.ts
+++ b/packages/validator-bonds-cli-institutional/src/commands/manage/initBond.ts
@@ -14,14 +14,12 @@ export function installInitBond(program: Command) {
       bondAuthority,
       rentPayer,
       cpmpe = new BN(0),
-      maxStakeWanted = new BN(0),
     }: {
       voteAccount: Promise<PublicKey>
       validatorIdentity?: Promise<WalletInterface | PublicKey>
       bondAuthority: Promise<PublicKey>
       rentPayer?: Promise<WalletInterface | PublicKey>
       cpmpe: BN
-      maxStakeWanted: BN
     }) => {
       await manageInitBond({
         config: MARINADE_INSTITUTIONAL_CONFIG_ADDRESS,
@@ -30,7 +28,7 @@ export function installInitBond(program: Command) {
         bondAuthority: await bondAuthority,
         rentPayer: await rentPayer,
         cpmpe,
-        maxStakeWanted,
+        maxStakeWanted: undefined,
       })
     },
   )

--- a/packages/validator-bonds-cli-institutional/src/index.ts
+++ b/packages/validator-bonds-cli-institutional/src/index.ts
@@ -8,7 +8,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli-institutional'
 
 launchCliProgram({
-  version: '2.1.2',
+  version: '2.1.3',
   installAdditionalOptions: program => {
     program.setOptionValueWithSource(
       'programId',

--- a/packages/validator-bonds-cli/README.md
+++ b/packages/validator-bonds-cli/README.md
@@ -23,7 +23,7 @@ added 165 packages in 35s
 
 # to verify installed version
 validator-bonds --version
-2.1.2
+2.1.3
 ```
 
 To get info on available commands
@@ -684,7 +684,7 @@ To check where NPM packages are and will be installed:
 # Get npm global installation folder
 npm list -g
 > /usr/lib
-> +-- @marinade.finance/validator-bonds-cli@2.1.2
+> +-- @marinade.finance/validator-bonds-cli@2.1.3
 > ...
 # In this case, the `bin` folder is located at /usr/bin
 ```
@@ -710,7 +710,7 @@ With this configuration, NPM packages will be installed under the `prefix` direc
 npm i -g @marinade.finance/validator-bonds-cli@latest
 npm list -g
 > ~/.local/share/npm/lib
-> `-- @marinade.finance/validator-bonds-cli@2.1.2
+> `-- @marinade.finance/validator-bonds-cli@2.1.3
 ```
 
 To execute the installed packages from any location,
@@ -869,7 +869,7 @@ Commands:
   # Get npm global installation folder
   npm list -g
   > ~/.local/share/npm/lib
-  > `-- @marinade.finance/validator-bonds-cli@2.1.2
+  > `-- @marinade.finance/validator-bonds-cli@2.1.3
   # In this case, the 'bin' folder is located at ~/.local/share/npm/bin
 
   # Get validator-bonds binary folder

--- a/packages/validator-bonds-cli/README.md
+++ b/packages/validator-bonds-cli/README.md
@@ -71,10 +71,8 @@ validator-bonds fund-bond <vote-account-address> --stake-account <stake-account-
 
 # STEP 3: PARTICIPATE IN AUCTION
 # validator needs to participate in bidding to get the stake
-# --max-stake-wanted specifies the maximum amount of stake the validator aims to receive. The actual amount delegated will depend on the auction and may be equal to or less than this value.
 # --cpmpe defines how many lamports the validator is willing to pay for every 1000 SOLs delegated
-validator-bonds configure-bond <vote-account-address> --authority ./validator-identity.json \
-  --cpmpe <lamports> --max-stake-wanted <lamports>
+validator-bonds configure-bond <vote-account-address> --authority ./validator-identity.json --cpmpe <lamports>
 > Bond account BondAddress9iRYo3ZEK6dpmm9jYWX3Kb63Ed7RAFfUc successfully configured
 
 # VERIFICATION
@@ -139,13 +137,13 @@ The parameters and their meanings are explained in detail below:
    The bond's security is established by providing a stake account. The lamports in the stake account then corresponds to the SOL amount added to the security of the bond account.
    There is no direct payment of SOLs to the bond; it is accomplished solely by allocating stake accounts.
 * `--cpmpe`: Cost per mille per epoch, in lamports. How many lamports the validator is willing to pay for every 1000 SOLs delegated.
-  The property configures the bid the `Bond` owner wishes to pay for receiving delegated stake. The maximum delegated stake is defined by `max-stake-wanted`.
-  The actual amount of delegated stake is influenced by constraints defined by the [delegation strategy](https://docs.marinade.finance/marinade-protocol/validators).
+  The property configures the bid the `Bond` owner wishes to pay for receiving delegated stake. The maximum delegated stake is defined as a percent of full Marinade TVL.
+  The percentage is configured within project [ds-sam-pipeline](https://github.com/marinade-finance/ds-sam-pipeline/)
+  in [the config as `maxMarinadeTvlSharePerValidatorDec`](https://github.com/marinade-finance/ds-sam-pipeline/blob/main/auction-config.json).
+  The actual amount of delegated stake is defined by the [delegation strategy](https://docs.marinade.finance/marinade-protocol/validators).
   The `cpmpe` value goes into the auction where compared with other bids the delegation strategy determines
   the actual amount of stake delegated to the vote account linked to the `Bond` account.
-* `--max-stake-wanted`: The maximum stake, in lamports(!), that the `Bond` owner desires to get delegated
-  from the [delegation strategy](https://docs.marinade.finance/marinade-protocol/validators).
-  The funded bond is charged only for the amount of stake that was actually delegated
+* The funded bond is charged only for the amount of stake that was actually delegated
   (if nothing is delegated, nothing is charged).
 
 ### Show the bond account
@@ -174,8 +172,7 @@ Expected output on created bond is like
     "config": "vbMaRfmTCg92HWGzmd53APkMNpPnGVGZTUHwUJQkXAU",
     "voteAccount": "...",
     "authority": "...",
-    "costPerMillePerEpoch": "1000 lamports",
-    "maxStakeWanted": "10000 SOLs"
+    "costPerMillePerEpoch": "1000 lamports"
   },
   "voteAccount": {
     "nodePubkey": "...",
@@ -233,7 +230,6 @@ Subtracting this from the available amount results in a negative `amountActive`,
 signifying that no funds are available for Settlement funding.
 
 
-
 ### Bond account configuration
 
 The `Bond` owner may configure following properties of the account:
@@ -245,8 +241,7 @@ The `Bond` owner may configure following properties of the account:
 * `--cpmpe`: Cost per mille per epoch (in lamports). It's a bid used in the delegation strategy
   auction. The Bond owner agrees to pay this amount in lamports to get stake delegated to the vote
   account for one epoch.
-* `--max-stake-wanted` In lamports, the maximum amount of stake that the Bond owner desires to get delegated
-  to their vote account.
+
 
 #### Permission-ed Configure workflow
 
@@ -495,7 +490,7 @@ Configuration parameters:
 * `slotsToStartSettlementClaiming`: Number of slots that must elapse after a `Settlement` is created before claiming is permitted.
 * `withdrawLockupEpochs`: Number of epochs that must elapse before a Bonds withdrawal request can be claimed.
 * `minimumStakeLamports`: Minimum size of a stake account when working with split stakes.
-* `minBondMaxStakeWanted`: Minimal value in lamports to be permitted being defined for bond `--max-stake-wanted` parameter.
+* `minBondMaxStakeWanted`: Minimal value in lamports to be permitted being defined for bond.
 
 ```sh
 # Global configuration of Marinade Validator Bonds Program

--- a/packages/validator-bonds-cli/__tests__/test-validator/configureBond.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/configureBond.spec.ts
@@ -147,8 +147,6 @@ describe('Configure bond account using CLI', () => {
           newBondAuthority.toBase58(),
           '--cpmpe',
           32,
-          '--max-stake-wanted',
-          1000_000_000_000,
           '--confirmation-finality',
           'confirmed',
         ],
@@ -163,7 +161,6 @@ describe('Configure bond account using CLI', () => {
     const bondsData2 = await getBond(program, bondAccount)
     expect(bondsData2.authority).toEqual(newBondAuthority)
     expect(bondsData2.cpmpe).toEqual(32)
-    expect(bondsData2.maxStakeWanted).toEqual(1000 * LAMPORTS_PER_SOL)
   })
 
   it('configure bond account with mint', async () => {
@@ -249,8 +246,6 @@ describe('Configure bond account using CLI', () => {
           newBondAuthority.toBase58(),
           '--cpmpe',
           2,
-          '--max-stake-wanted',
-          999000000000,
           '--with-token',
           '--confirmation-finality',
           'confirmed',
@@ -266,7 +261,6 @@ describe('Configure bond account using CLI', () => {
     const bondsData = await getBond(program, bondAccount)
     expect(bondsData.authority).toEqual(newBondAuthority)
     expect(bondsData.cpmpe).toEqual(2)
-    expect(bondsData.maxStakeWanted).toEqual(999 * LAMPORTS_PER_SOL)
   })
 
   it('configure bond in print-only mode', async () => {

--- a/packages/validator-bonds-cli/__tests__/test-validator/configureBond.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/configureBond.spec.ts
@@ -4,7 +4,7 @@ import {
   pubkey,
 } from '@marinade.finance/web3js-common'
 import { shellMatchers } from '@marinade.finance/jest-utils'
-import { Keypair, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js'
+import { Keypair, PublicKey } from '@solana/web3.js'
 import {
   ValidatorBondsProgram,
   bondAddress,

--- a/packages/validator-bonds-cli/__tests__/test-validator/initBond.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/initBond.spec.ts
@@ -11,6 +11,7 @@ import {
   ValidatorBondsProgram,
   bondAddress,
   getBond,
+  getConfig,
 } from '@marinade.finance/validator-bonds-sdk'
 import { executeInitConfigInstruction } from '../../../validator-bonds-sdk/__tests__/utils/testTransactions'
 import { initTest } from '../../../validator-bonds-sdk/__tests__/test-validator/testValidator'
@@ -101,8 +102,6 @@ describe('Init bond account using CLI', () => {
           rentPayerPath,
           '--cpmpe',
           33,
-          '--max-stake-wanted',
-          1000_000_000_000,
           '--confirmation-finality',
           'confirmed',
         ],
@@ -124,7 +123,6 @@ describe('Init bond account using CLI', () => {
     expect(bondsData.voteAccount).toEqual(voteAccount)
     expect(bondsData.authority).toEqual(bondAuthority.publicKey)
     expect(bondsData.cpmpe).toEqual(33)
-    expect(bondsData.maxStakeWanted).toEqual(1000 * LAMPORTS_PER_SOL)
     expect(bondsData.bump).toEqual(bump)
     await expect(
       await provider.connection.getBalance(rentPayerKeypair.publicKey),
@@ -161,6 +159,7 @@ describe('Init bond account using CLI', () => {
       stdout: /Bond account .* successfully created/,
     })
 
+    const config = await getConfig(program, configAccount)
     const [bondAccount, bump] = bondAddress(
       configAccount,
       voteAccount,
@@ -171,7 +170,7 @@ describe('Init bond account using CLI', () => {
     expect(bondsData.voteAccount).toEqual(voteAccount)
     expect(bondsData.authority).toEqual(validatorIdentity.publicKey)
     expect(bondsData.cpmpe).toEqual(0)
-    expect(bondsData.maxStakeWanted).toEqual(0)
+    expect(bondsData.maxStakeWanted).toEqual(config.minBondMaxStakeWanted)
     expect(bondsData.bump).toEqual(bump)
     await expect(
       await provider.connection.getBalance(rentPayerKeypair.publicKey),
@@ -193,8 +192,6 @@ describe('Init bond account using CLI', () => {
           configAccount.toBase58(),
           '--vote-account',
           voteAccount.toBase58(),
-          '--max-stake-wanted',
-          1000000000000,
           '--confirmation-finality',
           'confirmed',
         ],
@@ -216,7 +213,6 @@ describe('Init bond account using CLI', () => {
     expect(bondsData.voteAccount).toEqual(voteAccount)
     expect(bondsData.authority).toEqual(validatorIdentity.publicKey)
     expect(bondsData.cpmpe).toEqual(0)
-    expect(bondsData.maxStakeWanted).toEqual(0)
     expect(bondsData.bump).toEqual(bump)
   })
 

--- a/packages/validator-bonds-cli/__tests__/test-validator/show.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/show.spec.ts
@@ -280,7 +280,6 @@ describe('Show command using CLI', () => {
         voteAccount: voteAccount.toBase58(),
         authority: bondAuthority.publicKey.toBase58(),
         costPerMillePerEpoch: '222 lamports',
-        maxStakeWanted: '2000 SOLs',
       },
     }
     const expectedDataFundingSingleItem = {
@@ -533,7 +532,6 @@ describe('Show command using CLI', () => {
         voteAccount: voteAccount,
         authority: bondAuthority.publicKey,
         costPerMillePerEpoch: '1 lamport',
-        maxStakeWanted: '0 SOL',
       },
     }
     const voteAccountShow = await loadTestingVoteAccount(

--- a/packages/validator-bonds-cli/package.json
+++ b/packages/validator-bonds-cli/package.json
@@ -24,8 +24,8 @@
   ],
   "main": "src/index",
   "dependencies": {
-    "@marinade.finance/validator-bonds-sdk": "workspace: ^2.1.3",
-    "@marinade.finance/validator-bonds-cli-core": "workspace: ^2.1.3",
+    "@marinade.finance/validator-bonds-sdk": "^2.1.3",
+    "@marinade.finance/validator-bonds-cli-core": "^2.1.3",
     "@coral-xyz/anchor": "^0.29.0",
     "@marinade.finance/anchor-common": "=2.4.13",
     "@marinade.finance/cli-common": "=2.4.13",

--- a/packages/validator-bonds-cli/package.json
+++ b/packages/validator-bonds-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "CLI of the validator bonds contract",
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
   ],
   "main": "src/index",
   "dependencies": {
-    "@marinade.finance/validator-bonds-sdk": "^2.1.2",
-    "@marinade.finance/validator-bonds-cli-core": "^2.1.2",
+    "@marinade.finance/validator-bonds-sdk": "workspace: ^2.1.3",
+    "@marinade.finance/validator-bonds-cli-core": "workspace: ^2.1.3",
     "@coral-xyz/anchor": "^0.29.0",
     "@marinade.finance/anchor-common": "=2.4.13",
     "@marinade.finance/cli-common": "=2.4.13",

--- a/packages/validator-bonds-cli/src/commands/manage/configureBond.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/configureBond.ts
@@ -28,7 +28,6 @@ export function installConfigureBond(program: Command) {
           withToken,
           bondAuthority,
           cpmpe,
-          maxStakeWanted,
         }: {
           config?: Promise<PublicKey>
           voteAccount?: Promise<PublicKey>
@@ -36,7 +35,6 @@ export function installConfigureBond(program: Command) {
           withToken: boolean
           bondAuthority?: Promise<PublicKey>
           cpmpe?: BN
-          maxStakeWanted?: BN
         },
       ) => {
         await manageConfigureBond({
@@ -47,7 +45,7 @@ export function installConfigureBond(program: Command) {
           withToken,
           newBondAuthority: await bondAuthority,
           cpmpe,
-          maxStakeWanted,
+          maxStakeWanted: undefined,
         })
       },
     )

--- a/packages/validator-bonds-cli/src/commands/manage/initBond.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/initBond.ts
@@ -23,7 +23,6 @@ export function installInitBond(program: Command) {
         bondAuthority,
         rentPayer,
         cpmpe = new BN(0),
-        maxStakeWanted = new BN(0),
       }: {
         config?: Promise<PublicKey>
         voteAccount: Promise<PublicKey>
@@ -31,7 +30,6 @@ export function installInitBond(program: Command) {
         bondAuthority: Promise<PublicKey>
         rentPayer?: Promise<WalletInterface | PublicKey>
         cpmpe: BN
-        maxStakeWanted: BN
       }) => {
         await manageInitBond({
           config: (await config) ?? MARINADE_CONFIG_ADDRESS,
@@ -40,7 +38,7 @@ export function installInitBond(program: Command) {
           bondAuthority: await bondAuthority,
           rentPayer: await rentPayer,
           cpmpe,
-          maxStakeWanted,
+          maxStakeWanted: undefined,
         })
       },
     )

--- a/packages/validator-bonds-cli/src/commands/show.ts
+++ b/packages/validator-bonds-cli/src/commands/show.ts
@@ -5,7 +5,6 @@ import {
 } from '@marinade.finance/cli-common'
 import {
   configureShowBond,
-  getCliContext,
   reformatBond,
   showBond,
 } from '@marinade.finance/validator-bonds-cli-core'
@@ -53,14 +52,13 @@ export function reformatBondBidding(
   key: string,
   value: unknown,
 ): ReformatAction {
-  if (!getCliContext().logger.isLevelEnabled('debug')) {
-    if (
-      typeof key === 'string' &&
-      // max stake wanted was removed from bidding auction (MIP.10)
-      (key as string).startsWith('maxStakeWanted')
-    ) {
-      return { type: 'Remove' }
-    }
+  if (
+    typeof key === 'string' &&
+    // Max Stake Wanted is no longer used in ds-sam bidding auctions (MIP-10).
+    // The on-chain data still exists but is not useful to users, so the CLI no longer displays it.
+    (key as string).startsWith('maxStakeWanted')
+  ) {
+    return { type: 'Remove' }
   }
 
   return reformatBond(key, value)

--- a/packages/validator-bonds-cli/src/commands/show.ts
+++ b/packages/validator-bonds-cli/src/commands/show.ts
@@ -1,6 +1,12 @@
-import { FormatType, parsePubkey } from '@marinade.finance/cli-common'
+import {
+  FormatType,
+  ReformatAction,
+  parsePubkey,
+} from '@marinade.finance/cli-common'
 import {
   configureShowBond,
+  getCliContext,
+  reformatBond,
   showBond,
 } from '@marinade.finance/validator-bonds-cli-core'
 import { MARINADE_CONFIG_ADDRESS } from '@marinade.finance/validator-bonds-sdk'
@@ -37,7 +43,25 @@ export function installShowBond(program: Command) {
           bondAuthority: await bondAuthority,
           withFunding,
           format,
+          reformatBondFunction: reformatBondBidding,
         })
       },
     )
+}
+
+export function reformatBondBidding(
+  key: string,
+  value: unknown,
+): ReformatAction {
+  if (!getCliContext().logger.isLevelEnabled('debug')) {
+    if (
+      typeof key === 'string' &&
+      // max stake wanted was removed from bidding auction (MIP.10)
+      (key as string).startsWith('maxStakeWanted')
+    ) {
+      return { type: 'Remove' }
+    }
+  }
+
+  return reformatBond(key, value)
 }

--- a/packages/validator-bonds-cli/src/index.ts
+++ b/packages/validator-bonds-cli/src/index.ts
@@ -9,7 +9,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli'
 
 launchCliProgram({
-  version: '2.1.2',
+  version: '2.1.3',
   installAdditionalOptions: program => {
     program.option(
       '--program-id <pubkey>',

--- a/packages/validator-bonds-sdk/package.json
+++ b/packages/validator-bonds-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-sdk",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "SDK of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-sdk/src/instructions/initBond.ts
+++ b/packages/validator-bonds-sdk/src/instructions/initBond.ts
@@ -8,6 +8,7 @@ import { ValidatorBondsProgram, bondAddress } from '../sdk'
 import { anchorProgramWalletPubkey } from '../utils'
 import BN from 'bn.js'
 import { Wallet as WalletInterface } from '@coral-xyz/anchor/dist/cjs/provider'
+import { getConfig } from '../api'
 
 /**
  * Generate instruction to initialize bond account. The bond account is coupled to a vote account.
@@ -22,7 +23,7 @@ export async function initBondInstruction({
   validatorIdentity,
   bondAuthority = anchorProgramWalletPubkey(program),
   cpmpe = 0,
-  maxStakeWanted = 0,
+  maxStakeWanted,
   rentPayer = anchorProgramWalletPubkey(program),
 }: {
   program: ValidatorBondsProgram
@@ -50,6 +51,11 @@ export async function initBondInstruction({
     voteAccount,
     program.programId,
   )
+
+  if (maxStakeWanted === undefined) {
+    const config = await getConfig(program, configAccount)
+    maxStakeWanted = config.minBondMaxStakeWanted
+  }
 
   const instruction = await program.methods
     .initBond({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,11 +65,11 @@ importers:
         specifier: '=2.4.13'
         version: 2.4.13
       '@marinade.finance/validator-bonds-cli-core':
-        specifier: ^2.1.2
-        version: 2.1.2(gwmqqshnivnuxddedvfb6ygbbm)
+        specifier: 'workspace: ^2.1.3'
+        version: link:../validator-bonds-cli-core
       '@marinade.finance/validator-bonds-sdk':
-        specifier: ^2.1.2
-        version: 2.1.2(@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@marinade.finance/marinade-ts-sdk@5.0.10(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10))(@marinade.finance/ts-common@2.4.13)(@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(crypto-js@4.2.0)(jsbi@4.3.0)
+        specifier: 'workspace: ^2.1.3'
+        version: link:../validator-bonds-sdk
       '@marinade.finance/web3js-common':
         specifier: '=2.4.13'
         version: 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
@@ -129,8 +129,8 @@ importers:
         specifier: '=2.4.13'
         version: 2.4.13
       '@marinade.finance/validator-bonds-sdk':
-        specifier: ^2.1.2
-        version: 2.1.2(@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@marinade.finance/marinade-ts-sdk@5.0.10(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10))(@marinade.finance/ts-common@2.4.13)(@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(crypto-js@4.2.0)(jsbi@4.3.0)
+        specifier: 'workspace: ^2.1.3'
+        version: link:../validator-bonds-sdk
       '@marinade.finance/web3js-common':
         specifier: '=2.4.13'
         version: 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
@@ -180,11 +180,11 @@ importers:
         specifier: '=2.4.13'
         version: 2.4.13
       '@marinade.finance/validator-bonds-cli-core':
-        specifier: ^2.1.2
-        version: 2.1.2(gwmqqshnivnuxddedvfb6ygbbm)
+        specifier: 'workspace: ^2.1.3'
+        version: link:../validator-bonds-cli-core
       '@marinade.finance/validator-bonds-sdk':
-        specifier: ^2.1.2
-        version: 2.1.2(@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@marinade.finance/marinade-ts-sdk@5.0.10(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10))(@marinade.finance/ts-common@2.4.13)(@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(crypto-js@4.2.0)(jsbi@4.3.0)
+        specifier: 'workspace: ^2.1.3'
+        version: link:../validator-bonds-sdk
       '@marinade.finance/web3js-common':
         specifier: '=2.4.13'
         version: 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
@@ -323,8 +323,8 @@ importers:
         specifier: '=2.4.13'
         version: 2.4.13
       '@marinade.finance/validator-bonds-sdk':
-        specifier: ^2.1.2
-        version: 2.1.2(@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@marinade.finance/marinade-ts-sdk@5.0.10(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10))(@marinade.finance/ts-common@2.4.13)(@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(crypto-js@4.2.0)(jsbi@4.3.0)
+        specifier: 'workspace: ^2.1.3'
+        version: link:../packages/validator-bonds-sdk
       '@marinade.finance/web3js-common':
         specifier: '=2.4.13'
         version: 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
@@ -805,43 +805,6 @@ packages:
       '@metaplex-foundation/umi': ^0.8.2
       '@metaplex-foundation/umi-bundle-defaults': ^0.8.2
       '@solana/web3.js': ^1.98.0
-
-  '@marinade.finance/validator-bonds-cli-core@2.1.2':
-    resolution: {integrity: sha512-O5XMzJKop85/xm15DIWAgw0T/11OPD7JX5eg1F+ET7B0vg6A/ABQzNQKpSLqfGMolKjXaSb/fsI5CQBu7CMCcQ==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@coral-xyz/anchor': ^0.29.0
-      '@marinade.finance/anchor-common': '=2.4.13'
-      '@marinade.finance/cli-common': '=2.4.13'
-      '@marinade.finance/ledger-utils': ^3.0.1
-      '@marinade.finance/ts-common': '=2.4.13'
-      '@marinade.finance/validator-bonds-sdk': ^2.1.2
-      '@marinade.finance/web3js-common': '=2.4.13'
-      '@solana/web3.js': ^1.98.0
-      bn.js: ^5.2.1
-      bs58: ^6.0.0
-      commander: ^13.1.0
-      jsbi: ^4.3.0
-      pino: ^9.6.0
-      pino-pretty: ^13.0.0
-      solana-spl-token-modern: npm:@solana/spl-token@^0.3.11
-      yaml: ^2.4.5
-
-  '@marinade.finance/validator-bonds-sdk@2.1.2':
-    resolution: {integrity: sha512-tLDA4UVzGNIfIxgNxGM8y5sB2/INFe+zQb33JTlJM9TWn9JkhPMbRH4V7qUfX/bIYofsC8f1Zxs7ukdjFtIt/g==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@coral-xyz/anchor': ^0.29.0
-      '@marinade.finance/marinade-ts-sdk': ^5.0.10
-      '@marinade.finance/ts-common': '=2.4.13'
-      '@marinade.finance/web3js-common': '=2.4.13'
-      '@solana/web3.js': ^1.98.0
-      bn.js: ^5.2.1
-      borsh: ^0.7.0
-      bs58: ^6.0.0
-      crypto-js: ^4.2.0
-      jsbi: ^4.3.0
-      solana-spl-token-modern: npm:@solana/spl-token@^0.3.11
 
   '@marinade.finance/web3js-common@2.4.13':
     resolution: {integrity: sha512-WT8qRH2ztGRYzJ6ydztcJcUtSMiAfEAXoYGeTyzmHL/oSPDevZ/4X+YS2VjR3kSG4DVALvsf61GDff9BR09dpw==}
@@ -3999,39 +3962,6 @@ snapshots:
       '@metaplex-foundation/umi': 0.8.10
       '@metaplex-foundation/umi-bundle-defaults': 0.8.10(@metaplex-foundation/umi@0.8.10)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-
-  '@marinade.finance/validator-bonds-cli-core@2.1.2(gwmqqshnivnuxddedvfb6ygbbm)':
-    dependencies:
-      '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@marinade.finance/anchor-common': 2.4.13(@anza-xyz/solana-rpc-get-stake-activation@1.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@marinade.finance/ts-common@2.4.13)(@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)
-      '@marinade.finance/cli-common': 2.4.13(@marinade.finance/ledger-utils@3.0.1(@ledgerhq/errors@6.16.2)(@ledgerhq/hw-app-solana@7.1.4)(@ledgerhq/hw-transport-node-hid-noevents@6.29.4)(@marinade.finance/ts-common@2.4.13)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@marinade.finance/ts-common@2.4.13)(@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(pino@9.6.0)(yaml@2.4.5)
-      '@marinade.finance/ledger-utils': 3.0.1(@ledgerhq/errors@6.16.2)(@ledgerhq/hw-app-solana@7.1.4)(@ledgerhq/hw-transport-node-hid-noevents@6.29.4)(@marinade.finance/ts-common@2.4.13)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@marinade.finance/ts-common': 2.4.13
-      '@marinade.finance/validator-bonds-sdk': 2.1.2(@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@marinade.finance/marinade-ts-sdk@5.0.10(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10))(@marinade.finance/ts-common@2.4.13)(@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(crypto-js@4.2.0)(jsbi@4.3.0)
-      '@marinade.finance/web3js-common': 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
-      '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      bn.js: 5.2.1
-      bs58: 6.0.0
-      commander: 13.1.0
-      jsbi: 4.3.0
-      pino: 9.6.0
-      pino-pretty: 13.0.0
-      solana-spl-token-modern: '@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)'
-      yaml: 2.4.5
-
-  '@marinade.finance/validator-bonds-sdk@2.1.2(@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@marinade.finance/marinade-ts-sdk@5.0.10(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10))(@marinade.finance/ts-common@2.4.13)(@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(crypto-js@4.2.0)(jsbi@4.3.0)':
-    dependencies:
-      '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@marinade.finance/marinade-ts-sdk': 5.0.10(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10)
-      '@marinade.finance/ts-common': 2.4.13
-      '@marinade.finance/web3js-common': 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
-      '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      bn.js: 5.2.1
-      borsh: 0.7.0
-      bs58: 6.0.0
-      crypto-js: 4.2.0
-      jsbi: 4.3.0
-      solana-spl-token-modern: '@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)'
 
   '@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,11 +65,11 @@ importers:
         specifier: '=2.4.13'
         version: 2.4.13
       '@marinade.finance/validator-bonds-cli-core':
-        specifier: 'workspace: ^2.1.3'
-        version: link:../validator-bonds-cli-core
+        specifier: ^2.1.3
+        version: 2.1.3(3lt6crth4yvdf5xqxedetox5pu)
       '@marinade.finance/validator-bonds-sdk':
-        specifier: 'workspace: ^2.1.3'
-        version: link:../validator-bonds-sdk
+        specifier: ^2.1.3
+        version: 2.1.3(d6ppddjmzb4tcnq5ipyyqxbd5u)
       '@marinade.finance/web3js-common':
         specifier: '=2.4.13'
         version: 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
@@ -129,8 +129,8 @@ importers:
         specifier: '=2.4.13'
         version: 2.4.13
       '@marinade.finance/validator-bonds-sdk':
-        specifier: 'workspace: ^2.1.3'
-        version: link:../validator-bonds-sdk
+        specifier: ^2.1.3
+        version: 2.1.3(ygjnhts5xqbscfmxt2b7atg4ga)
       '@marinade.finance/web3js-common':
         specifier: '=2.4.13'
         version: 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
@@ -180,11 +180,11 @@ importers:
         specifier: '=2.4.13'
         version: 2.4.13
       '@marinade.finance/validator-bonds-cli-core':
-        specifier: 'workspace: ^2.1.3'
-        version: link:../validator-bonds-cli-core
+        specifier: ^2.1.3
+        version: 2.1.3(3lt6crth4yvdf5xqxedetox5pu)
       '@marinade.finance/validator-bonds-sdk':
-        specifier: 'workspace: ^2.1.3'
-        version: link:../validator-bonds-sdk
+        specifier: ^2.1.3
+        version: 2.1.3(d6ppddjmzb4tcnq5ipyyqxbd5u)
       '@marinade.finance/web3js-common':
         specifier: '=2.4.13'
         version: 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
@@ -323,8 +323,8 @@ importers:
         specifier: '=2.4.13'
         version: 2.4.13
       '@marinade.finance/validator-bonds-sdk':
-        specifier: 'workspace: ^2.1.3'
-        version: link:../packages/validator-bonds-sdk
+        specifier: ^2.1.3
+        version: 2.1.3(d6ppddjmzb4tcnq5ipyyqxbd5u)
       '@marinade.finance/web3js-common':
         specifier: '=2.4.13'
         version: 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
@@ -805,6 +805,44 @@ packages:
       '@metaplex-foundation/umi': ^0.8.2
       '@metaplex-foundation/umi-bundle-defaults': ^0.8.2
       '@solana/web3.js': ^1.98.0
+
+  '@marinade.finance/validator-bonds-cli-core@2.1.3':
+    resolution: {integrity: sha512-EvMYS5BAcqZD7SZMdfaMiFaKrgxknu6RX9VkPIZEyZs5clDXPkyTIU6OkB8shTN1SAYsx5FTQr08bLYVY/e7fQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@coral-xyz/anchor': ^0.29.0
+      '@marinade.finance/anchor-common': '=2.4.13'
+      '@marinade.finance/cli-common': '=2.4.13'
+      '@marinade.finance/ledger-utils': ^3.0.1
+      '@marinade.finance/ts-common': '=2.4.13'
+      '@marinade.finance/validator-bonds-sdk': ^2.1.3
+      '@marinade.finance/web3js-common': '=2.4.13'
+      '@solana/web3.js': ^1.98.0
+      bn.js: ^5.2.1
+      bs58: ^6.0.0
+      commander: ^13.1.0
+      jsbi: ^4.3.0
+      pino: ^9.6.0
+      pino-pretty: ^13.0.0
+      solana-spl-token-modern: npm:@solana/spl-token@^0.3.11
+      yaml: ^2.4.5
+
+  '@marinade.finance/validator-bonds-sdk@2.1.3':
+    resolution: {integrity: sha512-M2zpf+eeeuMkxuE0ZdzaZTg4UjSkWg3FjV7PhemDCMuPijzeDFWQja0oCewpLCJBxIh9Rrtj7bLMrnuZlYasUQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@coral-xyz/anchor': ^0.29.0
+      '@marinade.finance/jest-utils': '=2.4.13'
+      '@marinade.finance/marinade-ts-sdk': ^5.0.10
+      '@marinade.finance/ts-common': '=2.4.13'
+      '@marinade.finance/web3js-common': '=2.4.13'
+      '@solana/web3.js': ^1.98.0
+      bn.js: ^5.2.1
+      borsh: ^0.7.0
+      bs58: ^6.0.0
+      crypto-js: ^4.2.0
+      jsbi: ^4.3.0
+      solana-spl-token-modern: npm:@solana/spl-token@^0.3.11
 
   '@marinade.finance/web3js-common@2.4.13':
     resolution: {integrity: sha512-WT8qRH2ztGRYzJ6ydztcJcUtSMiAfEAXoYGeTyzmHL/oSPDevZ/4X+YS2VjR3kSG4DVALvsf61GDff9BR09dpw==}
@@ -3962,6 +4000,55 @@ snapshots:
       '@metaplex-foundation/umi': 0.8.10
       '@metaplex-foundation/umi-bundle-defaults': 0.8.10(@metaplex-foundation/umi@0.8.10)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+
+  '@marinade.finance/validator-bonds-cli-core@2.1.3(3lt6crth4yvdf5xqxedetox5pu)':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@marinade.finance/anchor-common': 2.4.13(@anza-xyz/solana-rpc-get-stake-activation@1.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@marinade.finance/ts-common@2.4.13)(@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)
+      '@marinade.finance/cli-common': 2.4.13(@marinade.finance/ledger-utils@3.0.1(@ledgerhq/errors@6.16.2)(@ledgerhq/hw-app-solana@7.1.4)(@ledgerhq/hw-transport-node-hid-noevents@6.29.4)(@marinade.finance/ts-common@2.4.13)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@marinade.finance/ts-common@2.4.13)(@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(pino@9.6.0)(yaml@2.4.5)
+      '@marinade.finance/ledger-utils': 3.0.1(@ledgerhq/errors@6.16.2)(@ledgerhq/hw-app-solana@7.1.4)(@ledgerhq/hw-transport-node-hid-noevents@6.29.4)(@marinade.finance/ts-common@2.4.13)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@marinade.finance/ts-common': 2.4.13
+      '@marinade.finance/validator-bonds-sdk': 2.1.3(d6ppddjmzb4tcnq5ipyyqxbd5u)
+      '@marinade.finance/web3js-common': 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
+      '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      bn.js: 5.2.1
+      bs58: 6.0.0
+      commander: 13.1.0
+      jsbi: 4.3.0
+      pino: 9.6.0
+      pino-pretty: 13.0.0
+      solana-spl-token-modern: '@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)'
+      yaml: 2.4.5
+
+  '@marinade.finance/validator-bonds-sdk@2.1.3(d6ppddjmzb4tcnq5ipyyqxbd5u)':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@marinade.finance/jest-utils': 2.4.13(@jest/globals@29.7.0)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(jest-shell-matchers@1.0.2(jest@29.7.0(@types/node@22.10.7)(ts-node@10.9.2(@types/node@22.10.7)(typescript@5.4.5))))
+      '@marinade.finance/marinade-ts-sdk': 5.0.10(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10)
+      '@marinade.finance/ts-common': 2.4.13
+      '@marinade.finance/web3js-common': 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
+      '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      bn.js: 5.2.1
+      borsh: 0.7.0
+      bs58: 6.0.0
+      crypto-js: 4.2.0
+      jsbi: 4.3.0
+      solana-spl-token-modern: '@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)'
+
+  '@marinade.finance/validator-bonds-sdk@2.1.3(ygjnhts5xqbscfmxt2b7atg4ga)':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@marinade.finance/jest-utils': 2.4.12(@jest/globals@29.7.0)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(jest-shell-matchers@1.0.2(jest@29.7.0(@types/node@22.10.7)(ts-node@10.9.2(@types/node@22.10.7)(typescript@5.4.5))))
+      '@marinade.finance/marinade-ts-sdk': 5.0.10(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10)
+      '@marinade.finance/ts-common': 2.4.13
+      '@marinade.finance/web3js-common': 2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
+      '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      bn.js: 5.2.1
+      borsh: 0.7.0
+      bs58: 6.0.0
+      crypto-js: 4.2.0
+      jsbi: 4.3.0
+      solana-spl-token-modern: '@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)'
 
   '@marinade.finance/web3js-common@2.4.13(@marinade.finance/ts-common@2.4.13)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)':
     dependencies:

--- a/settlement-pipelines/package.json
+++ b/settlement-pipelines/package.json
@@ -17,7 +17,7 @@
     "author": "Marinade.Finance",
     "license": "ISC",
     "devDependencies": {
-      "@marinade.finance/validator-bonds-sdk": "workspace: ^2.1.3",
+      "@marinade.finance/validator-bonds-sdk": "^2.1.3",
       "@coral-xyz/anchor": "^0.29.0",
       "@solana/web3.js": "^1.98.0",
       "@marinade.finance/ledger-utils": "^3.0.1",

--- a/settlement-pipelines/package.json
+++ b/settlement-pipelines/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@marinade.finance/settlement-pipelines",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "description": "Tests for settlement pipelines CLI",
     "repository": {
       "type": "git",
@@ -17,7 +17,7 @@
     "author": "Marinade.Finance",
     "license": "ISC",
     "devDependencies": {
-      "@marinade.finance/validator-bonds-sdk": "^2.1.2",
+      "@marinade.finance/validator-bonds-sdk": "workspace: ^2.1.3",
       "@coral-xyz/anchor": "^0.29.0",
       "@solana/web3.js": "^1.98.0",
       "@marinade.finance/ledger-utils": "^3.0.1",


### PR DESCRIPTION
Implementing MIP.10 proposal

* https://forum.marinade.finance/t/mip-10-simplification-of-sams-delegation-strategy/1713
* https://app.realms.today/dao/MNDE/proposal/E5HsJzBZhniUfoRrT7aV1gAJ2VXqFQqvwWp8AcgSco9i

Removal of max stake wanted from the CLI (configure, show, readme)

Notes:
* The existence of the commented-out text for the CLI arguments is intentional. The contract still supports this configuration option and maybe later it can be added back. While it seems wrong from a review perspective I'm not such strong in this opinion.
* the dependencies update works for the local development. For publishing there needs to be added a new commit without `workspace:`.