### PR TITLE
Fix pipeline settlement test [GEN-4612]

### DIFF
--- a/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
+++ b/settlement-pipelines/__tests__/test-validator/pipelineSettlement.spec.ts
@@ -297,7 +297,7 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any
     ).toHaveMatchingSpawnOutput({
-      code: 2,
+      code: 99, // code 99 => Warning, test did not prepare all stake accounts
       stdout: /funded 1.10 settlements/,
       stderr: /no stake account available/,
     })
@@ -358,7 +358,7 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any
     ).toHaveMatchingSpawnOutput({
-      code: 2,
+      code: 99,
       stdout: /funded 0.10 settlements/,
       stderr: /no stake account available/,
     })
@@ -390,7 +390,7 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any
     ).toHaveMatchingSpawnOutput({
-      code: 2,
+      code: 99,
       stdout: /funded 0.10 settlements/,
       stderr: /no stake account available/,
     })
@@ -468,7 +468,7 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any
     ).toHaveMatchingSpawnOutput({
-      code: 2,
+      code: 99,
       stdout: /funded 9.10 settlements/,
       stderr:
         /will be funded with 2 stake accounts(.|\n|\r)*9 executed successfully/,
@@ -508,9 +508,10 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any
     ).toHaveMatchingSpawnOutput({
-      code: 0,
-      stdout: /funded 0.10 settlements/,
-      stderr: /already funded(.|\n|\r)*0 executed successfully/,
+      code: 99,
+      stdout: /ProtectedEvent: funded 0.10 settlements/,
+      stderr:
+        /already funded.*skipping funding(.|\n|\r)*ixes 0 executed successfully/,
     })
     previousTest = TestNames.InitSettlement
   })
@@ -603,7 +604,7 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any
     ).toHaveMatchingSpawnOutput({
-      code: 2,
+      code: 99,
       stderr: /All stake accounts are locked for claiming/,
       stdout: /claimed 1[1-2][0-9][0-9][0-9].[0-9]+ merkle nodes/,
     })
@@ -634,7 +635,7 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any
     ).toHaveMatchingSpawnOutput({
-      code: 0,
+      code: 99,
       stdout: /funded 0.10 settlements/,
       stderr: /already funded(.|\n|\r)*0 executed successfully/,
     })
@@ -662,7 +663,7 @@ describe.skip('Cargo CLI: Pipeline Settlement', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any
     ).toHaveMatchingSpawnOutput({
-      code: 2,
+      code: 99,
       stderr: /already claimed merkle tree nodes 414/,
       stdout:
         /claimed 0.[0-9]+ merkle nodes(.|\n|\r)*No stake account found with enough SOLs to claim/,

--- a/settlement-pipelines/src/json_data.rs
+++ b/settlement-pipelines/src/json_data.rs
@@ -1,7 +1,7 @@
 use crate::cli_result::CliError;
 use crate::settlement_data::{parse_settlements_from_json, SettlementRecord};
 use anchor_client::anchor_lang::prelude::Pubkey;
-use anyhow::anyhow;
+use anyhow::{anyhow, format_err};
 use bid_psr_distribution::merkle_tree_collection::{MerkleTreeCollection, MerkleTreeMeta};
 use bid_psr_distribution::settlement_collection::{Settlement, SettlementCollection};
 use bid_psr_distribution::utils::read_from_json_file;
@@ -108,9 +108,10 @@ fn insert_json_parsed_data(
     // Get the epoch and handle mismatches
     match (&merkle_tree_collection, &settlement_collection) {
         (Some(mc), Some(sc)) if mc.epoch != sc.epoch => {
-            return Err(CliError::critical(format!(
+            return Err(CliError::critical(format_err!(
                 "Epoch mismatch between merkle tree collection and settlement collection: {} != {}",
-                mc.epoch, sc.epoch
+                mc.epoch,
+                sc.epoch
             )));
         }
         (Some(mc), _) => mc.epoch,

--- a/settlement-pipelines/src/reporting.rs
+++ b/settlement-pipelines/src/reporting.rs
@@ -1,4 +1,5 @@
 use crate::cli_result::{CliError, CliResult};
+use anyhow::format_err;
 use log::{error, info};
 use solana_transaction_builder_executor::TransactionBuilderExecutionErrors;
 use std::fmt::Display;
@@ -111,7 +112,7 @@ impl ErrorHandler {
             for warning in &self.warnings {
                 println!("{}", warning);
             }
-            result = Err(CliError::warning(format!(
+            result = Err(CliError::warning(format_err!(
                 "Some warnings occurred during processing: {} warnings",
                 self.warnings.len()
             )));
@@ -122,7 +123,7 @@ impl ErrorHandler {
             for error in &self.errors {
                 println!("{}", error);
             }
-            result = Err(CliError::critical(format!(
+            result = Err(CliError::critical(format_err!(
                 "Some errors occurred during processing: {} errors",
                 self.errors.len()
             )));
@@ -133,7 +134,7 @@ impl ErrorHandler {
             for error in &self.retry_able_errors {
                 println!("{}", error);
             }
-            result = Err(CliError::retry_able(format!(
+            result = Err(CliError::retry_able(format_err!(
                 "Some retry-able errors occurred: {} errors",
                 self.retry_able_errors.len()
             )));


### PR DESCRIPTION
Fixing tests running a kind of integration test on pipeline settlement creation.
This test case takes time (~10 mins), and it is skipped by default. It was failing for a while, and with recent changes and fixes at #213, fixing the test processing as well.

NOTE: This PR is better to be reviewed after #213 is merged