### PR TITLE
[contract] update epoch info on funding settlements

### DIFF
--- a/packages/validator-bonds-sdk/generated/validator_bonds.ts
+++ b/packages/validator-bonds-sdk/generated/validator_bonds.ts
@@ -3722,6 +3722,11 @@ export type ValidatorBonds = {
           "name": "index",
           "type": "u64",
           "index": false
+        },
+        {
+          "name": "settlementEpoch",
+          "type": "u64",
+          "index": false
         }
       ]
     },
@@ -3861,6 +3866,11 @@ export type ValidatorBonds = {
           "name": "currentEpoch",
           "type": "u64",
           "index": false
+        },
+        {
+          "name": "settlementEpoch",
+          "type": "u64",
+          "index": false
         }
       ]
     },
@@ -3935,6 +3945,11 @@ export type ValidatorBonds = {
           "name": "authority",
           "type": "publicKey",
           "index": false
+        },
+        {
+          "name": "settlementEpoch",
+          "type": "u64",
+          "index": false
         }
       ]
     },
@@ -3994,6 +4009,11 @@ export type ValidatorBonds = {
         },
         {
           "name": "splitRentAmount",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "settlementEpoch",
           "type": "u64",
           "index": false
         }
@@ -8364,6 +8384,11 @@ export const IDL: ValidatorBonds = {
           "name": "index",
           "type": "u64",
           "index": false
+        },
+        {
+          "name": "settlementEpoch",
+          "type": "u64",
+          "index": false
         }
       ]
     },
@@ -8503,6 +8528,11 @@ export const IDL: ValidatorBonds = {
           "name": "currentEpoch",
           "type": "u64",
           "index": false
+        },
+        {
+          "name": "settlementEpoch",
+          "type": "u64",
+          "index": false
         }
       ]
     },
@@ -8577,6 +8607,11 @@ export const IDL: ValidatorBonds = {
           "name": "authority",
           "type": "publicKey",
           "index": false
+        },
+        {
+          "name": "settlementEpoch",
+          "type": "u64",
+          "index": false
         }
       ]
     },
@@ -8636,6 +8671,11 @@ export const IDL: ValidatorBonds = {
         },
         {
           "name": "splitRentAmount",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "settlementEpoch",
           "type": "u64",
           "index": false
         }

--- a/programs/validator-bonds/src/events/settlement.rs
+++ b/programs/validator-bonds/src/events/settlement.rs
@@ -31,6 +31,7 @@ pub struct CloseSettlementEvent {
     pub rent_collector: Pubkey,
     pub expiration_epoch: u64,
     pub current_epoch: u64,
+    pub settlement_epoch: u64,
 }
 
 #[event]
@@ -47,6 +48,7 @@ pub struct CancelSettlementEvent {
     pub split_rent_refund: Option<Pubkey>,
     pub rent_collector: Pubkey,
     pub authority: Pubkey,
+    pub settlement_epoch: u64,
 }
 
 #[event]
@@ -61,4 +63,5 @@ pub struct FundSettlementEvent {
     pub split_stake_account: Option<SplitStakeData>,
     pub split_rent_collector: Option<Pubkey>,
     pub split_rent_amount: u64,
+    pub settlement_epoch: u64,
 }

--- a/programs/validator-bonds/src/events/settlement_claim.rs
+++ b/programs/validator-bonds/src/events/settlement_claim.rs
@@ -11,4 +11,5 @@ pub struct ClaimSettlementV2Event {
     pub stake_account_staker: Pubkey,
     pub amount: u64,
     pub index: u64,
+    pub settlement_epoch: u64,
 }

--- a/programs/validator-bonds/src/instructions/bond/fund_bond.rs
+++ b/programs/validator-bonds/src/instructions/bond/fund_bond.rs
@@ -124,6 +124,11 @@ impl<'info> FundBond<'info> {
             None,
         )?;
 
+        msg!(
+            "Funded {} lamports to bond {}",
+            ctx.accounts.stake_account.get_lamports(),
+            ctx.accounts.bond.key()
+        );
         emit_cpi!(FundBondEvent {
             bond: ctx.accounts.bond.key(),
             vote_account: ctx.accounts.bond.vote_account.key(),

--- a/programs/validator-bonds/src/instructions/settlement/cancel_settlement.rs
+++ b/programs/validator-bonds/src/instructions/settlement/cancel_settlement.rs
@@ -117,6 +117,7 @@ impl<'info> CancelSettlement<'info> {
         emit_cpi!(CancelSettlementEvent {
             bond: ctx.accounts.settlement.bond.key(),
             settlement: ctx.accounts.settlement.key(),
+            settlement_epoch: ctx.accounts.settlement.epoch_created_for,
             merkle_root: ctx.accounts.settlement.merkle_root,
             max_total_claim: ctx.accounts.settlement.max_total_claim,
             max_merkle_nodes: ctx.accounts.settlement.max_merkle_nodes,

--- a/programs/validator-bonds/src/instructions/settlement/claim_settlement.rs
+++ b/programs/validator-bonds/src/instructions/settlement/claim_settlement.rs
@@ -269,6 +269,7 @@ impl<'info> ClaimSettlementV2<'info> {
 
         emit_cpi!(ClaimSettlementV2Event {
             settlement: ctx.accounts.settlement.key(),
+            settlement_epoch: ctx.accounts.settlement.epoch_created_for,
             stake_account_to: ctx.accounts.stake_account_to.key(),
             settlement_lamports_claimed: U64ValueChange {
                 old: ctx.accounts.settlement.lamports_claimed - claim,

--- a/programs/validator-bonds/src/instructions/settlement/close_settlement.rs
+++ b/programs/validator-bonds/src/instructions/settlement/close_settlement.rs
@@ -114,6 +114,7 @@ impl<'info> CloseSettlementV2<'info> {
         emit_cpi!(CloseSettlementEvent {
             bond: ctx.accounts.settlement.bond.key(),
             settlement: ctx.accounts.settlement.key(),
+            settlement_epoch: ctx.accounts.settlement.epoch_created_for,
             merkle_root: ctx.accounts.settlement.merkle_root,
             max_total_claim: ctx.accounts.settlement.max_total_claim,
             max_merkle_nodes: ctx.accounts.settlement.max_merkle_nodes,

--- a/programs/validator-bonds/src/instructions/settlement/fund_settlement.rs
+++ b/programs/validator-bonds/src/instructions/settlement/fund_settlement.rs
@@ -398,9 +398,16 @@ impl<'info> FundSettlement<'info> {
 
         ctx.accounts.settlement.lamports_funded += funding_amount;
 
+        msg!(
+            "Funded {} lamports to settlement {} of epoch {}",
+            funding_amount,
+            ctx.accounts.settlement.key(),
+            ctx.accounts.settlement.epoch_created_for
+        );
         emit_cpi!(FundSettlementEvent {
             bond: ctx.accounts.bond.key(),
             settlement: ctx.accounts.settlement.key(),
+            settlement_epoch: ctx.accounts.settlement.epoch_created_for,
             funding_amount,
             stake_account: ctx.accounts.stake_account.key(),
             lamports_funded: ctx.accounts.settlement.lamports_funded,


### PR DESCRIPTION
When an upgrade of the contract is considered, more information on funding settlements should be added on-chain to make it easier to investigate funding events (as asked by various validators).

Providing information on what epoch the event belongs to may help.

This is a kick-off of such change. Needed to:

- update `resources/idl`
- verify tests and fix that
- check the TS SDK not having issue with the change