### PR TITLE
Fixing errors for close Settlements in pipelines [GEN-5223]

### DIFF
--- a/settlement-pipelines/src/settlements.rs
+++ b/settlement-pipelines/src/settlements.rs
@@ -175,7 +175,7 @@ pub async fn load_expired_settlements(
 
     let filtered_settlements: (Vec<_>, Vec<_>) = all_settlements.into_iter().zip(bonds_for_settlements.into_iter())
         .filter(|((settlement_address, settlement), (_, bond))| {
-            let is_for_config = bond.is_none() || bond.as_ref().unwrap().config == *config_address;
+            let is_for_config = bond.as_ref().map_or(false, |b| b.config == *config_address);
             let is_expired = current_epoch > settlement.epoch_created_for + config.epochs_to_claim_settlement;
 
         debug!(

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -29,6 +29,14 @@ pub const MARINADE_LIQUID_STAKER_AUTHORITY: &str = "4bZ6o3eUUNXhKuqjdCnCoPAoLgWi
 pub const MARINADE_INSTITUTIONAL_STAKER_AUTHORITY: &str =
     "STNi1NHDUi6Hvibvonawgze8fM83PFLeJhuGMEXyGps";
 
+// Stake accounts that were not closed by pipeline for some prevalent reasons
+pub const IGNORE_DANGLING_NOT_CLOSABLE_STAKE_ACCOUNTS_LIST: [&str; 2] = [
+    // [GEN-5105]: stake accounts belonging to validator accounts that were closed before stake account could be reset (the Settlement was closed)
+    // these are for vote account: 84gebYpPpEafPeGJUVA8QzfaTQC3GeyVufCTHpqsQqE2, bond account: Agw2pSmo64BSduy7Q9Ua7ABYzLXGz4zxsqM9u1YMxWS3
+    "5u7Dk8JqVJ5CFmxtXEfZJ53wELX4tibwVur9k5k2KGPJ",
+    "HZa2FDjWXepz58NwnuDxNp3T7FXCDNKt7YzpPBBpPdtj",
+];
+
 // Prioritize collected stake accounts where to claim to.
 // - error if all are locked or no stake accounts
 pub fn prioritize_for_claiming(


### PR DESCRIPTION
The Close settlement pipeline consistently fails.

* One reason is that the close bidding considersclosinge the Select settlements (there are different config accounts and one cannot close the other)
* another reason is non-reset stake accounts that are not possible to be closed, as there is a missing functionality in contract [GEN-5105]