### PR TITLE
No cpmpe in institutional cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## TS CLI&SDK [2.1.6](https://github.com/marinade-finance/validator-bonds/compare/v2.1.5...v2.1.6) (2025-04-25)
+
+### Fixes
+
+* cli: `--cpmpe` configuration for init and config of bond is relevant only for non-institutional CLI variant
+
 ## TS CLI&SDK [2.1.5](https://github.com/marinade-finance/validator-bonds/compare/v2.1.4...v2.1.5) (2025-03-11)
 
 ### Fixes

--- a/packages/validator-bonds-cli-core/package.json
+++ b/packages/validator-bonds-cli-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-core",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Common CLI Core of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-core/src/commands/manage/configureBond.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/configureBond.ts
@@ -17,7 +17,7 @@ import {
   configureBondWithMintInstruction,
 } from '@marinade.finance/validator-bonds-sdk'
 import { Wallet as WalletInterface } from '@marinade.finance/web3js-common'
-import { getBondFromAddress, toBN } from '../../utils'
+import { getBondFromAddress } from '../../utils'
 import {
   CONFIGURE_BOND_LIMIT_UNITS,
   CONFIGURE_BOND_MINT_LIMIT_UNITS,
@@ -51,11 +51,6 @@ export function configureConfigureBond(program: Command): Command {
       '--bond-authority <pubkey>',
       'New value of "bond authority" that is permitted to operate with the bond account.',
       parsePubkeyOrPubkeyFromWallet,
-    )
-    .option(
-      '--cpmpe <number>',
-      'New value of cost per mille per epoch, in lamports. The maximum amount of lamports the validator desires to pay for each 1000 delegated SOLs per epoch.',
-      value => toBN(value),
     )
   // MIP.10 removed maxStakeWanted from bidding auction, institutional staking does not support this option
   // .option(

--- a/packages/validator-bonds-cli-core/src/commands/manage/initBond.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/initBond.ts
@@ -19,7 +19,6 @@ import {
 } from '@marinade.finance/validator-bonds-sdk'
 import { Wallet as WalletInterface } from '@marinade.finance/web3js-common'
 import { PublicKey, Signer } from '@solana/web3.js'
-import { toBN } from '../../utils'
 import { INIT_BOND_LIMIT_UNITS } from '../../computeUnits'
 import BN from 'bn.js'
 import { Logger } from 'pino'
@@ -50,11 +49,6 @@ export function configureInitBond(program: Command): Command {
       '--rent-payer <keypair_or_ledger_or_pubkey>',
       'Rent payer for the account creation (default: wallet keypair)',
       parseWalletOrPubkey,
-    )
-    .option(
-      '--cpmpe <number>',
-      'Cost per mille per epoch, in lamports. The maximum amount of lamports the validator desires to pay for each 1000 delegated SOLs per epoch. (default: 0)',
-      value => toBN(value),
     )
   // MIP.10 removed maxStakeWanted from bidding auction, institutional staking does not support this option
   // .option(

--- a/packages/validator-bonds-cli-institutional/README.md
+++ b/packages/validator-bonds-cli-institutional/README.md
@@ -25,7 +25,7 @@ To get info on available commands
 ```sh
 # to verify installed version
 validator-bonds-institutional --version
-2.1.5
+2.1.6
 
 # get reference of available commands
 validator-bonds-institutional --help

--- a/packages/validator-bonds-cli-institutional/__tests__/test-validator/configureBondInstitutional.spec.ts
+++ b/packages/validator-bonds-cli-institutional/__tests__/test-validator/configureBondInstitutional.spec.ts
@@ -196,8 +196,6 @@ describe('Configure bond account using CLI (institutional)', () => {
           userPath,
           '--bond-authority',
           newBondAuthority.toBase58(),
-          '--cpmpe',
-          2,
           '--with-token',
           '--confirmation-finality',
           'confirmed',
@@ -212,6 +210,5 @@ describe('Configure bond account using CLI (institutional)', () => {
 
     const bondsData = await getBond(program, bondAccount)
     expect(bondsData.authority).toEqual(newBondAuthority)
-    expect(bondsData.cpmpe).toEqual(2)
   })
 })

--- a/packages/validator-bonds-cli-institutional/__tests__/test-validator/initBondInstitutional.spec.ts
+++ b/packages/validator-bonds-cli-institutional/__tests__/test-validator/initBondInstitutional.spec.ts
@@ -89,8 +89,6 @@ describe('CLI init bond account (institutional)', () => {
           bondAuthority.publicKey.toBase58(),
           '--rent-payer',
           rentPayerPath,
-          '--cpmpe',
-          33,
           '--confirmation-finality',
           'confirmed',
         ],
@@ -111,7 +109,6 @@ describe('CLI init bond account (institutional)', () => {
     expect(bondsData.config).toEqual(MARINADE_INSTITUTIONAL_CONFIG_ADDRESS)
     expect(bondsData.voteAccount).toEqual(voteAccount)
     expect(bondsData.authority).toEqual(bondAuthority.publicKey)
-    expect(bondsData.cpmpe).toEqual(33)
     expect(bondsData.bump).toEqual(bump)
     await expect(
       await provider.connection.getBalance(rentPayerKeypair.publicKey),

--- a/packages/validator-bonds-cli-institutional/package.json
+++ b/packages/validator-bonds-cli-institutional/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-institutional",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "CLI of the validator bonds contract streamlined for institutional users",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-institutional/src/index.ts
+++ b/packages/validator-bonds-cli-institutional/src/index.ts
@@ -8,7 +8,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli-institutional'
 
 launchCliProgram({
-  version: '2.1.5',
+  version: '2.1.6',
   installAdditionalOptions: program => {
     program.setOptionValueWithSource(
       'programId',

--- a/packages/validator-bonds-cli/README.md
+++ b/packages/validator-bonds-cli/README.md
@@ -23,7 +23,7 @@ added 165 packages in 35s
 
 # to verify installed version
 validator-bonds --version
-2.1.5
+2.1.6
 ```
 
 To get info on available commands
@@ -697,7 +697,7 @@ To check where NPM packages are and will be installed:
 # Get npm global installation folder
 npm list -g
 > /usr/lib
-> +-- @marinade.finance/validator-bonds-cli@2.1.5
+> +-- @marinade.finance/validator-bonds-cli@2.1.6
 > ...
 # In this case, the `bin` folder is located at /usr/bin
 ```
@@ -723,7 +723,7 @@ With this configuration, NPM packages will be installed under the `prefix` direc
 npm i -g @marinade.finance/validator-bonds-cli@latest
 npm list -g
 > ~/.local/share/npm/lib
-> `-- @marinade.finance/validator-bonds-cli@2.1.5
+> `-- @marinade.finance/validator-bonds-cli@2.1.6
 ```
 
 To execute the installed packages from any location,
@@ -882,7 +882,7 @@ Commands:
   # Get npm global installation folder
   npm list -g
   > ~/.local/share/npm/lib
-  > `-- @marinade.finance/validator-bonds-cli@2.1.5
+  > `-- @marinade.finance/validator-bonds-cli@2.1.6
   # In this case, the 'bin' folder is located at ~/.local/share/npm/bin
 
   # Get validator-bonds binary folder

--- a/packages/validator-bonds-cli/package.json
+++ b/packages/validator-bonds-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "CLI of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli/src/commands/manage/configureBond.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/configureBond.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander'
 import {
   configureConfigureBond,
   manageConfigureBond,
+  toBN,
 } from '@marinade.finance/validator-bonds-cli-core'
 import { MARINADE_CONFIG_ADDRESS } from '@marinade.finance/validator-bonds-sdk'
 import { Wallet as WalletInterface } from '@marinade.finance/web3js-common'
@@ -17,6 +18,11 @@ export function installConfigureBond(program: Command) {
         '(optional; to derive bond address from vote account address) ' +
         `(default: ${MARINADE_CONFIG_ADDRESS.toBase58()})`,
       parsePubkey,
+    )
+    .option(
+      '--cpmpe <number>',
+      'Cost per mille per epoch, in lamports. The maximum amount of lamports the validator desires to pay for each 1000 delegated SOLs per epoch. (default: 0)',
+      value => toBN(value),
     )
     .action(
       async (

--- a/packages/validator-bonds-cli/src/commands/manage/initBond.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/initBond.ts
@@ -1,6 +1,9 @@
 import { parsePubkey } from '@marinade.finance/cli-common'
 import { Command } from 'commander'
-import { manageInitBond } from '@marinade.finance/validator-bonds-cli-core'
+import {
+  manageInitBond,
+  toBN,
+} from '@marinade.finance/validator-bonds-cli-core'
 import { MARINADE_CONFIG_ADDRESS } from '@marinade.finance/validator-bonds-sdk'
 import { Wallet as WalletInterface } from '@marinade.finance/web3js-common'
 import { PublicKey } from '@solana/web3.js'
@@ -14,6 +17,11 @@ export function installInitBond(program: Command) {
       'The config account that the bond is created under. ' +
         `(default: ${MARINADE_CONFIG_ADDRESS.toBase58()})`,
       parsePubkey,
+    )
+    .option(
+      '--cpmpe <number>',
+      'New value of cost per mille per epoch, in lamports. The maximum amount of lamports the validator desires to pay for each 1000 delegated SOLs per epoch.',
+      value => toBN(value),
     )
     .action(
       async ({

--- a/packages/validator-bonds-cli/src/index.ts
+++ b/packages/validator-bonds-cli/src/index.ts
@@ -9,7 +9,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli'
 
 launchCliProgram({
-  version: '2.1.5',
+  version: '2.1.6',
   installAdditionalOptions: program => {
     program.option(
       '--program-id <pubkey>',

--- a/packages/validator-bonds-sdk/package.json
+++ b/packages/validator-bonds-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-sdk",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "SDK of the validator bonds contract",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The institutional CLI provides a way to configure `--cpmpe` that is relevant only for bidding and for institutional calculation.