### PR TITLE
[pipeline] not using rpc url as parameter

### DIFF
--- a/.buildkite/claim-settlements.yml
+++ b/.buildkite/claim-settlements.yml
@@ -51,13 +51,14 @@ steps:
 
   - label: ":campfire: List claimable epochs"
     env:
+      RPC_URL: "$$RPC_URL"
       RUST_LOG: info,solana_transaction_builder_executor=debug,solana_transaction_builder=debug,builder_executor=debug,solana_transaction_executor=debug,settlement_pipelines=debug,list_claimable_epoch=debug
     commands:
     - . "$HOME/.cargo/env"
     - buildkite-agent artifact download --include-retried-jobs target/release/list-claimable-epoch .
     - config_pubkey=$(buildkite-agent meta-data get config_pubkey)
     - chmod +x target/release/list-claimable-epoch
-    - possible_epochs_json=$(./target/release/list-claimable-epoch --rpc-url $$RPC_URL --config "$$config_pubkey")
+    - possible_epochs_json=$(./target/release/list-claimable-epoch --config "$$config_pubkey")
     - buildkite-agent meta-data set --redacted-vars='' possible_epochs_json "$$possible_epochs_json"
 
   - wait: ~
@@ -113,6 +114,7 @@ steps:
 
   - label: ":campfire::arrow_right: Claim settlements"
     env:
+      RPC_URL: "$$RPC_URL"
       RUST_LOG: info,solana_transaction_builder_executor=debug,solana_transaction_builder=debug,builder_executor=debug,solana_transaction_executor=debug,settlement_pipelines=debug,claim_settlement=debug
       # RUST_BACKTRACE: full
     commands:
@@ -149,7 +151,6 @@ steps:
       handle_command_execution "claim-settlement" \
       ./target/release/claim-settlement \
         --config $(buildkite-agent meta-data get config_pubkey) \
-        --rpc-url $$RPC_URL \
         --operator-authority "$$VALIDATOR_BONDS_OPERATOR_AUTHORITY" \
         --fee-payer "$$PSR_TX_FEE_WALLET" \
         $$files

--- a/.buildkite/close-settlements.yml
+++ b/.buildkite/close-settlements.yml
@@ -91,6 +91,7 @@ steps:
 
   - label: ":campfire: List past settlements"
     env:
+      RPC_URL: "$$RPC_URL"
       RUST_LOG: info,solana_transaction_builder_executor=debug,solana_transaction_builder=debug,solana_transaction_executor=debug,list_settlement=debug
     commands:
     - . "$HOME/.cargo/env"
@@ -99,7 +100,6 @@ steps:
     - chmod +x target/release/list-settlement
     - |
       ./target/release/list-settlement \
-        -u $$RPC_URL \
         -m ./merkle-trees/* \
         --config $(buildkite-agent meta-data get config_pubkey) \
         --out ./past-settlements.json
@@ -110,6 +110,7 @@ steps:
 
   - label: ":campfire::arrow_right: Close settlements"
     env:
+      RPC_URL: "$$RPC_URL"
       RUST_LOG: info,solana_transaction_builder_executor=debug,solana_transaction_builder=debug,solana_transaction_executor=debug,close_settlement=debug
       # RUST_BACKTRACE: full
     commands:
@@ -129,7 +130,6 @@ steps:
       handle_command_execution "close-settlement" \
       ./target/release/close-settlement \
         --config $(buildkite-agent meta-data get config_pubkey) \
-        --rpc-url $$RPC_URL \
         --operator-authority "$$VALIDATOR_BONDS_OPERATOR_AUTHORITY" \
         --fee-payer "$$PSR_TX_FEE_WALLET" \
         --marinade-wallet "$$PSR_MARINADE_DAO_FUNDER_WALLET" \

--- a/.buildkite/collect-bonds.yml
+++ b/.buildkite/collect-bonds.yml
@@ -32,6 +32,8 @@ steps:
   - wait: ~
 
   - label: ":microscope: Collect Bonds"
+    env:
+      RPC_URL: "$$RPC_URL"
     commands:
     - |
       claim_type=${CLAIM_TYPE:-$(buildkite-agent meta-data get claim_type)}
@@ -40,7 +42,7 @@ steps:
     - chmod +x target/release/bonds-collector
     - |
       ./target/release/bonds-collector collect-bonds \
-        --bond-type $$bond_type -u "$$RPC_URL" > bonds.yaml
+        --bond-type $$bond_type > bonds.yaml
     artifact_paths:
       - bonds.yaml
 

--- a/.buildkite/fund-settlements.yml
+++ b/.buildkite/fund-settlements.yml
@@ -104,6 +104,7 @@ steps:
 
   - label: ":campfire::arrow_right: Fund settlements"
     env:
+      RPC_URL: "$$RPC_URL"
       RUST_LOG: info,solana_transaction_builder_executor=debug,solana_transaction_builder=debug,solana_transaction_executor=debug,fund_settlement=debug
     commands:
     - . "$HOME/.cargo/env"
@@ -133,7 +134,6 @@ steps:
       handle_command_execution "$$command_name" \
       ./target/release/fund-settlement \
         --config $(buildkite-agent meta-data get config_pubkey) \
-        --rpc-url "$$RPC_URL" \
         --operator-authority "$$VALIDATOR_BONDS_OPERATOR_AUTHORITY" \
         --fee-payer "$$PSR_TX_FEE_WALLET" \
         --marinade-wallet "$$PSR_MARINADE_DAO_FUNDER_WALLET" \

--- a/.buildkite/init-settlements.yml
+++ b/.buildkite/init-settlements.yml
@@ -115,6 +115,7 @@ steps:
 
   - label: ":campfire::arrow_right: Create settlements"
     env:
+      RPC_URL: "$$RPC_URL"
       RUST_LOG: info,solana_transaction_builder_executor=debug,solana_transaction_builder=debug,builder_executor=debug,solana_transaction_executor=debug,settlement_pipelines=debug,init_settlement=debug
       #  RUST_BACKTRACE: full
     commands:
@@ -136,7 +137,6 @@ steps:
       handle_command_execution "$$command_name" \
       ./target/release/init-settlement \
         --config $(buildkite-agent meta-data get config_pubkey) \
-        --rpc-url $$RPC_URL \
         --input-merkle-tree-collection "./settlement-merkle-trees.json" \
         --input-settlement-collection "./settlements.json" \
         --operator-authority "$$VALIDATOR_BONDS_OPERATOR_AUTHORITY" \

--- a/.buildkite/verify-settlements.yml
+++ b/.buildkite/verify-settlements.yml
@@ -86,6 +86,7 @@ steps:
 
   - label: ":campfire: List past settlements"
     env:
+      RPC_URL: "$$RPC_URL"
       RUST_LOG: info,solana_transaction_builder_executor=debug,solana_transaction_builder=debug,solana_transaction_executor=debug,list_settlement=debug
     commands:
     - . "$HOME/.cargo/env"
@@ -94,7 +95,6 @@ steps:
     - chmod +x target/release/list-settlement
     - |
       ./target/release/list-settlement \
-        -u $$RPC_URL \
         -m ./merkle-trees/* \
         --config $(buildkite-agent meta-data get config_pubkey) \
         --out ./past-settlements.json
@@ -105,6 +105,7 @@ steps:
 
   - label: ":campfire::arrow_right: Verify settlements"
     env:
+      RPC_URL: "$$RPC_URL"
       RUST_LOG: info,solana_transaction_builder_executor=debug,solana_transaction_builder=debug,solana_transaction_executor=debug,verify_settlement=debug
     commands:
     - . "$HOME/.cargo/env"
@@ -119,7 +120,6 @@ steps:
       handle_command_execution "$$command_name" \
       ./target/release/verify-settlement \
         --config $(buildkite-agent meta-data get config_pubkey) \
-        --rpc-url $$RPC_URL \
         --past-settlements ./past-settlements.json
     key: 'verify-settlement'
     artifact_paths:

--- a/packages/validator-bonds-cli-core/src/commands/mainCommand.ts
+++ b/packages/validator-bonds-cli-core/src/commands/mainCommand.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-process-exit */
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import {
   configureLogger,
   parseWalletFromOpts,
@@ -32,11 +32,14 @@ export function launchCliProgram({
     .version(version)
     .allowExcessArguments(false)
     .configureHelp({ showGlobalOptions: true })
-    .option(
-      '-u, --url <rpc-url>',
-      'solana RPC URL or a moniker ' +
-        '(m/mainnet/mainnet-beta, d/devnet, t/testnet, l/localhost), see https://solana.com/rpc',
-      'mainnet',
+    .addOption(
+      new Option(
+        '-u, --url <rpc-url>',
+        'solana RPC URL or a moniker ' +
+          '(m/mainnet/mainnet-beta, d/devnet, t/testnet, l/localhost), see https://solana.com/rpc',
+      )
+        .default('mainnet')
+        .env('RPC_URL'),
     )
     .option('-c, --cluster <cluster>', 'alias for "-u, --url"')
     .option(


### PR DESCRIPTION
A change to not work with parameters of RPC_URL as a CLI command line argument, as the RPC URL contains a secret token. Using env var to be passed into CLI (Rust provides this, for TS adding such an option)