### PR TITLE
[pipeline] close settlement pipeline checks for delegated stake

### DIFF
--- a/settlement-pipelines/src/settlements.rs
+++ b/settlement-pipelines/src/settlements.rs
@@ -225,8 +225,9 @@ pub async fn obtain_settlement_closing_refunds(
             } else {
                 split_rent_refund_accounts?
             };
-            let split_rent_refund_account = if let Some(first_account) =
-                split_rent_refund_accounts.first()
+            let split_rent_refund_account = if let Some(first_account) = split_rent_refund_accounts
+                .iter()
+                .find(|collected_stake| collected_stake.2.delegation().is_some())
             {
                 first_account.0
             } else {


### PR DESCRIPTION
There was an error when closing the settlement in the buildkite pipeline script. The contract expects to work with stake that is delegated but the pipeline was missing to filter that type of account.

[1] https://github.com/marinade-finance/validator-bonds/blob/main/programs/validator-bonds/src/instructions/settlement/close_settlement.rs