### PR TITLE
More info on institutional pipeline [GEN-5100][GEN-4883]

### DIFF
--- a/.buildkite/prepare-institutional-distribution.yml
+++ b/.buildkite/prepare-institutional-distribution.yml
@@ -85,6 +85,24 @@ steps:
     artifact_paths:
       - "./discord-public-report.txt"
 
+  - label: "📓 Details from payouts data"
+    commands:
+    - buildkite-agent artifact download --include-retried-jobs institutional-payouts.json .
+    - |
+      jq '[.validators[].stakedAmounts | {
+        institutionalActive,
+        institutionalActivating,
+        institutionalDeactivating,
+        institutionalEffective
+      }] | {
+        institutionalActive: (map(.institutionalActive | tonumber) | add / 1e9),
+        institutionalActivating: (map(.institutionalActivating | tonumber) | add / 1e9),
+        institutionalDeactivating: (map(.institutionalDeactivating | tonumber) | add / 1e9),
+        institutionalEffective: (map(.institutionalEffective | tonumber) | add / 1e9)
+      }' ./institutional-payouts.json | jq -r 'to_entries | (.[] | " \(.key): \(.value)")' > './institutional-payouts-summary.txt'
+    artifact_paths:
+      - "./institutional-payouts-summary.txt"
+
   - wait: ~
 
   - label: ":floppy_disk: :arrow_right: :cloud: Upload artifacts Prepare Bid Distribution"
@@ -99,8 +117,17 @@ steps:
 
   - wait: ~
 
+  - label: ":information_source::printer: Aggregated report"
+    commands:
+    - buildkite-agent artifact download --include-retried-jobs institutional-payouts-summary.txt .
+    - cat './institutional-payouts-summary.txt'
+    - buildkite-agent artifact download --include-retried-jobs institutional-payouts.json .
+    - ./scripts/generate-select-validator-report.bash './institutional-payouts.json'
+
   - label: ":mega: Notification"
     commands:
+    - buildkite-agent artifact download --include-retried-jobs institutional-payouts-summary.txt .
+    - institutional_payouts_summary=$(cat ./institutional-payouts-summary.txt)
     - |
       epoch=$(buildkite-agent meta-data get epoch)
       curl ${SLACK_API} -X POST -H 'Content-Type: application/json; charset=utf-8' \
@@ -110,8 +137,9 @@ steps:
             {
               "color": "#8000ff",
               "title": "Claims for Validator Bonds ('"${CLAIM_TYPE}"') generated ('"$$epoch"').",
-              "title_link": "'"$$BUILDKITE_BUILD_URL"'",
-              "footer": "<'"$$BUILDKITE_BUILD_URL"'|View in Buildkite>"
+              "title_link": "'"$$BUILDKITE_BUILD_URL/#$${BUILDKITE_JOB_ID}"'",
+              "text": "'"$$institutional_payouts_summary"'",
+              "footer": "<'"$$BUILDKITE_BUILD_URL/#$${BUILDKITE_JOB_ID}"'|View in Buildkite>"
             }
           ]
       }'

--- a/scripts/generate-select-validator-report.bash
+++ b/scripts/generate-select-validator-report.bash
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+set -e
+
+# Set locale to ensure consistent number formatting
+export LC_NUMERIC=C
+
+json_file="$1"
+
+if [[ -z $json_file ]]
+then
+    echo "Usage: $0 <json file>" >&2
+    exit 1
+fi
+
+if [[ ! -f $json_file ]]; then
+    echo "Error: File '$json_file' not found." >&2
+    exit 1
+fi
+
+function format_percentage {
+    local value="$1"
+    # Handle empty or invalid values
+    if [[ -z "$value" || "$value" == "null" ]]; then
+        echo "0.00%"
+        return
+    fi
+    # Convert decimal to percentage and format to 2 decimal places
+    local percentage=$(LC_NUMERIC=C awk "BEGIN {printf \"%.2f\", $value * 100}")
+    echo "${percentage}%"
+}
+
+function format_sol_amount {
+    local lamports="$1"
+    if [[ -z "$lamports" || "$lamports" == "null" ]]; then
+        echo "0.0000"
+        return
+    fi
+    # Convert lamports to SOL (divide by 1e9) and format to 4 decimal places
+    LC_NUMERIC=C awk "BEGIN {printf \"%.4f\", $lamports / 1000000000}"
+}
+
+function format_commission {
+    local value="$1"
+    if [[ -z "$value" || "$value" == "null" ]]; then
+        echo "0%"
+        return
+    fi
+    local percentage=$(LC_NUMERIC=C awk "BEGIN {printf \"%.0f\", $value}")
+    echo "${percentage}%"
+}
+
+echo "Payouts data for epoch: $(<"$json_file" jq -r '.epoch')"
+
+# Get institutional validator vote accounts as associative array
+declare -A institutional_validators
+while IFS='|' read -r vote_account name; do
+    institutional_validators["$vote_account"]="$name"
+done < <(<"$json_file" jq -r '.institutionalValidators.validators[] | "\(.vote_pubkey)|\(.name // "")"')
+
+# Calculate staker payouts per validator
+declare -A staker_payouts
+while IFS='|' read -r vote_account payout_lamports; do
+    if [[ -n "$vote_account" && "$vote_account" != "null" ]]; then
+        current_total="${staker_payouts[$vote_account]:-0}"
+        staker_payouts["$vote_account"]=$(awk "BEGIN {print $current_total + $payout_lamports}")
+    fi
+done < <(<"$json_file" jq -r '.payoutStakers[] | "\(.voteAccount)|\(.payoutLamports // "0")"')
+
+# Calculate distributor payouts per validator
+declare -A distributor_payouts
+while IFS='|' read -r vote_account payout_lamports; do
+    if [[ -n "$vote_account" && "$vote_account" != "null" ]]; then
+        distributor_payouts["$vote_account"]="$payout_lamports"
+    fi
+done < <(<"$json_file" jq -r '.payoutDistributors[] | "\(.voteAccount)|\(.payoutLamports // "0")"')
+
+declare -a select_validators
+declare -a non_select_validators
+
+while IFS='|' read -r vote_account apy total_rewards institutional_effective commission mev_commission psr_fee_lamports; do
+    psr_penalty="${psr_fee_lamports:-0}"
+    staker_payout="${staker_payouts[$vote_account]:-0}"
+    distributor_payout="${distributor_payouts[$vote_account]:-0}"
+
+    infl_comm=$(format_commission "$commission")
+    mev_comm=$(format_commission "$mev_commission")
+    commission_display="${infl_comm}/${mev_comm}"
+
+    if [[ -n "${institutional_validators[$vote_account]}" ]]; then
+        # This is a select validator
+        name="${institutional_validators[$vote_account]}"
+        display_name="${name:0:15}"
+        select_validators+=("$vote_account|$display_name|$apy|$total_rewards|$institutional_effective|$psr_penalty|$staker_payout|$distributor_payout|$commission_display")
+    else
+        # This is a non-select validator / skip if no institutional stake
+        if [[ "$institutional_effective" == "0" ]]; then
+            continue
+        fi
+        non_select_validators+=("$vote_account|$apy|$total_rewards|$institutional_effective|$psr_penalty|$staker_payout|$distributor_payout|$commission_display")
+    fi
+done < <(<"$json_file" jq -r '.validators[] | "\(.voteAccount)|\(.apy // "0")|\(.totalRewards // "0")|\(.stakedAmounts.institutionalEffective // "0")|\(.commission // "0")|\(.mevCommission // "null")|\(.psrFeeLamports // "0")"')
+
+# --- Print Select Validators ---
+select_count=${#select_validators[@]}
+if [[ $select_count -gt 0 ]]; then
+    echo "Select Vote Account ($select_count)                     | Name            |          APY | Infl./MEV |   Total Rewards |   Select Effective |  PSR Penalty | Staker Payout | Distributor Payout"
+    echo "---------------------------------------------+-----------------+--------------+-----------+-----------------+--------------------+--------------+---------------+--------------------"
+
+    total_total_rewards=0
+    total_effective=0
+    total_psr_penalty=0
+    total_staker_payout=0
+    total_distributor_payout=0
+
+    for validator_data in "${select_validators[@]}"; do
+        IFS='|' read -r vote_account name apy total_rewards institutional_effective psr_penalty staker_payout distributor_payout commission_display <<< "$validator_data"
+
+        formatted_apy=$(format_percentage "$apy")
+        formatted_rewards=$(format_sol_amount "$total_rewards")
+        formatted_effective=$(format_sol_amount "$institutional_effective")
+        formatted_penalty=$(format_sol_amount "$psr_penalty")
+        formatted_staker_payout=$(format_sol_amount "$staker_payout")
+        formatted_distributor_payout=$(format_sol_amount "$distributor_payout")
+
+        printf "%-44s | %-15s | %12s | %9s | %15s | %18s | %12s | %13s | %18s\n" \
+            "$vote_account" \
+            "$name" \
+            "$formatted_apy" \
+            "$commission_display" \
+            "$formatted_rewards" \
+            "$formatted_effective" \
+            "$formatted_penalty" \
+            "$formatted_staker_payout" \
+            "$formatted_distributor_payout"
+
+        total_total_rewards=$((total_total_rewards + total_rewards))
+        total_effective=$((total_effective + institutional_effective))
+        total_psr_penalty=$((total_psr_penalty + psr_penalty))
+        total_staker_payout=$((total_staker_payout + staker_payout))
+        total_distributor_payout=$((total_distributor_payout + distributor_payout))
+    done
+
+    echo "---------------------------------------------+-----------------+--------------+-----------+-----------------+--------------------+--------------+---------------+--------------------+--------------"
+    printf "%-44s | %-15s | %12s | %9s | %15s | %18s | %12s | %13s | %18s | %12s \n" \
+        "TOTAL" \
+        "" \
+        "" \
+        "" \
+        "$(format_sol_amount "$total_total_rewards")" \
+        "$(format_sol_amount "$total_effective")" \
+        "$(format_sol_amount "$total_psr_penalty")" \
+        "$(format_sol_amount "$total_staker_payout")" \
+        "$(format_sol_amount "$total_distributor_payout")" \
+        "$(format_sol_amount "$(($total_distributor_payout + $total_staker_payout))")"
+
+fi
+
+echo ""
+
+# --- Print Non-Select Validators ---
+non_select_count=${#non_select_validators[@]}
+if [[ $non_select_count -gt 0 ]]; then
+    echo "Non-Select Vote Account ($non_select_count)                  |          APY | Infl./MEV |   Total Rewards |   Select Effective |  PSR Penalty | Staker Payout | Distributor Payout"
+    echo "---------------------------------------------+--------------+-----------+-----------------+--------------------+--------------+---------------+--------------------"
+
+    total_total_rewards=0
+    total_effective=0
+    total_psr_penalty=0
+    total_staker_payout=0
+    total_distributor_payout=0
+
+    for validator_data in "${non_select_validators[@]}"; do
+        IFS='|' read -r vote_account apy total_rewards institutional_effective psr_penalty staker_payout distributor_payout commission_display <<< "$validator_data"
+
+        formatted_apy=$(format_percentage "$apy")
+        formatted_rewards=$(format_sol_amount "$total_rewards")
+        formatted_effective=$(format_sol_amount "$institutional_effective")
+        formatted_penalty=$(format_sol_amount "$psr_penalty")
+        formatted_staker_payout=$(format_sol_amount "$staker_payout")
+        formatted_distributor_payout=$(format_sol_amount "$distributor_payout")
+
+        printf "%-44s | %12s | %9s | %15s | %18s | %12s | %13s | %18s\n" \
+            "$vote_account" \
+            "$formatted_apy" \
+            "$commission_display" \
+            "$formatted_rewards" \
+            "$formatted_effective" \
+            "$formatted_penalty" \
+            "$formatted_staker_payout" \
+            "$formatted_distributor_payout"
+
+        total_total_rewards=$((total_total_rewards + total_rewards))
+        total_effective=$((total_effective + institutional_effective))
+        total_psr_penalty=$((total_psr_penalty + psr_penalty))
+        total_staker_payout=$((total_staker_payout + staker_payout))
+        total_distributor_payout=$((total_distributor_payout + distributor_payout))
+    done
+
+    echo "---------------------------------------------+--------------+-----------+-----------------+--------------------+--------------+---------------+--------------------+--------------"
+    printf "%-44s | %12s | %9s | %15s | %18s | %12s | %13s | %18s | %12s \n" \
+        "TOTAL" \
+        "" \
+        "" \
+        "$(format_sol_amount "$total_total_rewards")" \
+        "$(format_sol_amount "$total_effective")" \
+        "$(format_sol_amount "$total_psr_penalty")" \
+        "$(format_sol_amount "$total_staker_payout")" \
+        "$(format_sol_amount "$total_distributor_payout")" \
+        "$(format_sol_amount "$(($total_distributor_payout + $total_staker_payout))")"
+fi

--- a/scripts/settlement-json-listing.sh
+++ b/scripts/settlement-json-listing.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ### ---- Call with json file arguments
-# settlement-json-listing.sh --settlements 1_settlements.json --merkle-trees 1_settlement-merkle-trees.json [--claim-type bid-claim]
+# settlement-json-listing.sh --settlements 1_settlements.json --merkle-trees 1_settlement-merkle-trees.json --claim-type <bid|institutional>
 ### ----
 
 solsdecimal() {
@@ -56,8 +56,8 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-if [ -z "$SETTLEMENTS_JSON_FILE" ] || [ -z "$MERKLE_TREES_JSON_FILE" ]; then
-    echo "Both --settlements and --merkle-trees parameters are required"
+if [ -z "$SETTLEMENTS_JSON_FILE" ] || [ -z "$MERKLE_TREES_JSON_FILE" ] || [ -z "$CLAIM_TYPE" ]; then
+    echo "Both --settlements <path> and --merkle-trees <path> and --claim-type <bid*|institutional*> parameters are required"
     exit 1
 fi
 
@@ -100,6 +100,52 @@ settlements=$(jq -c '.settlements[]' "$SETTLEMENTS_JSON_FILE")
 
 declare -A claims_amounts
 declare -A claims_number
+declare -A unique_funders
+
+declare -A funder_map
+SELECTED_FUNDER=""
+get_next_funder() {
+    SELECTED_FUNDER="<UNKNOWN>"
+    local vote_account="$1"
+    local amount="$2"
+    local funder_data="$3"
+    
+    local preset_key="${vote_account}_${amount}"
+    
+    # Check if funder_data contains multiple funders (separated by newlines)
+    if [[ -n "$funder_data" ]]; then
+        # Convert funder_data to array, splitting by newlines
+        local funder_array
+        readarray -t funder_array <<< "$funder_data"
+        
+        local cleaned_funders=()
+        local funder
+        for funder in "${funder_array[@]}"; do
+            local clean_funder # Remove quotes and trim whitespace
+            clean_funder=$(echo "$funder" | sed 's/^"//; s/"$//' | xargs)
+            if [[ -n "$clean_funder" ]]; then
+                cleaned_funders+=("$clean_funder")
+            fi
+        done
+        if [[ ${#cleaned_funders[@]} -gt 0 ]]; then
+            local count=0
+            local map_key
+            for map_key in "${!funder_map[@]}"; do
+                if [[ "$map_key" == "${preset_key}_"* ]]; then
+                    count=$((count + 1))
+                fi
+            done
+            # Calculate index based on count (cycling through available funders)
+            local current_index=$((count % ${#cleaned_funders[@]}))
+            # Get the funder at current index
+            local selected_funder="${cleaned_funders[$current_index]}"            
+            # Store in map with unique suffix to track multiple entries
+            funder_map["${preset_key}_${count}"]="$selected_funder"
+            
+            SELECTED_FUNDER="$selected_funder"
+        fi
+    fi
+}
 
 index=0
 while IFS= read -r tree; do
@@ -117,8 +163,10 @@ while IFS= read -r tree; do
   echo "$tree" | jq '.tree_nodes | length'
 
   # Query the settlement data once per loop
-  FUNDER=$(echo "$settlements" | jq -c 'select((.vote_account == "'$VOTE_ACCOUNT'") and (.claims_amount == '$LAMPORTS_MAX')) | .meta.funder')
-  echo "Funder: ${FUNDER:-<UNKNOWN>}"
+  FUNDER_PARSED=$(echo "$settlements" | jq -c 'select((.vote_account == "'$VOTE_ACCOUNT'") and (.claims_amount == '$LAMPORTS_MAX')) | .meta.funder')
+  get_next_funder "$VOTE_ACCOUNT" "$LAMPORTS_MAX" "$FUNDER_PARSED"
+  FUNDER="$SELECTED_FUNDER"
+  echo "Funder: $FUNDER"
 
   current_sum=${claims_amounts[$FUNDER]}
   claims_amounts[$FUNDER]=$(($current_sum+$LAMPORTS_MAX))

--- a/scripts/settlement-json-listing.sh
+++ b/scripts/settlement-json-listing.sh
@@ -57,7 +57,7 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 if [ -z "$SETTLEMENTS_JSON_FILE" ] || [ -z "$MERKLE_TREES_JSON_FILE" ] || [ -z "$CLAIM_TYPE" ]; then
-    echo "Both --settlements <path> and --merkle-trees <path> and --claim-type <bid*|institutional*> parameters are required"
+    echo "Parameters --settlements <path> and --merkle-trees <path> and --claim-type <bid*|institutional*> are required"
     exit 1
 fi
 


### PR DESCRIPTION
A way to list the data within the payouts JSON, and whether it is reasonable to process it on-chain. I've got to this processing bash that lists data about payouts. This could need some tuning in the future, but having this as a start seems okayish.
Example listing: https://buildkite.com/marinade-finance/prepare-institutional-distribution/builds/64#0196fc5c-1122-42a8-a4d1-39e9e5b72f85

+ fixing an issue in PSR listing data for settlements in the initial settlement pipeline that shows the wrong info