### PR TITLE
[tsconfig] not needed tsconfig [trivial][GEN-5521]

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": [
-    "node_modules",
-    "dist",
-    "packages/**/__tests__",
-    "settlement-pipelines/**"
-  ]
-}


### PR DESCRIPTION
The `tsconfig.build.json` was needed before eslinting refactoring. This is only a cleanup of the repository.