### PR TITLE
CLI: permit validator identity to be used when showing bond info [GEN-6189]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## TS CLI&SDK [2.1.10](https://github.com/marinade-finance/validator-bonds/compare/v2.1.9...v2.1.10) (2025-09-02)
+
+### Updates
+
+* cli: `show-bond` command to display the bond information when provided validator identity address
+
 ## TS CLI&SDK [2.1.9](https://github.com/marinade-finance/validator-bonds/compare/v2.1.8...v2.1.9) (2025-07-26)
 
 ### Fixes

--- a/packages/validator-bonds-cli-core/package.json
+++ b/packages/validator-bonds-cli-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-core",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Common CLI Core of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-core/src/utils.ts
+++ b/packages/validator-bonds-cli-core/src/utils.ts
@@ -59,7 +59,7 @@ export async function getBondFromAddress({
   let voteAccountAddress: PublicKey | null = null
   if (
     accountInfo === null || // no account exists at the address
-    (accountInfo !== null && accountInfo.owner.equals(SystemProgram.programId))
+    accountInfo.owner.equals(SystemProgram.programId)
   ) {
     const voteAccount = await findVoteAccountByIdentity({
       connection: program.provider.connection,

--- a/packages/validator-bonds-cli-institutional/README.md
+++ b/packages/validator-bonds-cli-institutional/README.md
@@ -25,7 +25,7 @@ To get info on available commands
 ```sh
 # to verify installed version
 validator-bonds-institutional --version
-2.1.9
+2.1.10
 
 # get reference of available commands
 validator-bonds-institutional --help

--- a/packages/validator-bonds-cli-institutional/package.json
+++ b/packages/validator-bonds-cli-institutional/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-institutional",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "CLI of the validator bonds contract streamlined for institutional users",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-institutional/src/index.ts
+++ b/packages/validator-bonds-cli-institutional/src/index.ts
@@ -8,7 +8,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli-institutional'
 
 launchCliProgram({
-  version: '2.1.9',
+  version: '2.1.10',
   installAdditionalOptions: program => {
     program.setOptionValueWithSource(
       'programId',

--- a/packages/validator-bonds-cli/README.md
+++ b/packages/validator-bonds-cli/README.md
@@ -23,7 +23,7 @@ added 165 packages in 35s
 
 # to verify installed version
 validator-bonds --version
-2.1.9
+2.1.10
 ```
 
 To get info on available commands
@@ -711,7 +711,7 @@ To check where NPM packages are and will be installed:
 # Get npm global installation folder
 npm list -g
 > /usr/lib
-> +-- @marinade.finance/validator-bonds-cli@2.1.9
+> +-- @marinade.finance/validator-bonds-cli@2.1.10
 > ...
 # In this case, the `bin` folder is located at /usr/bin
 ```
@@ -737,7 +737,7 @@ With this configuration, NPM packages will be installed under the `prefix` direc
 npm i -g @marinade.finance/validator-bonds-cli@latest
 npm list -g
 > ~/.local/share/npm/lib
-> `-- @marinade.finance/validator-bonds-cli@2.1.9
+> `-- @marinade.finance/validator-bonds-cli@2.1.10
 ```
 
 To execute the installed packages from any location,
@@ -904,7 +904,7 @@ Commands:
   # Get npm global installation folder
   npm list -g
   > ~/.local/share/npm/lib
-  > `-- @marinade.finance/validator-bonds-cli@2.1.9
+  > `-- @marinade.finance/validator-bonds-cli@2.1.10
   # In this case, the 'bin' folder is located at ~/.local/share/npm/bin
 
   # Get validator-bonds binary folder

--- a/packages/validator-bonds-cli/__tests__/test-validator/show.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/show.spec.ts
@@ -362,6 +362,32 @@ describe('Show command using CLI', () => {
       // stderr: '',
       stdout: YAML.stringify(expectedDataFundingSingleItem),
     })
+    await (
+      expect([
+        'pnpm',
+        [
+          '--silent',
+          'cli',
+          '-u',
+          provider.connection.rpcEndpoint,
+          '--program-id',
+          program.programId.toBase58(),
+          'show-bond',
+          '--config',
+          configAccount.toBase58(),
+          validatorIdentity.publicKey.toBase58(),
+          '--with-funding',
+          '-f',
+          'yaml',
+        ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ]) as any
+    ).toHaveMatchingSpawnOutput({
+      code: 0,
+      signal: '',
+      // stderr: '',
+      stdout: YAML.stringify(expectedDataFundingSingleItem),
+    })
 
     await (
       expect([
@@ -485,11 +511,11 @@ describe('Show command using CLI', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any
     ).toHaveMatchingSpawnOutput({
-      code: 1,
+      code: 200,
       signal: '',
       // stderr: '',
       stdout:
-        /Account of type bond or voteAccount or withdrawRequest was not found/,
+        /Provided address is neither a bond, vote account, withdraw request, stake account nor validator identity/,
     })
   })
 

--- a/packages/validator-bonds-cli/package.json
+++ b/packages/validator-bonds-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "CLI of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli/src/index.ts
+++ b/packages/validator-bonds-cli/src/index.ts
@@ -9,7 +9,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli'
 
 launchCliProgram({
-  version: '2.1.9',
+  version: '2.1.10',
   installAdditionalOptions: program => {
     program.option(
       '--program-id <pubkey>',

--- a/packages/validator-bonds-sdk/package.json
+++ b/packages/validator-bonds-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-sdk",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "SDK of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-sdk/src/web3.js/voteAccount.ts
+++ b/packages/validator-bonds-sdk/src/web3.js/voteAccount.ts
@@ -1,4 +1,16 @@
-import { Provider } from '@marinade.finance/web3js-common'
+import { LoggerPlaceholder, logDebug } from '@marinade.finance/ts-common'
+import {
+  HasProvider,
+  Provider,
+  getConnection,
+  ProgramAccountInfo,
+} from '@marinade.finance/web3js-common'
+import {
+  Connection,
+  GetProgramAccountsFilter,
+  PublicKey,
+  VOTE_PROGRAM_ID,
+} from '@solana/web3.js'
 
 // Depending if new vote account feature-set is gated on.
 // It can be 3762 or 3736
@@ -6,6 +18,8 @@ import { Provider } from '@marinade.finance/web3js-common'
 // It may emit error:
 //  Failed to process transaction: transport transaction error: Error processing Instruction 1: invalid account data for instruction
 export const VOTE_ACCOUNT_SIZE = 3762
+// https://github.com/solana-labs/solana/blob/v1.17.10/sdk/program/src/vote/state/vote_state_versions.rs#L4
+const VALIDATOR_IDENTITY_OFFSET = 4
 
 export async function getRentExemptVote(
   provider: Provider,
@@ -17,4 +31,42 @@ export async function getRentExemptVote(
       VOTE_ACCOUNT_SIZE,
     ))
   )
+}
+
+export async function findVoteAccountByIdentity({
+  connection,
+  identity,
+  logger,
+}: {
+  connection: Provider | Connection | HasProvider
+  identity: PublicKey
+  logger?: LoggerPlaceholder
+}): Promise<ProgramAccountInfo<Buffer> | undefined> {
+  const filters: GetProgramAccountsFilter[] = []
+  filters.push({
+    memcmp: {
+      offset: VALIDATOR_IDENTITY_OFFSET,
+      bytes: identity.toBase58(),
+    },
+  })
+
+  connection = getConnection(connection)
+  const accounts = await connection.getProgramAccounts(VOTE_PROGRAM_ID, {
+    filters,
+  })
+
+  if (accounts.length === 0 || accounts.length > 1) {
+    logDebug(
+      logger,
+      `Found ${accounts.length} (${accounts.map(a => a.pubkey.toBase58()).join(', ')}) vote accounts for identity ${identity.toBase58()}.` +
+        'Expectation was to have potentially find one vote account for the identity.',
+    )
+    return undefined
+  }
+
+  const voteAccountData = accounts[0]
+  return {
+    publicKey: voteAccountData.pubkey,
+    account: voteAccountData.account,
+  }
 }

--- a/packages/validator-bonds-sdk/src/web3.js/voteAccount.ts
+++ b/packages/validator-bonds-sdk/src/web3.js/voteAccount.ts
@@ -42,13 +42,14 @@ export async function findVoteAccountByIdentity({
   identity: PublicKey
   logger?: LoggerPlaceholder
 }): Promise<ProgramAccountInfo<Buffer> | undefined> {
-  const filters: GetProgramAccountsFilter[] = []
-  filters.push({
-    memcmp: {
-      offset: VALIDATOR_IDENTITY_OFFSET,
-      bytes: identity.toBase58(),
+  const filters: GetProgramAccountsFilter[] = [
+    {
+      memcmp: {
+        offset: VALIDATOR_IDENTITY_OFFSET,
+        bytes: identity.toBase58(),
+      },
     },
-  })
+  ]
 
   connection = getConnection(connection)
   const accounts = await connection.getProgramAccounts(VOTE_PROGRAM_ID, {


### PR DESCRIPTION
Making it possible to use the validator identity to show the bond account