### PR TITLE
[settlement-pipelines][GEN-1260] claim for institutional with different priority

### DIFF
--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -187,10 +187,10 @@ fn get_claiming_priority_key(
             StakeAccountStateType::DelegatedAndDeactivated => {
                 ClaimingPriorityKey::full(0, lamports)
             }
+            StakeAccountStateType::Initialized => ClaimingPriorityKey::full(1, lamports),
             StakeAccountStateType::DelegatedAndDeactivating => {
-                ClaimingPriorityKey::full(1, lamports)
+                ClaimingPriorityKey::full(2, lamports)
             }
-            StakeAccountStateType::Initialized => ClaimingPriorityKey::full(2, lamports),
             StakeAccountStateType::DelegatedAndActive => ClaimingPriorityKey::full(3, lamports),
             StakeAccountStateType::DelegatedAndActivating => ClaimingPriorityKey::full(4, lamports),
             StakeAccountStateType::NonAuthorized => ClaimingPriorityKey::full(255, lamports),


### PR DESCRIPTION
Changing the claiming order of stake accounts for institutional staking.

I was considering to proceed with some CLI argument but then ended with using the same strategy as for liquid staking. Let's see if it is considered feasible.