### PR TITLE
[todo] removal of two outdated TODOs

### DIFF
--- a/settlement-config.yaml
+++ b/settlement-config.yaml
@@ -1,4 +1,3 @@
-# TODO: review requires to confirm the correctness of the values
 ---
 - DowntimeRevenueImpactSettlement:
     meta:

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -674,7 +674,7 @@ async fn fund_settlements(
         transaction_executor.clone(),
         &mut transaction_builder,
         priority_fee_policy,
-        true, // TODO: set false when contract 2.1.0 is deployed (https://github.com/marinade-finance/validator-bonds/pull/77)
+        false,
     )
     .await;
     reporting.add_tx_execution_result(execute_result_funding, "FundSettlements");


### PR DESCRIPTION
There are two TODO items in validator bonds code base that I believe are not up-to-date anymore.
For the second one in the code, it is needed to be checked if all work after merging in the pipeline.