### PR TITLE
[pipelines] fix reporting enum maps creations

### DIFF
--- a/settlement-pipelines/src/reporting_data.rs
+++ b/settlement-pipelines/src/reporting_data.rs
@@ -133,14 +133,11 @@ impl SettlementsReportData {
         settlement_records: &HashSet<SettlementRecord>,
         pubkeys: &[Pubkey],
     ) -> HashMap<ReportingReasonSettlement, HashSet<Pubkey>> {
-        let mut result: HashMap<ReportingReasonSettlement, HashSet<Pubkey>> = HashMap::new();
-        result.insert(ReportingReasonSettlement::ProtectedEvent, HashSet::new());
-        result.insert(ReportingReasonSettlement::BidTooLowPenalty, HashSet::new());
-        result.insert(ReportingReasonSettlement::Bidding, HashSet::new());
-        result.insert(
-            ReportingReasonSettlement::InstitutionalPayout,
-            HashSet::new(),
-        );
+        let mut result: HashMap<ReportingReasonSettlement, HashSet<Pubkey>> =
+            ReportingReasonSettlement::items()
+                .into_iter()
+                .map(|reason| (reason, HashSet::new()))
+                .collect();
 
         // Mapping provided pubkeys to type based on the settlement records
         for pubkey in pubkeys {


### PR DESCRIPTION
A fix on creating data buckets for reporting of settlements that were processed.

Fixing error

```
[2025-06-26T12:11:29Z INFO  settlement_pipelines::reporting] ClaimSettlement HADnmpF6WYk4U7iTqLou7ywiowfjZYenD8fnhRPu6QMq: txes 0/ixes 0 executed successfully
thread 'main' panicked at settlement-pipelines/src/reporting_data.rs:166:46:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
claim-settlement: completed with critical errors
🚨 Error: The command exited with status 1
user command error: exit status 1
```