### PR TITLE
[GEN-4975] workaround big decimal from institutional payouts

### DIFF
--- a/.buildkite/prepare-institutional-distribution.yml
+++ b/.buildkite/prepare-institutional-distribution.yml
@@ -64,6 +64,7 @@ steps:
 
   - label: ":scales: Prepare Validator Bonds Merkle Tree"
     env:
+      RUST_BACKTRACE: 1
     commands:
     - snapshot_slot=$(buildkite-agent meta-data get snapshot_slot)
     - buildkite-agent artifact download --include-retried-jobs target/release/institutional-distribution-cli .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,20 +3713,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
 
 [[package]]
-name = "postgres"
-version = "0.19.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7915b33ed60abc46040cbcaa25ffa1c7ec240668e0477c4f3070786f5916d451"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "futures-util",
- "log",
- "tokio",
- "tokio-postgres",
-]
-
-[[package]]
 name = "postgres-openssl"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4363,15 +4349,15 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.3"
+version = "1.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
+checksum = "faa7de2ba56ac291bd90c6b9bece784a52ae1411f9506544b3eae36dd2356d50"
 dependencies = [
  "arrayvec",
  "borsh 1.3.1",
  "bytes",
  "num-traits",
- "postgres",
+ "postgres-types",
  "rand 0.8.5",
  "rkyv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ merkle-tree = { path = "./merkle-tree" }
 openssl = "0.10.72"
 postgres-openssl = "0.5.1"
 regex = "1.10.4"
-rust_decimal = { version = "1.26", features = ["db-postgres"] }
+rust_decimal = { version = "1.37.1", features = ["db-postgres"] }
 serde = "1.0.197"
 serde_json = "1.0.114"
 serde_yaml = "0.8"

--- a/settlement-distributions/institutional-distribution/src/custom_deserialize.rs
+++ b/settlement-distributions/institutional-distribution/src/custom_deserialize.rs
@@ -24,7 +24,7 @@ where
     let s: String = serde::Deserialize::deserialize(deserializer)?;
     let value = s.trim().to_lowercase();
     // For extremely large values, return a maximum Decimal
-    if value.contains('e') && value.contains('+') {
+    if value.contains("e+") {
         let parsed_value = value.split('e').collect::<Vec<&str>>()[1]
             .parse::<i32>()
             .unwrap_or(0);

--- a/settlement-distributions/institutional-distribution/src/custom_deserialize.rs
+++ b/settlement-distributions/institutional-distribution/src/custom_deserialize.rs
@@ -13,7 +13,7 @@ where
 }
 
 /// The custom deserialize_large_decimal function handles parsing string representations of large decimal numbers.
-/// The TypeScript institutional staking codebase uses saves the decimal as sientific notation.
+/// The TypeScript institutional staking codebase saves the decimal as scientific notation.
 /// This function tries to handle specific cases where the decimal is extremely large and Rust is not capable of parsing it.
 /// This happened e.g., for epoch 779 with validator '6H9J5xtcqGwh2hd2GpBHfvrnDicWk8GtvpnypH7piktA' that has got with stake 0.01 SOL
 /// extremely high MEV (39 SOLs)/block(29 SOLs) rewards (https://console.cloud.google.com/storage/browser/_details/jito-mainnet/779/tip-router-rpc-1/779-stake-meta-collection.json)

--- a/settlement-distributions/institutional-distribution/src/custom_deserialize.rs
+++ b/settlement-distributions/institutional-distribution/src/custom_deserialize.rs
@@ -1,0 +1,43 @@
+use rust_decimal::Decimal;
+use serde::de;
+use std::str::FromStr;
+
+/// The custom deserialize_bigint function handles parsing string representations of big integers.
+/// As the TypeScript codebase uses strings to represent big integers, this function is necessary.
+pub fn deserialize_bigint<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: String = serde::Deserialize::deserialize(deserializer)?;
+    s.parse::<u64>().map_err(serde::de::Error::custom)
+}
+
+/// The custom deserialize_large_decimal function handles parsing string representations of large decimal numbers.
+/// The TypeScript institutional staking codebase uses saves the decimal as sientific notation.
+/// This function tries to handle specific cases where the decimal is extremely large and Rust is not capable of parsing it.
+/// This happened e.g., for epoch 779 with validator '6H9J5xtcqGwh2hd2GpBHfvrnDicWk8GtvpnypH7piktA' that has got with stake 0.01 SOL
+/// extremely high MEV (39 SOLs)/block(29 SOLs) rewards (https://console.cloud.google.com/storage/browser/_details/jito-mainnet/779/tip-router-rpc-1/779-stake-meta-collection.json)
+pub fn deserialize_large_decimal<'de, D>(deserializer: D) -> Result<Decimal, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: String = serde::Deserialize::deserialize(deserializer)?;
+    let value = s.trim().to_lowercase();
+    // For extremely large values, return a maximum Decimal
+    if value.contains('e') && value.contains('+') {
+        let parsed_value = value.split('e').collect::<Vec<&str>>()[1]
+            .parse::<i32>()
+            .unwrap_or(0);
+        if parsed_value > 28 {
+            return Ok(Decimal::MAX);
+        }
+        if parsed_value < 0 && parsed_value.abs() > 28 {
+            return Ok(Decimal::ZERO);
+        }
+    }
+
+    // For normal values, regular parsing
+    Decimal::from_str(value.as_str())
+        .or_else(|_| Decimal::from_scientific(value.as_str()))
+        .map_err(|_| de::Error::custom(format!("Failed to parse as Decimal: {}", value)))
+}

--- a/settlement-distributions/institutional-distribution/src/institutional_payouts.rs
+++ b/settlement-distributions/institutional-distribution/src/institutional_payouts.rs
@@ -1,3 +1,4 @@
+use crate::custom_deserialize::{deserialize_bigint, deserialize_large_decimal};
 use merkle_tree::serde_serialize::{pubkey_string_conversion, vec_pubkey_string_conversion};
 use rust_decimal::Decimal;
 use serde::Deserialize;
@@ -40,10 +41,12 @@ pub struct Validator {
     #[serde(deserialize_with = "deserialize_bigint")]
     pub total_rewards: u64,
 
+    #[serde(deserialize_with = "deserialize_large_decimal")]
     pub apy: Decimal,
 
     pub institutional_staked_ratio: Decimal,
 
+    #[serde(deserialize_with = "deserialize_large_decimal")]
     pub apy_percentile_diff: Decimal,
 }
 
@@ -133,6 +136,7 @@ pub struct PayoutDistributor {
 pub struct PercentileData {
     pub percentile: u16,
 
+    #[serde(deserialize_with = "deserialize_large_decimal")]
     pub apy: Decimal,
 
     #[serde(deserialize_with = "deserialize_bigint")]
@@ -156,14 +160,4 @@ pub struct InstitutionalPayout {
     pub validators: Vec<Validator>,
 
     pub validator_payout_info: Vec<ValidatorPayoutInfo>,
-}
-
-/// The custom deserialize_bigint function handles parsing string representations of big integers.
-/// As the TypeScript codebase uses strings to represent big integers, this function is necessary.
-fn deserialize_bigint<'de, D>(deserializer: D) -> Result<u64, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let s: String = serde::Deserialize::deserialize(deserializer)?;
-    s.parse::<u64>().map_err(serde::de::Error::custom)
 }

--- a/settlement-distributions/institutional-distribution/src/lib.rs
+++ b/settlement-distributions/institutional-distribution/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod custom_deserialize;
 pub mod institutional_payouts;
 pub mod settlement_config;
 pub mod settlement_generator;


### PR DESCRIPTION
There happens to be a big decimal numbers or small in scientific notation generated by TS Decimal.
This adds a custom deserializer that manages it and workarounds it.

```
Error: Failure at '--institutional-payouts ./institutional-payouts.json': invalid value: string "4.8076269033743718234e+882", expected a Decimal type representing a fixed-point number at line 11110 column 41
```