### PR TITLE
[pipelines] empty redacted vars at all places

### DIFF
--- a/.buildkite/claim-settlements.yml
+++ b/.buildkite/claim-settlements.yml
@@ -38,12 +38,12 @@ steps:
     commands:
       - |
         claim_type=${CLAIM_TYPE:-$(buildkite-agent meta-data get claim_type)}
-        buildkite-agent meta-data set claim_type "$$claim_type"
+        buildkite-agent meta-data set --redacted-vars='' claim_type "$$claim_type"
         config_pubkey=$(./scripts/bonds-config-pubkey.sh "$$claim_type")
-        buildkite-agent meta-data set config_pubkey "$$config_pubkey"
+        buildkite-agent meta-data set --redacted-vars='' config_pubkey "$$config_pubkey"
       - |
         slack_feed=$(./scripts/bonds-slack-feed.sh "$$claim_type")
-        buildkite-agent meta-data set slack_feed "$$slack_feed"
+        buildkite-agent meta-data set --redacted-vars='' slack_feed "$$slack_feed"
       - |
         echo "Claim Type: '$$claim_type'/'$$config_pubkey', Slack feed: '$$slack_feed'"
 
@@ -58,7 +58,7 @@ steps:
     - config_pubkey=$(buildkite-agent meta-data get config_pubkey)
     - chmod +x target/release/list-claimable-epoch
     - possible_epochs_json=$(./target/release/list-claimable-epoch --rpc-url $$RPC_URL --config "$$config_pubkey")
-    - buildkite-agent meta-data set --redacted-vars="" possible_epochs_json "$$possible_epochs_json"
+    - buildkite-agent meta-data set --redacted-vars='' possible_epochs_json "$$possible_epochs_json"
 
   - wait: ~
 

--- a/.buildkite/close-settlements.yml
+++ b/.buildkite/close-settlements.yml
@@ -38,12 +38,12 @@ steps:
     commands:
     - |
       claim_type=${CLAIM_TYPE:-$(buildkite-agent meta-data get claim_type)}
-      buildkite-agent meta-data set claim_type "$$claim_type"
+      buildkite-agent meta-data set --redacted-vars='' claim_type "$$claim_type"
       config_pubkey=$(./scripts/bonds-config-pubkey.sh "$$claim_type")
-      buildkite-agent meta-data set config_pubkey "$$config_pubkey"
+      buildkite-agent meta-data set --redacted-vars='' config_pubkey "$$config_pubkey"
     - |
       slack_feed=$(./scripts/bonds-slack-feed.sh "$$claim_type")
-      buildkite-agent meta-data set slack_feed "$$slack_feed"
+      buildkite-agent meta-data set --redacted-vars='' slack_feed "$$slack_feed"
     - |
       echo "Claim Type: '$$claim_type'/'$$config_pubkey'"
 

--- a/.buildkite/fund-settlements.yml
+++ b/.buildkite/fund-settlements.yml
@@ -40,10 +40,10 @@ steps:
       claim_type=${CLAIM_TYPE:-$(buildkite-agent meta-data get claim_type)}
       buildkite-agent meta-data set --redacted-vars='' claim_type "$$claim_type"
       config_pubkey=$(./scripts/bonds-config-pubkey.sh "$$claim_type")
-      buildkite-agent meta-data set config_pubkey "$$config_pubkey"
+      buildkite-agent meta-data set --redacted-vars='' config_pubkey "$$config_pubkey"
     - |
       slack_feed=$(./scripts/bonds-slack-feed.sh "$$claim_type")
-      buildkite-agent meta-data set slack_feed "$$slack_feed"
+      buildkite-agent meta-data set --redacted-vars='' slack_feed "$$slack_feed"
     - |
       echo "Epoch: '$$epoch', Claim Type: '$$claim_type'/'$$config_pubkey', Slack Feed: '$$slack_feed'"
 

--- a/.buildkite/init-settlements.yml
+++ b/.buildkite/init-settlements.yml
@@ -39,10 +39,10 @@ steps:
       claim_type=${CLAIM_TYPE:-$(buildkite-agent meta-data get claim_type)}
       buildkite-agent meta-data set --redacted-vars='' claim_type "$$claim_type"
       config_pubkey=$(./scripts/bonds-config-pubkey.sh "$$claim_type")
-      buildkite-agent meta-data set config_pubkey "$$config_pubkey"
+      buildkite-agent meta-data set --redacted-vars='' config_pubkey "$$config_pubkey"
     - |
       slack_feed=$(./scripts/bonds-slack-feed.sh "$$claim_type")
-      buildkite-agent meta-data set slack_feed "$$slack_feed"
+      buildkite-agent meta-data set --redacted-vars='' slack_feed "$$slack_feed"
     - |
       echo "Epoch: '$$epoch', Claim Type: '$$claim_type'/'$$config_pubkey', Slack Feed: '$$slack_feed'"
 

--- a/.buildkite/verify-settlements.yml
+++ b/.buildkite/verify-settlements.yml
@@ -49,12 +49,12 @@ steps:
     commands:
     - |
       claim_type=${CLAIM_TYPE:-$(buildkite-agent meta-data get claim_type)}
-      buildkite-agent meta-data set claim_type "$$claim_type"
+      buildkite-agent meta-data set --redacted-vars='' claim_type "$$claim_type"
       config_pubkey=$(./scripts/bonds-config-pubkey.sh "$$claim_type")
-      buildkite-agent meta-data set config_pubkey "$$config_pubkey"
+      buildkite-agent meta-data set --redacted-vars='' config_pubkey "$$config_pubkey"
     - |
       slack_feed=$(./scripts/bonds-slack-feed.sh "$$claim_type")
-      buildkite-agent meta-data set slack_feed "$$slack_feed"
+      buildkite-agent meta-data set --redacted-vars='' slack_feed "$$slack_feed"
     - |
       echo "Claim Type: '$$claim_type'/'$$config_pubkey', Slack Feed: '$$slack_feed'"
 


### PR DESCRIPTION
I need to disable redacted vars handling in other places for bonds as well. They cause the pipeline to fail which is more than annoying.