### PR TITLE
[buildkite] fix for verify settlement to pass [GEN-1335]

### DIFF
--- a/.buildkite/collect-bonds.yml
+++ b/.buildkite/collect-bonds.yml
@@ -39,8 +39,8 @@ steps:
     - buildkite-agent artifact download --include-retried-jobs target/release/bonds-collector .
     - chmod +x target/release/bonds-collector
     - |
-      ./target/release/bonds-collector --bond-type $$bond_type \
-        collect-bonds -u "$$RPC_URL" > bonds.yaml
+      ./target/release/bonds-collector collect-bonds \
+        --bond-type $$bond_type -u "$$RPC_URL" > bonds.yaml
     artifact_paths:
       - bonds.yaml
 

--- a/.buildkite/verify-settlements.yml
+++ b/.buildkite/verify-settlements.yml
@@ -138,7 +138,7 @@ steps:
      - |
        ATTEMPT_COUNT=$(grep -c ATTEMPT "$$report_path" | sed 's/.*ATTEMPT //g')
        buildkite-agent meta-data set --redacted-vars='' attempts_count "$${ATTEMPT_COUNT:-0}"
-     - 'cat "$$report_path" | grep -v "ATTEMPT" > ./verify-report.json'
+     - cat "$$report_path" | grep -v "ATTEMPT" > ./verify-report.json
     artifact_paths:
     - "./verify-report.json"
     key: 'notification'
@@ -152,15 +152,9 @@ steps:
     - buildkite-agent artifact download --include-retried-jobs verify-report.json .
     - source ./scripts/execute-handlers.sh
     - check_command_execution_status "verify-settlement" || true
-    - |
-      if [[ -z "$$build_result" || "$$build_result" =~ "failed" ]]; then
-        echo "Failure at process of settlements verification"
-        cat ./verify-report.json
-        exit 42
-      fi
-    - echo "--- Verify report: ---"
     - cat ./verify-report.json
-    - echo "--- End of Verify report ---"
+    - echo "--------------------------------------------"
+    - slack_feed=$(buildkite-agent meta-data get slack_feed)
     - |
       number_unknown_settlements=$(jq '. | length' ./verify-report.json)
       if [ $$number_unknown_settlements -gt 0 ]; then


### PR DESCRIPTION
I found a couple of issues around buildkite pipelines (e.g. verify settlement check is handled by `check_command_execution_status`, not by a special if clause)