### PR TITLE
[pipeline] fund settlement to work with claim type [GEN-4691]

### DIFF
--- a/.buildkite/fund-settlements.yml
+++ b/.buildkite/fund-settlements.yml
@@ -80,17 +80,15 @@ steps:
         echo "Merkle trees already downloaded"
         exit 0
       fi
-    - |
-      claim_type=$(buildkite-agent meta-data get claim_type)
-      claim_type_prefix="$${claim_type%%-*}"
-    - 'mkdir ./merkle-trees/'
+    - claim_type=$(buildkite-agent meta-data get claim_type)
+    - mkdir ./merkle-trees/
     - |
       for epoch in $(seq $$epochs_start_index $$current_epoch); do
         if [[ $$epoch -lt $$starting_epoch_contract_v2 ]]; then
           echo "Skipping epoch $$epoch, because it's before the contract v2 deployment epoch $$starting_epoch_contract_v2"
           continue
         fi
-        for merkle_tree_file in $(gcloud storage ls "$gs_bucket/$$epoch/$${claim_type_prefix}*settlement-merkle-trees.json"); do
+        for merkle_tree_file in $(gcloud storage ls "$gs_bucket/$$epoch/$${claim_type}*settlement-merkle-trees.json"); do
           base_name=$(basename "$$merkle_tree_file")
           prefix_name="$${base_name%settlement-merkle-trees.json}"
           target_dir="./merkle-trees/$${epoch}_$${prefix_name%-*}/"


### PR DESCRIPTION
With changes #189 it slipped through a change that the fund settlement worked with a prefix and not a claim type.
That causes that on init settlement the fund may fail. The issue is that init settlement works separately for bids and psr.
When psr runs first then it tries to fund bids and psr together - but on running psr, the bids settlement is not ready yet - and the pipeline fails.
When the fund filters on whole claim_type - `bid-psr-distribution` or `bid-distribution` it will be trying to fund only the particular type that should be just initialized on-chain.