### PR TITLE
[pipeline] fix for close settlement

### DIFF
--- a/.buildkite/close-settlements.yml
+++ b/.buildkite/close-settlements.yml
@@ -111,7 +111,7 @@ steps:
   - label: ":campfire::arrow_right: Close settlements"
     env:
       RPC_URL: "$$RPC_URL"
-      RUST_LOG: info,solana_transaction_builder_executor=debug,solana_transaction_builder=debug,solana_transaction_executor=debug,close_settlement=debug
+      RUST_LOG: info,solana_transaction_builder_executor=debug,solana_transaction_builder=debug,solana_transaction_executor=debug,close_settlement=debug,settlement_pipelines=debug
       # RUST_BACKTRACE: full
     commands:
     - . "$HOME/.cargo/env"

--- a/common-rs/src/settlements.rs
+++ b/common-rs/src/settlements.rs
@@ -136,13 +136,18 @@ pub async fn get_bonds_for_settlements(
         .collect::<Vec<Pubkey>>();
 
     let bonds = get_bonds_for_pubkeys(rpc_client, &bond_pubkeys).await?;
+    debug!(
+        "Found {} bonds for {} unique bond pubkeys",
+        bonds.len(),
+        bond_pubkeys.len()
+    );
 
     let settlements_bonds = settlements
         .iter()
-        .map(|(pubkey, settlement)| {
+        .map(|(_, settlement)| {
             bonds
                 .iter()
-                .find(|(bond_pubkey, bond)| bond_pubkey == pubkey && bond.is_some())
+                .find(|(bond_pubkey, bond)| *bond_pubkey == settlement.bond && bond.is_some())
                 .map_or_else(
                     || (settlement.bond, None),
                     |(_, bond)| {

--- a/settlement-pipelines/src/settlements.rs
+++ b/settlement-pipelines/src/settlements.rs
@@ -172,6 +172,11 @@ pub async fn load_expired_settlements(
         get_bonds_for_settlements(rpc_client.clone(), &all_settlements).await?;
 
     assert_eq!(all_settlements.len(), bonds_for_settlements.len());
+    debug!(
+        "Current epoch: {}, all settlements: {}",
+        current_epoch,
+        all_settlements.len()
+    );
 
     let filtered_settlements: (Vec<_>, Vec<_>) = all_settlements.into_iter().zip(bonds_for_settlements.into_iter())
         .filter(|((settlement_address, settlement), (_, bond))| {
@@ -185,7 +190,7 @@ pub async fn load_expired_settlements(
             current_epoch,
             config.epochs_to_claim_settlement,
             is_for_config,
-            is_expired
+            is_expired,
         );
 
         is_for_config && is_expired


### PR DESCRIPTION
A fix https://github.com/marinade-finance/validator-bonds/pull/237 introduced there is an error in other part of loading bonds data for settlements.

For correctly closing bonds we need a fix here
https://github.com/marinade-finance/validator-bonds/compare/close-settlement-fix?expand=1#diff-a399f3c8afd3af7e8e9b1851ddbf193f37afb9967242aa3aa780b3b8fae04ff8R150