### PR TITLE
[GEN-5372] Implement commission settlemen penalty markup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "log",
  "merkle-tree",
  "rust_decimal",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -4364,6 +4365,16 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "rust_decimal_macros"
+version = "1.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6268b74858287e1a062271b988a0c534bf85bbeb567fe09331bf40ed78113d5"
+dependencies = [
+ "quote 1.0.35",
+ "syn 2.0.50",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ postgres-openssl = "0.5.1"
 regex = "1.10.4"
 reqwest = "0.11.22"
 rust_decimal = { version = "1.37.1", features = ["db-postgres"] }
-rust_decimal_macros = { version = "1.37.1" }
+rust_decimal_macros = "1.37.1"
 serde = "1.0.197"
 serde_json = "1.0.114"
 serde_yaml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ postgres-openssl = "0.5.1"
 regex = "1.10.4"
 reqwest = "0.11.22"
 rust_decimal = { version = "1.37.1", features = ["db-postgres"] }
+rust_decimal_macros = { version = "1.37.1" }
 serde = "1.0.197"
 serde_json = "1.0.114"
 serde_yaml = "0.8"

--- a/settlement-config.yaml
+++ b/settlement-config.yaml
@@ -16,6 +16,6 @@
     min_settlement_lamports: 10000000 # 0.01 SOL
     grace_increase_bps: 100 # 1 %
     covered_range_bps: [0, 10000] # 0 % - 100 %
-    penalty_threshold_bps: 700 # 7%
+    extra_penalty_threshold_bps: 700 # 7%
     base_markup_bps: 1000 # 10%
     penalty_markup_bps: 10000 # 100%

--- a/settlement-config.yaml
+++ b/settlement-config.yaml
@@ -16,3 +16,6 @@
     min_settlement_lamports: 10000000 # 0.01 SOL
     grace_increase_bps: 100 # 1 %
     covered_range_bps: [0, 10000] # 0 % - 100 %
+    penalty_threshold_bps: 700 # 7%
+    base_markup_bps: 1000 # 10%
+    penalty_markup_bps: 10000 # 100%

--- a/settlement-distributions/bid-psr-distribution/Cargo.toml
+++ b/settlement-distributions/bid-psr-distribution/Cargo.toml
@@ -15,6 +15,7 @@ env_logger = { workspace = true }
 log = { workspace = true }
 merkle-tree = { workspace = true }
 rust_decimal = { workspace = true, features = ["serde-float"] }
+rust_decimal_macros = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/settlement-distributions/bid-psr-distribution/src/protected_events.rs
+++ b/settlement-distributions/bid-psr-distribution/src/protected_events.rs
@@ -104,7 +104,9 @@ impl ProtectedEvent {
                         ..
                     } => {
                         let threshold = bps_to_fraction(*penalty_threshold_bps);
-                        let markup = if actual_inflation_commission <= threshold && actual_mev_commission <= threshold {
+                        let markup = if *actual_inflation_commission <= threshold
+                            && actual_mev_commission.unwrap_or(Decimal::ZERO) <= threshold
+                        {
                             *base_markup_bps
                         } else {
                             *penalty_markup_bps

--- a/settlement-distributions/bid-psr-distribution/src/protected_events.rs
+++ b/settlement-distributions/bid-psr-distribution/src/protected_events.rs
@@ -100,10 +100,10 @@ impl ProtectedEvent {
                     SettlementConfig::CommissionSamIncreaseSettlement {
                         base_markup_bps,
                         penalty_markup_bps,
-                        penalty_threshold_bps,
+                        extra_penalty_threshold_bps,
                         ..
                     } => {
-                        let threshold = bps_to_fraction(*penalty_threshold_bps);
+                        let threshold = bps_to_fraction(*extra_penalty_threshold_bps);
                         let markup = if *actual_inflation_commission <= threshold
                             && actual_mev_commission.unwrap_or(Decimal::ZERO) <= threshold
                         {

--- a/settlement-distributions/bid-psr-distribution/src/protected_events.rs
+++ b/settlement-distributions/bid-psr-distribution/src/protected_events.rs
@@ -1,7 +1,9 @@
 use crate::revenue_expectation_meta::{RevenueExpectationMeta, RevenueExpectationMetaCollection};
+use crate::settlement_config::SettlementConfig;
 use crate::utils::bps_decimal;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 
 use {
     crate::utils::{bps, bps_to_fraction},
@@ -84,14 +86,35 @@ impl ProtectedEvent {
         }
     }
 
-    fn claim_per_stake(&self) -> Decimal {
+    fn claim_per_stake(&self, cfg: &SettlementConfig) -> Decimal {
         match self {
             ProtectedEvent::CommissionSamIncrease {
                 expected_epr,
                 actual_epr,
                 ..
-            } => expected_epr - actual_epr,
-
+            } => {
+                // TODO ... should be based on the "target" APY, not the difference
+                let base_cps = expected_epr - actual_epr;
+                match cfg {
+                    SettlementConfig::CommissionSamIncreaseSettlement {
+                        base_markup_bps,
+                        penalty_markup_bps,
+                        penalty_threshold_bps,
+                        ..
+                    } => {
+                        let markup =
+                            if base_cps <= bps_to_fraction(*penalty_threshold_bps) {
+                                *base_markup_bps
+                            } else {
+                                *penalty_markup_bps
+                            };
+                        base_cps * (Decimal::ONE + bps_to_fraction(markup))
+                    }
+                    _ => {
+                        panic!("Can not process CommissionSamIncrease settlement with wrong config: {cfg:?}")
+                    }
+                }
+            }
             ProtectedEvent::DowntimeRevenueImpact {
                 expected_epr,
                 actual_epr,
@@ -104,20 +127,15 @@ impl ProtectedEvent {
         }
     }
 
-    pub fn claim_amount(&self, stake: u64) -> u64 {
-        (self.claim_per_stake() * Decimal::from(stake))
-            .to_u64()
-            .expect("claim_amount: cannot convert to u64")
-    }
-
-    pub fn claim_amount_in_loss_range(&self, range_bps: &[u64; 2], stake: u64) -> u64 {
+    pub fn claim_amount_in_loss_range(&self, cfg: &SettlementConfig, stake: u64) -> u64 {
+        let range_bps = cfg.covered_range_bps();
         let lower_bps = range_bps[0];
         let upper_bps = range_bps[1];
 
         let max_claim_per_stake = bps_to_fraction(upper_bps) * self.expected_epr();
         let ignored_claim_per_stake = bps_to_fraction(lower_bps) * self.expected_epr();
         let claim_per_stake =
-            self.claim_per_stake().min(max_claim_per_stake) - ignored_claim_per_stake;
+            self.claim_per_stake(cfg).min(max_claim_per_stake) - ignored_claim_per_stake;
 
         (Decimal::from(stake) * claim_per_stake)
             .max(Decimal::ZERO)
@@ -138,8 +156,6 @@ pub fn collect_commission_increase_events(
     revenue_expectation_map: &HashMap<Pubkey, RevenueExpectationMeta>,
 ) -> Vec<ProtectedEvent> {
     info!("Collecting commission increase events...");
-    let decimal_1000 = Decimal::from(1000);
-
     validator_meta_collection
         .validator_metas
         .iter()
@@ -169,8 +185,8 @@ pub fn collect_commission_increase_events(
                             before_sam_commission_increase_pmpe: revenue_expectation.before_sam_commission_increase_pmpe,
                             // expected_non_bid_pmpe is what how many SOLs was expected to gain per 1000 of staked SOLs
                             // expected_epr is ratio of how many SOLS to pay for 1 staked SOL (it does not matter if in lamports or SOLs when ratio)
-                            expected_epr: expected_commission_pmpe / decimal_1000,
-                            actual_epr: revenue_expectation.actual_non_bid_pmpe / decimal_1000,
+                            expected_epr: expected_commission_pmpe / dec!(1000),
+                            actual_epr: revenue_expectation.actual_non_bid_pmpe / dec!(1000),
                             epr_loss_bps: bps_decimal(
                                 expected_commission_pmpe - revenue_expectation.actual_non_bid_pmpe,
                                 expected_commission_pmpe
@@ -200,8 +216,6 @@ pub fn collect_downtime_revenue_impact_events(
     let total_stake_weighted_credits = validator_meta_collection.total_stake_weighted_credits();
     let expected_credits =
         (total_stake_weighted_credits / validator_meta_collection.total_stake() as u128) as u64;
-    let decimal_1000 = Decimal::from(1000);
-
     validator_meta_collection
         .validator_metas
         .iter()
@@ -218,8 +232,8 @@ pub fn collect_downtime_revenue_impact_events(
                             vote_account,
                             actual_credits: credits,
                             expected_credits,
-                            expected_epr: revenue_expectation.actual_non_bid_pmpe / decimal_1000,
-                            actual_epr: (revenue_expectation.actual_non_bid_pmpe / decimal_1000) * uptime,
+                            expected_epr: revenue_expectation.actual_non_bid_pmpe / dec!(1000),
+                            actual_epr: revenue_expectation.actual_non_bid_pmpe / dec!(1000) * uptime,
                             epr_loss_bps: bps(
                                 expected_credits - credits,
                                 expected_credits

--- a/settlement-distributions/bid-psr-distribution/src/protected_events.rs
+++ b/settlement-distributions/bid-psr-distribution/src/protected_events.rs
@@ -102,12 +102,11 @@ impl ProtectedEvent {
                         penalty_threshold_bps,
                         ..
                     } => {
-                        let markup =
-                            if base_cps <= bps_to_fraction(*penalty_threshold_bps) {
-                                *base_markup_bps
-                            } else {
-                                *penalty_markup_bps
-                            };
+                        let markup = if base_cps <= bps_to_fraction(*penalty_threshold_bps) {
+                            *base_markup_bps
+                        } else {
+                            *penalty_markup_bps
+                        };
                         base_cps * (Decimal::ONE + bps_to_fraction(markup))
                     }
                     _ => {

--- a/settlement-distributions/bid-psr-distribution/src/settlement_config.rs
+++ b/settlement-distributions/bid-psr-distribution/src/settlement_config.rs
@@ -25,8 +25,9 @@ pub enum SettlementConfig {
         grace_increase_bps: Option<u64>,
         /// range of bps that are covered by the settlement, usually differentiated by type of funder
         covered_range_bps: [u64; 2],
-        /// if the EPR change exceeds this value the penalty markup will be applied
-        penalty_threshold_bps: u64,
+        /// if any of the commissions exceeds this value the penalty markup will be applied,
+        /// base markup is applied otherwise
+        extra_penalty_threshold_bps: u64,
         /// base settlement markup, in basis points, applied if EPR change is low
         base_markup_bps: u64,
         /// penalty settlement markup, in basis points, applied if EPR change is large

--- a/settlement-distributions/bid-psr-distribution/src/settlement_config.rs
+++ b/settlement-distributions/bid-psr-distribution/src/settlement_config.rs
@@ -22,6 +22,9 @@ pub enum SettlementConfig {
         min_settlement_lamports: u64,
         grace_increase_bps: Option<u64>,
         covered_range_bps: [u64; 2],
+        penalty_threshold_bps: u64,
+        base_markup_bps: u64,
+        penalty_markup_bps: u64,
     },
 }
 

--- a/settlement-distributions/bid-psr-distribution/src/settlement_config.rs
+++ b/settlement-distributions/bid-psr-distribution/src/settlement_config.rs
@@ -19,11 +19,17 @@ pub enum SettlementConfig {
     /// configuration for protected event [protected_events::ProtectedEvent::CommissionSamIncrease]
     CommissionSamIncreaseSettlement {
         meta: SettlementMeta,
+        /// when settlement sum of claims is under this value, it is not generated
         min_settlement_lamports: u64,
+        /// when downtime of the validator is lower to the grace period the settlement is not generated
         grace_increase_bps: Option<u64>,
+        /// range of bps that are covered by the settlement, usually differentiated by type of funder
         covered_range_bps: [u64; 2],
+        /// if the EPR change exceeds this value the penalty markup will be applied
         penalty_threshold_bps: u64,
+        /// base settlement markup, in basis points, applied if EPR change is low
         base_markup_bps: u64,
+        /// penalty settlement markup, in basis points, applied if EPR change is large
         penalty_markup_bps: u64,
     },
 }

--- a/settlement-distributions/bid-psr-distribution/src/settlement_generator.rs
+++ b/settlement-distributions/bid-psr-distribution/src/settlement_generator.rs
@@ -50,10 +50,8 @@ pub fn generate_settlements(
                     .collect();
                 let active_stake = stake_accounts.values().sum();
 
-                let claim_amount = protected_event.claim_amount_in_loss_range(
-                    settlement_config.covered_range_bps(),
-                    active_stake,
-                );
+                let claim_amount =
+                    protected_event.claim_amount_in_loss_range(settlement_config, active_stake);
 
                 if active_stake > 0 && claim_amount > 0 {
                     claims.push(SettlementClaim {

--- a/settlement-distributions/bid-psr-distribution/src/utils.rs
+++ b/settlement-distributions/bid-psr-distribution/src/utils.rs
@@ -1,5 +1,6 @@
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use serde::{de::DeserializeOwned, Serialize};
 use std::path::Path;
 use std::{
@@ -62,7 +63,7 @@ pub fn bps_decimal(value: Decimal, max: Decimal) -> u64 {
 }
 
 pub fn bps_to_fraction(value: u64) -> Decimal {
-    Decimal::from(value) / Decimal::from(10000)
+    Decimal::from(value) / dec!(10000)
 }
 
 pub fn file_error<'a>(


### PR DESCRIPTION
Implements a CommissionRugPenalty, as described in the related documents on notion...

The task is here: https://www.notion.so/marinade/P-II-a-Implement-CommissionRugPenalty-into-validator-bonds-217e465715a48003959bdacc980a1b75?source=copy_link

An excerpt follows...

How is the CommissionRugPenalty penalty calculated?

The commission change settlement will increase by 10% for changes until 7% commission and an additional 90% for changes resulting in commission above 7%. For example, if a validator increases their commission by 2% from 5% to 7% they will pay 110% of the lost rewards. If they increase from 0% to 100%, they will pay 200% of the lost rewards. This approach allows honest validators to make commission adjustments while deterring commission rugs.