### PR TITLE
[pnpm] approve build scripts of bigint-buffer, bufferutil, node-hid, utf-8-validate [trivial]

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,13 @@
             "cross-spawn@<7.0.5": "7.0.5",
             "braces@<3.0.3": "3.0.3",
             "micromatch@<4.0.8": "4.0.8"
-        }
+        },
+        "onlyBuiltDependencies": [
+            "bigint-buffer",
+            "bufferutil",
+            "node-hid",
+            "utf-8-validate"
+        ]
     },
     "engines": {
         "node": ">=16"


### PR DESCRIPTION
With pnpm 9+ (?) there is a need to approve build script to be processed from 3rd party dependencies. Allowing them for the repository.