### PR TITLE
[pipeline] second fix of generate report script [SUP-82]

### DIFF
--- a/.buildkite/prepare-bid-distribution.yml
+++ b/.buildkite/prepare-bid-distribution.yml
@@ -119,11 +119,7 @@ steps:
     commands:
     - 'buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}-settlements.json .'
     - |
-      if [[ "$MARINADE_FEE_BPS" == "10000" ]]; then
-        ./scripts/generate-discord-public-report.bash "./${CLAIM_TYPE}-settlements.json" "Bidding" > "./discord-public-report.txt"
-      else
-        ./scripts/generate-discord-public-report.bash "./${CLAIM_TYPE}-settlements.json" "Bidding" true > "./discord-public-report.txt"
-      fi
+      ./scripts/generate-discord-public-report.bash "./${CLAIM_TYPE}-settlements.json" "Bidding" > "./discord-public-report.txt"
     artifact_paths:
       - "./discord-public-report.txt"
 

--- a/.buildkite/prepare-institutional-distribution.yml
+++ b/.buildkite/prepare-institutional-distribution.yml
@@ -89,7 +89,7 @@ steps:
     commands:
     - buildkite-agent artifact download --include-retried-jobs ${CLAIM_TYPE}-settlements.json .
     - |
-      ./scripts/generate-discord-public-report.bash "./${CLAIM_TYPE}-settlements.json" "Institutional" true > "./discord-public-report.txt"
+      ./scripts/generate-discord-public-report.bash "./${CLAIM_TYPE}-settlements.json" "Institutional" > "./discord-public-report.txt"
     artifact_paths:
       - "./discord-public-report.txt"
 

--- a/settlement-distributions/institutional-distribution/README.md
+++ b/settlement-distributions/institutional-distribution/README.md
@@ -75,5 +75,5 @@ merkle tree generation CLI you can do:
    export MARINADE_FEE_WITHDRAW_AUTHORITY=$(solana-keygen pubkey)
    export DAO_FEE_STAKE_AUTHORITY=$(solana-keygen pubkey)
    export DAO_FEE_WITHDRAW_AUTHORITY=$(solana-keygen pubkey)
-   ./scripts/generate-discord-public-report.bash "$TARGET"/institutional-settlements.json "Institutional" true
+   ./scripts/generate-discord-public-report.bash "$TARGET"/institutional-settlements.json "Institutional"
    ```


### PR DESCRIPTION
After PR #270, there is a second update of the script. The trouble of the JSON data is that until now we know that we have 100% of fee and we can decide to sum marinade fee claims with non-fee ones. Otherwise only non-fee ones are used.
With validator bid small and no share to user stake accounts is provided we need to come with a different approach to a) not double calculate and b) not showing 0 when no share to user stake is happening this epoch.