### PR TITLE
[api] fixing bonds query to not fail on bond type limit [GEN-4939]

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ cargo build --release
 
 # Run API on port 8000 (default) or set a custom one using --port
 ./target/release/api \
-  --postgres-url "$POSTGRES_URL"
+  --postgres-url "$POSTGRES_URL" \
+  --postgres-ssl-root-cert "$POSTGRES_SSL_ROOT_CERT"
 ```
 
 ### On-Chain related parts


### PR DESCRIPTION
This fixes an API issue caused by an incorrect filter applied to bond data processing, introduced with institutional staking.

The issue occurs because both bond types are not updated at the same time.
- Institutional bonds are created slightly later in the epoch compared to bidding bonds. As a result, the epoch for institutional bonds is effectively one epoch behind when compared to bidding bond data near the epoch boundary.

With the current SQL logic, the API breaks and returns no data (which causes the dashboard to fail), because the generic `cluster.epoch` value is taken from the highest epoch without filtering by bond type.