### PR TITLE
[pipelines] better reporting when verify finds some error [trivial]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ fuzzing/
 
 # Local
 *.local.json
+*.lock
 
 # Testing
 regression-data*

--- a/settlement-pipelines/src/bin/verify_settlement.rs
+++ b/settlement-pipelines/src/bin/verify_settlement.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use clap::Parser;
 use log::{error, info};
-use merkle_tree::serde_serialize::pubkey_string_conversion;
+use merkle_tree::serde_serialize::{option_pubkey_string_conversion, pubkey_string_conversion};
 use serde::{Deserialize, Serialize};
 use settlement_common::utils::read_from_json_file;
 use settlement_pipelines::arguments::{get_rpc_client, GlobalOpts, ReportOpts};
@@ -48,11 +48,25 @@ struct SettlementEpoch {
     epoch: u64,
     #[serde(with = "pubkey_string_conversion")]
     address: Pubkey,
+    #[serde(with = "option_pubkey_string_conversion")]
+    vote_account: Option<Pubkey>,
+    #[serde(with = "option_pubkey_string_conversion")]
+    bond: Option<Pubkey>,
 }
 
 impl SettlementEpoch {
-    fn new(epoch: u64, address: Pubkey) -> Self {
-        Self { epoch, address }
+    fn new(
+        epoch: u64,
+        address: Pubkey,
+        vote_account: Option<Pubkey>,
+        bond: Option<Pubkey>,
+    ) -> Self {
+        Self {
+            epoch,
+            address,
+            vote_account,
+            bond,
+        }
     }
 }
 
@@ -97,6 +111,8 @@ fn verify_unknown_settlements(
             unknown_settlements.push(SettlementEpoch::new(
                 settlement.epoch_created_for,
                 *settlement_pubkey,
+                None,
+                Some(settlement.bond),
             ));
         }
     }
@@ -139,6 +155,8 @@ fn verify_epoch_settlements(
                     non_funded_settlements.push(SettlementEpoch::new(
                         epoch_to_verify,
                         listed_settlement.settlement_address,
+                        Some(listed_settlement.vote_account_address),
+                        Some(listed_settlement.bond_address),
                     ));
                 }
             } else {
@@ -149,6 +167,8 @@ fn verify_epoch_settlements(
                 non_existing_settlements.push(SettlementEpoch::new(
                     epoch_to_verify,
                     listed_settlement.settlement_address,
+                    Some(listed_settlement.vote_account_address),
+                    Some(listed_settlement.bond_address),
                 ));
             }
         }


### PR DESCRIPTION
When `verify` finds issues with unfunded bonds, etc., I would like to get information on which vote account/bond is the problem.