### PR TITLE
[events] enhance notifications + ds dam update [GEN-7357]

### DIFF
--- a/migrations/0007-add-cap-marinade-stake-sol.sql
+++ b/migrations/0007-add-cap-marinade-stake-sol.sql
@@ -1,0 +1,7 @@
+-- Track the marinadeStakeSol value at the limiting cap constraint so that
+-- cap_changed events can emit the numeric previous vs current cap in SOL.
+-- AuctionConstraint.marinadeStakeSol is what the ds-sam SDK reports for the
+-- limiting constraint (previously `ASO`, `BOND`, etc.) at the time the cap
+-- was decided.
+ALTER TABLE bond_event_state
+    ADD COLUMN IF NOT EXISTS cap_marinade_stake_sol DOUBLE PRECISION;

--- a/package.json
+++ b/package.json
@@ -65,11 +65,7 @@
       }
     },
     "overrides": {
-      "cross-spawn@<7.0.5": "7.0.5",
-      "braces@<3.0.3": "3.0.3",
-      "micromatch@<4.0.8": "4.0.8",
-      "glob@<8": "^10.3.10",
-      "inflight": "npm:inflight-v2@^1.0.0"
+      "glob@<8": "^10.3.10"
     },
     "onlyBuiltDependencies": [
       "bigint-buffer",

--- a/packages/bonds-eventing/README.md
+++ b/packages/bonds-eventing/README.md
@@ -16,6 +16,10 @@ DB table and only emits events when something changes between runs.
 - State is saved per validator. If a validator's event fails to POST, only that validator's state save is skipped (so its delta is retried on next run). Other validators whose events succeeded get their state saved normally.
 - The state snapshot stored per validator is always the same shape (balance, auction status, bondGoodForNEpochs, cap constraint, SAM eligibility) regardless of which event fires. Events are derived from comparing the previous and current snapshots — the event type is orthogonal to the stored state.
 
+#### Engineering Todo
+
+- **Outbox cleanup**: The `notifications_outbox` table in `marinade-notifications` accumulates rows unconditionally (even for events with no subscribers). A periodic cleanup job should be implemented to delete expired rows where `relevance_until < now()` or `deactivated_at IS NOT NULL`.
+
 ## Event types
 
 ### Events emitted automatically
@@ -88,6 +92,27 @@ It's meant to be POSTed manually by admins directly to the notifications API.
 See [DEV_GUIDE.md — Publishing a CLI announcement banner](../../DEV_GUIDE.md#publishing-a-cli-announcement-banner)
 for the curl recipe and retraction steps.
 
-## MISSING / TODO
+## Troubleshooting
 
-- **Outbox cleanup**: The `notifications_outbox` table in `marinade-notifications` accumulates rows unconditionally (even for events with no subscribers). A periodic cleanup job should be implemented to delete expired rows where `relevance_until < now()` or `deactivated_at IS NOT NULL`.
+- **`Validator X is predicted to incur a bond risk fee Y SOL this epoch.`**<a id='troubleshooting-bond-risk-fee'></a>
+
+  Example body emitted by the `penalty_expected` event:
+
+  ```
+  Validator 8szGkuLTAux9XMgZ2vtY39jVSowEcpBfFfD8hXSEqdGC is predicted to
+  incur a bond risk fee 23.7997 SOL this epoch.
+  ```
+
+  **Meaning.** When this event fires, two things happen in settlement:
+  1. A portion of the validator's Marinade stake gets undelegated — stake moves away from the validator this epoch.
+  2. A fee (the amount shown, e.g. 23.8 SOL) is debited from the bond and given to stakers as compensation for the cost of moving that stake.
+
+  This is not a punishment. It is _risk compensation_ — stakers had been trusting the bond to cover risk, the bond got too thin, so the protocol rebalances: move stake to a properly-bonded validator and charge the under-bonded one for the disruption. See the [Bond Risk Reduction Mechanism](https://docs.marinade.finance/marinade-protocol/protocol-overview/stake-auction-market/bond-risk-reduction-mechanism) docs for the full formula and configuration.
+
+  The fee triggered because the bond dropped below **5 epochs of coverage** for the validator's current Marinade stake allocation.
+
+  **Solution:**
+  1. **Top up the bond.** The target is **≥ 13 epochs** of coverage — this keeps the validator both fee-safe and eligible to receive new stake from the auction. Rule of thumb: _maintain a bond that covers your own bid for 13 epochs across the current stake allocation._ Because `expectedMaxEffBidPmpe` in the auction formula can never exceed the validator's own bid, bonding for the validator's own bid is always sufficient.
+  2. Monitor bond coverage on the [PSR Dashboard](https://psr.marinade.finance/) and Subscribe to [Bond Notifications](https://docs.marinade.finance/marinade-protocol/protocol-overview/stake-auction-market/bond-notifications)
+
+  Related field in the SAM auction output: `bondGoodForNEpochs` is the same signal on a shifted scale — `0` is the fee threshold, negative means a fee is due this epoch, positive is headroom.

--- a/packages/bonds-eventing/__tests__/evaluate-deltas.spec.ts
+++ b/packages/bonds-eventing/__tests__/evaluate-deltas.spec.ts
@@ -91,6 +91,7 @@ function makePrevState(
     in_auction: true,
     bond_good_for_n_epochs: 5,
     cap_constraint: null,
+    cap_marinade_stake_sol: null,
     funded_amount_lamports: 10_000_000_000n,
     effective_amount_lamports: 10_000_000_000n,
     auction_stake_lamports: 1_000_000_000_000n,
@@ -278,6 +279,48 @@ describe('evaluateDeltas', () => {
     const capDetails = capChanged!.data.details as CapChangedDetails
     expect(capDetails.previous_cap).toBeNull()
     expect(capDetails.current_cap).toBe('BOND')
+  })
+
+  it('emits cap_changed with numeric context and driver data', () => {
+    const validators = [
+      makeValidator({
+        bondBalanceSol: 4.0,
+        lastCapConstraint: {
+          constraintType: 'BOND',
+          constraintName: 'bond_cap',
+          marinadeStakeSol: 5_867,
+          totalLeftToCapSol: 1_000,
+        },
+      }),
+    ]
+    const previousState = new Map<string, ValidatorState>()
+    previousState.set(
+      TEST_VOTE_ACCOUNT,
+      makePrevState({
+        cap_constraint: 'ASO',
+        cap_marinade_stake_sol: 12_345,
+        funded_amount_lamports: 10_000_000_000n, // 10 SOL
+      }),
+    )
+
+    const events = evaluateDeltas(
+      validators,
+      previousState,
+      930,
+      'bidding',
+      logger,
+    )
+
+    const capChanged = events.find(e => e.inner_type === 'cap_changed')
+    const d = capChanged!.data.details as CapChangedDetails
+    expect(d.previous_cap_type).toBe('ASO')
+    expect(d.current_cap_type).toBe('BOND')
+    expect(d.previous_cap_sol).toBe(12_345)
+    expect(d.current_cap_sol).toBe(5_867)
+    expect(d.total_left_to_cap_sol).toBe(1_000)
+    expect(d.bond_balance_sol).toBe(4.0)
+    expect(d.bond_balance_delta_sol).toBe(-6.0)
+    expect(d.required_coverage_sol).not.toBeNull()
   })
 
   it('emits bond_underfunded_change when epochs change', () => {
@@ -688,6 +731,135 @@ describe('evaluateDeltas', () => {
     expect(details.bid_too_low_penalty_sol).toBe(0)
     expect(details.blacklist_penalty_sol).toBe(0)
     expect(details.total_penalty_sol).toBe(5.5)
+  })
+
+  // Skipped while ACTIVATING_STAKE_FEE_ENABLED=false in evaluate-deltas.ts.
+  // Re-enable this assertion once settlement-side support for the activating-
+  // stake fee is in place. See src/evaluate-deltas.ts for the flag.
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('emits penalty_expected with activating-stake fee fields', () => {
+    // activating_stake_sol = max(0, SAM target 60000 - already activated 50000) = 10000
+    // activating_stake_fee_sol = 10000 * 2.0 / 1000 = 20
+    // total_penalty_sol must NOT include the activating-stake fee (it is a separate line item).
+    const validators = [
+      makeValidator({
+        marinadeActivatedStakeSol: 50000,
+        auctionStake: {
+          marinadeSamTargetSol: 60000,
+          externalActivatedSol: 0,
+        },
+        revShare: {
+          expectedMaxEffBidPmpe: 3.2,
+          onchainDistributedPmpe: 0.5,
+          bidTooLowPenaltyPmpe: 0.5,
+          blacklistPenaltyPmpe: 0,
+          activatingStakePmpe: 2.0,
+        },
+        values: { bondRiskFeeSol: 0 },
+      }),
+    ]
+    const previousState = new Map<string, ValidatorState>()
+    previousState.set(TEST_VOTE_ACCOUNT, makePrevState())
+
+    const events = evaluateDeltas(
+      validators,
+      previousState,
+      930,
+      'bidding',
+      logger,
+    )
+
+    const penalty = events.find(e => e.inner_type === 'penalty_expected')
+    expect(penalty).toBeDefined()
+    const details = penalty!.data.details as PenaltyExpectedDetails
+    expect(details.activating_stake_sol).toBe(10000)
+    expect(details.activating_stake_pmpe).toBe(2.0)
+    expect(details.activating_stake_fee_sol).toBe(20)
+    // bid_too_low only: 0.5/1000 * 50000 = 25 SOL; activating-stake fee (20) is NOT rolled in.
+    expect(details.total_penalty_sol).toBe(25)
+  })
+
+  // Skipped while ACTIVATING_STAKE_FEE_ENABLED=false in evaluate-deltas.ts.
+  // Re-enable this assertion once settlement-side support for the activating-
+  // stake fee is in place. See src/evaluate-deltas.ts for the flag.
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('emits penalty_expected when only activating-stake fee is present (no bond-side penalty)', () => {
+    // penalties.total = 0 (no bidTooLow, no blacklist, no bondRiskFee)
+    // activating_stake_sol = max(0, 60000 - 50000) = 10000; pmpe 3.0 => activating-stake fee = 30 SOL
+    const validators = [
+      makeValidator({
+        marinadeActivatedStakeSol: 50000,
+        auctionStake: {
+          marinadeSamTargetSol: 60000,
+          externalActivatedSol: 0,
+        },
+        revShare: {
+          expectedMaxEffBidPmpe: 3.2,
+          onchainDistributedPmpe: 0.5,
+          bidTooLowPenaltyPmpe: 0,
+          blacklistPenaltyPmpe: 0,
+          activatingStakePmpe: 3.0,
+        },
+        values: { bondRiskFeeSol: 0 },
+      }),
+    ]
+    const previousState = new Map<string, ValidatorState>()
+    previousState.set(TEST_VOTE_ACCOUNT, makePrevState())
+
+    const events = evaluateDeltas(
+      validators,
+      previousState,
+      930,
+      'bidding',
+      logger,
+    )
+
+    const penalty = events.find(e => e.inner_type === 'penalty_expected')
+    expect(penalty).toBeDefined()
+    const details = penalty!.data.details as PenaltyExpectedDetails
+    expect(details.total_penalty_sol).toBe(0)
+    expect(details.activating_stake_fee_sol).toBe(30)
+    // Emitter message uses the "activating-stake fee" wording and the
+    // pure-fee template (no bond-side charges)
+    expect(penalty!.data.message).toContain(
+      'activating-stake fee of 30.0000 SOL',
+    )
+    expect(penalty!.data.message).toContain('separate from bond penalties')
+  })
+
+  it('emits penalty_expected with zero activating-stake fields when SAM target <= activated', () => {
+    const validators = [
+      makeValidator({
+        marinadeActivatedStakeSol: 50000,
+        auctionStake: {
+          marinadeSamTargetSol: 40000,
+          externalActivatedSol: 0,
+        },
+        revShare: {
+          expectedMaxEffBidPmpe: 3.2,
+          onchainDistributedPmpe: 0.5,
+          bidTooLowPenaltyPmpe: 0.5,
+          blacklistPenaltyPmpe: 0,
+          activatingStakePmpe: 2.0,
+        },
+        values: { bondRiskFeeSol: 0 },
+      }),
+    ]
+    const previousState = new Map<string, ValidatorState>()
+    previousState.set(TEST_VOTE_ACCOUNT, makePrevState())
+
+    const events = evaluateDeltas(
+      validators,
+      previousState,
+      930,
+      'bidding',
+      logger,
+    )
+
+    const details = events.find(e => e.inner_type === 'penalty_expected')!.data
+      .details as PenaltyExpectedDetails
+    expect(details.activating_stake_sol).toBe(0)
+    expect(details.activating_stake_fee_sol).toBe(0)
   })
 
   it('emits multiple events for multiple changes on same validator', () => {

--- a/packages/bonds-eventing/package.json
+++ b/packages/bonds-eventing/package.json
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@marinade.finance/cli-common": "4.2.5",
-    "@marinade.finance/ds-sam-sdk": "0.0.46",
+    "@marinade.finance/ds-sam-sdk": "0.0.48",
     "@marinade.finance/ts-common": "4.2.5",
     "@marinade.finance/validator-bonds-sdk": "workspace:*",
-    "@marinade.finance/notifications-bonds-event-v1": "1.0.2",
+    "@marinade.finance/notifications-bonds-event-v1": "1.0.3",
     "@solana/web3.js": "1.98.4",
     "commander": "14.0.1",
     "pino": "9.9.5",

--- a/packages/bonds-eventing/src/evaluate-deltas.ts
+++ b/packages/bonds-eventing/src/evaluate-deltas.ts
@@ -25,6 +25,13 @@ import type { LoggerWrapper } from '@marinade.finance/ts-common'
 
 const LAMPORTS_PER_SOL = 1_000_000_000
 
+// Activating-stake fee: settlement-side support is not yet enabled, so the
+// emitter suppresses the fee from notifications (event, message body, and the
+// three payload fields stay at 0). Leave the calculation in place so
+// re-enabling is a one-line flip. TODO: when re-enabling, also revisit the
+// message copy — "fee" already; just confirm UX wording.
+const ACTIVATING_STAKE_FEE_ENABLED = false
+
 function solToLamports(sol: number | null | undefined): bigint {
   if (sol === null || sol === undefined || !isFinite(sol)) return 0n
   return BigInt(Math.round(sol * LAMPORTS_PER_SOL))
@@ -62,8 +69,84 @@ function isInAuction(v: AuctionValidator): boolean {
   return (v.auctionStake?.marinadeSamTargetSol ?? 0) > 0
 }
 
+/**
+ * Build the user-facing message for a penalty_expected event from the
+ * four possible charge components. Terminology:
+ *  - bid_too_low / blacklist   → "penalty" (punishment for validator behavior)
+ *  - bond_risk_fee             → "fee"     (cost of carrying risk)
+ *  - activating_stake_fee      → "fee"     (separate from bond-side total)
+ * Single bond-side component   → dedicated one-liner, no redundant total.
+ * Multiple bond-side components → "charges totaling X SOL … : a, b, c.".
+ * Activating-stake fee present → separate trailing sentence.
+ */
+function buildPenaltyExpectedMessage(
+  voteAccount: string,
+  penalties: {
+    total: number
+    bidTooLow: number
+    blacklist: number
+    bondRiskFee: number
+  },
+  activatingStakeFee: number,
+): string {
+  const components: string[] = []
+  if (penalties.bidTooLow > 0) {
+    components.push(`bid-too-low penalty ${penalties.bidTooLow.toFixed(4)} SOL`)
+  }
+  if (penalties.blacklist > 0) {
+    components.push(`blacklist penalty ${penalties.blacklist.toFixed(4)} SOL`)
+  }
+  if (penalties.bondRiskFee > 0) {
+    components.push(`bond risk fee ${penalties.bondRiskFee.toFixed(4)} SOL`)
+  }
+
+  let bondSideSentence: string | null = null
+  if (components.length === 1) {
+    bondSideSentence = `Validator ${voteAccount} is predicted to incur a ${components[0]} this epoch.`
+  } else if (components.length >= 2) {
+    bondSideSentence =
+      `Validator ${voteAccount} is predicted to incur charges totaling ${penalties.total.toFixed(4)} SOL this epoch: ` +
+      `${components.join(', ')}.`
+  }
+
+  if (activatingStakeFee > 0) {
+    const feeSentence =
+      bondSideSentence !== null
+        ? `In addition, an activating-stake fee of ${activatingStakeFee.toFixed(4)} SOL will be charged (separate from bond penalties).`
+        : `Validator ${voteAccount} is predicted to be charged an activating-stake fee of ${activatingStakeFee.toFixed(4)} SOL this epoch (separate from bond penalties).`
+    return bondSideSentence !== null
+      ? `${bondSideSentence} ${feeSentence}`
+      : feeSentence
+  }
+
+  // emit condition guarantees at least one of the components > 0
+  return bondSideSentence ?? ''
+}
+
 function getCapConstraint(v: AuctionValidator): string | null {
   return v.lastCapConstraint?.constraintType ?? null
+}
+
+function getCapMarinadeStakeSol(v: AuctionValidator): number | null {
+  return v.lastCapConstraint?.marinadeStakeSol ?? null
+}
+
+const VALID_CAP_TYPES = new Set([
+  'COUNTRY',
+  'ASO',
+  'VALIDATOR',
+  'BOND',
+  'WANT',
+  'RISK',
+])
+
+function asCapType(
+  value: string | null,
+): CapChangedDetails['current_cap_type'] {
+  if (value === null) return null
+  return VALID_CAP_TYPES.has(value)
+    ? (value as NonNullable<CapChangedDetails['current_cap_type']>)
+    : null
 }
 
 /**
@@ -266,6 +349,12 @@ export function evaluateDeltas(
 
     // Cap constraint changes
     if (prev.cap_constraint !== currentCap) {
+      const currentCapSol = getCapMarinadeStakeSol(v)
+      const bondBalanceSol = v.bondBalanceSol ?? null
+      const prevBondBalanceSol = lamportsToSol(prev.funded_amount_lamports)
+      const bondBalanceDeltaSol =
+        bondBalanceSol !== null ? bondBalanceSol - prevBondBalanceSol : null
+      const coverageMetrics = computeDeficitMetrics(v)
       events.push(
         makeEvent(
           'cap_changed',
@@ -279,6 +368,15 @@ export function evaluateDeltas(
             previous_cap: prev.cap_constraint,
             current_cap: currentCap,
             constraint_name: v.lastCapConstraint?.constraintName ?? null,
+            previous_cap_type: asCapType(prev.cap_constraint),
+            current_cap_type: asCapType(currentCap),
+            previous_cap_sol: prev.cap_marinade_stake_sol,
+            current_cap_sol: currentCapSol,
+            total_left_to_cap_sol:
+              v.lastCapConstraint?.totalLeftToCapSol ?? null,
+            bond_balance_sol: bondBalanceSol,
+            bond_balance_delta_sol: bondBalanceDeltaSol,
+            required_coverage_sol: coverageMetrics.epoch_cost_sol,
           } satisfies CapChangedDetails,
         ),
       )
@@ -398,7 +496,24 @@ export function evaluateDeltas(
     // Only emit on epoch change to avoid flooding the queue every run.
     // Brain dedup (per vote_account + epoch + renotify window) is the safety net.
     const penalties = computePenalties(v)
-    if (penalties.total > 0.001 && prev.epoch !== epoch) {
+    // Fee on newly activating stake: charged separately from total_penalty_sol.
+    // activating_stake_sol = max(0, SAM target - already activated); pairs with revShare.activatingStakePmpe.
+    const activatingStakeSol = Math.max(
+      0,
+      (v.auctionStake?.marinadeSamTargetSol ?? 0) - v.marinadeActivatedStakeSol,
+    )
+    const activatingStakePmpe = v.revShare.activatingStakePmpe ?? 0
+    const activatingStakeFee = (activatingStakeSol * activatingStakePmpe) / 1000
+    const effectiveActivatingStakeFee = ACTIVATING_STAKE_FEE_ENABLED
+      ? activatingStakeFee
+      : 0
+    // Emit when EITHER a bond-side penalty/fee OR an activating-stake fee is
+    // predicted. Activating-stake fee is charged separately from the bond-side
+    // total but still represents a real cost the validator should see.
+    if (
+      (penalties.total > 0.001 || effectiveActivatingStakeFee > 0.001) &&
+      prev.epoch !== epoch
+    ) {
       events.push(
         makeEvent(
           'penalty_expected',
@@ -406,18 +521,11 @@ export function evaluateDeltas(
           epoch,
           bondType,
           configAddress,
-          `Validator ${v.voteAccount} is expected to face a penalty of ` +
-            `${penalties.total.toFixed(4)} SOL this epoch` +
-            (penalties.bidTooLow > 0
-              ? ` (bid too low: ${penalties.bidTooLow.toFixed(4)} SOL)`
-              : '') +
-            (penalties.blacklist > 0
-              ? ` (blacklist: ${penalties.blacklist.toFixed(4)} SOL)`
-              : '') +
-            (penalties.bondRiskFee > 0
-              ? ` (bond risk fee: ${penalties.bondRiskFee.toFixed(4)} SOL)`
-              : '') +
-            '.',
+          buildPenaltyExpectedMessage(
+            v.voteAccount,
+            penalties,
+            effectiveActivatingStakeFee,
+          ),
           {
             total_penalty_sol: penalties.total,
             bid_too_low_penalty_sol: penalties.bidTooLow,
@@ -428,6 +536,13 @@ export function evaluateDeltas(
             marinade_activated_stake_sol: v.marinadeActivatedStakeSol,
             bond_balance_sol: v.bondBalanceSol,
             bond_good_for_n_epochs: roundEpochs(v.bondGoodForNEpochs),
+            activating_stake_sol: ACTIVATING_STAKE_FEE_ENABLED
+              ? activatingStakeSol
+              : 0,
+            activating_stake_pmpe: ACTIVATING_STAKE_FEE_ENABLED
+              ? activatingStakePmpe
+              : 0,
+            activating_stake_fee_sol: effectiveActivatingStakeFee,
           } satisfies PenaltyExpectedDetails,
         ),
       )
@@ -510,6 +625,7 @@ export function validatorToState(
     in_auction: isInAuction(v),
     bond_good_for_n_epochs: roundEpochs(v.bondGoodForNEpochs),
     cap_constraint: getCapConstraint(v),
+    cap_marinade_stake_sol: getCapMarinadeStakeSol(v),
     funded_amount_lamports: solToLamports(v.bondBalanceSol),
     effective_amount_lamports: solToLamports(
       v.claimableBondBalanceSol ?? v.bondBalanceSol,

--- a/packages/bonds-eventing/src/state.ts
+++ b/packages/bonds-eventing/src/state.ts
@@ -17,6 +17,7 @@ export async function loadPreviousState(
       in_auction,
       bond_good_for_n_epochs,
       cap_constraint,
+      cap_marinade_stake_sol,
       funded_amount_lamports,
       effective_amount_lamports,
       auction_stake_lamports,
@@ -35,6 +36,7 @@ export async function loadPreviousState(
     in_auction: boolean
     bond_good_for_n_epochs: number | null
     cap_constraint: string | null
+    cap_marinade_stake_sol: number | null
     funded_amount_lamports: string
     effective_amount_lamports: string
     auction_stake_lamports: string
@@ -53,6 +55,7 @@ export async function loadPreviousState(
       in_auction: row.in_auction,
       bond_good_for_n_epochs: row.bond_good_for_n_epochs,
       cap_constraint: row.cap_constraint,
+      cap_marinade_stake_sol: row.cap_marinade_stake_sol,
       funded_amount_lamports: BigInt(row.funded_amount_lamports ?? '0'),
       effective_amount_lamports: BigInt(row.effective_amount_lamports ?? '0'),
       auction_stake_lamports: BigInt(row.auction_stake_lamports ?? '0'),
@@ -88,6 +91,7 @@ export async function saveCurrentState(
       ${state.in_auction},
       ${state.bond_good_for_n_epochs},
       ${state.cap_constraint},
+      ${state.cap_marinade_stake_sol},
       ${state.funded_amount_lamports.toString()},
       ${state.effective_amount_lamports.toString()},
       ${state.auction_stake_lamports.toString()},
@@ -101,6 +105,7 @@ export async function saveCurrentState(
     INSERT INTO bond_event_state (
       vote_account, bond_pubkey, bond_type, epoch,
       in_auction, bond_good_for_n_epochs, cap_constraint,
+      cap_marinade_stake_sol,
       funded_amount_lamports, effective_amount_lamports,
       auction_stake_lamports, deficit_lamports, sam_eligible, updated_at
     ) VALUES
@@ -111,6 +116,7 @@ export async function saveCurrentState(
       in_auction = EXCLUDED.in_auction,
       bond_good_for_n_epochs = EXCLUDED.bond_good_for_n_epochs,
       cap_constraint = EXCLUDED.cap_constraint,
+      cap_marinade_stake_sol = EXCLUDED.cap_marinade_stake_sol,
       funded_amount_lamports = EXCLUDED.funded_amount_lamports,
       effective_amount_lamports = EXCLUDED.effective_amount_lamports,
       auction_stake_lamports = EXCLUDED.auction_stake_lamports,

--- a/packages/bonds-eventing/src/types.ts
+++ b/packages/bonds-eventing/src/types.ts
@@ -26,6 +26,7 @@ export interface ValidatorState {
   in_auction: boolean
   bond_good_for_n_epochs: number | null
   cap_constraint: string | null
+  cap_marinade_stake_sol: number | null
   funded_amount_lamports: bigint
   effective_amount_lamports: bigint
   auction_stake_lamports: bigint

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  cross-spawn@<7.0.5: 7.0.5
-  braces@<3.0.3: 3.0.3
-  micromatch@<4.0.8: 4.0.8
   glob@<8: ^10.3.10
-  inflight: npm:inflight-v2@^1.0.0
 
 importers:
 
@@ -73,11 +69,11 @@ importers:
         specifier: 4.2.5
         version: 4.2.5(@marinade.finance/ts-common@4.2.5)(class-validator@0.14.2)
       '@marinade.finance/ds-sam-sdk':
-        specifier: 0.0.46
-        version: 0.0.46
+        specifier: 0.0.48
+        version: 0.0.48
       '@marinade.finance/notifications-bonds-event-v1':
-        specifier: 1.0.2
-        version: 1.0.2
+        specifier: 1.0.3
+        version: 1.0.3
       '@marinade.finance/ts-common':
         specifier: 4.2.5
         version: 4.2.5
@@ -998,8 +994,8 @@ packages:
       bn.js: ^5.2.1
       jsbi: ^4.3.0
 
-  '@marinade.finance/ds-sam-sdk@0.0.46':
-    resolution: {integrity: sha512-Dj8BfaKS0vTQ9uHsMhoW1fCVNXmAj5GgXzwFnl6wyTbzHfF8Ynd4JQl7POX3JYSoA9gbJfsOso8F4TEF00TM2g==}
+  '@marinade.finance/ds-sam-sdk@0.0.48':
+    resolution: {integrity: sha512-5Zif9CrMaIAAmrHUhFxSzbZK4+hsloNnj/XJjGIEfnww6wB3hwkuBLdu1DoyuJuJ+ga+14W1rnANg2uuBI2fkw==}
 
   '@marinade.finance/eslint-config@1.3.5':
     resolution: {integrity: sha512-yKLW2vI9QmQ6uWO3SQSbOYDmtSpYPU34zuomKGCfoLF7/bN+c6GinyzUumIPoUshqztRkqjOpFels4F4E6puEg==}
@@ -1033,8 +1029,8 @@ packages:
   '@marinade.finance/native-staking-sdk@1.3.3':
     resolution: {integrity: sha512-bnjCiKj4AG7fiBXPjX0AOcsJ/VRYlGV9/vy83YM2Cg30L9tlkVYWEBf+WVcHDMMYAqTlO49nq9zTDCxu9Ui2JA==}
 
-  '@marinade.finance/notifications-bonds-event-v1@1.0.2':
-    resolution: {integrity: sha512-TRzqmu73rqai0qfcRvzMFCz5an7MZoQ1YK/R7l6X7dkS2riXvCIrZtidyv2pw7Neo5vlkAeO4OV1a8z1vwXSOw==}
+  '@marinade.finance/notifications-bonds-event-v1@1.0.3':
+    resolution: {integrity: sha512-JNtXHhMr60Kepi3BCFFQpDXIhWHWG0YzKjfAVZmJAgS8Pu0e2VJOThDSdIoTj9OOmdnIUpkSCyY3YRHoAP+DjA==}
 
   '@marinade.finance/notifications-header-v1@1.0.0':
     resolution: {integrity: sha512-hoHr0gw8SrLEY8JePl0Te4nPT6EPAVL8cKLlURWvwii/NCC4gZkSr5L/t93GBpNqWJpMu48Y1BlnSwUadJ6Vvg==}
@@ -2008,8 +2004,8 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   anchor-bankrun@0.2.0:
     resolution: {integrity: sha512-k/GIiYjkFzj10iluAXPjLjDInZtNNZ2FTcCTrtqgxwm5wofLbD8T0sy13LU9IfQSirj8/6eaTawDo+IvI03KRQ==}
@@ -5495,7 +5491,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@marinade.finance/ds-sam-sdk@0.0.46':
+  '@marinade.finance/ds-sam-sdk@0.0.48':
     dependencies:
       axios: 1.15.0
       decimal.js: 10.6.0
@@ -5594,19 +5590,19 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@marinade.finance/notifications-bonds-event-v1@1.0.2':
+  '@marinade.finance/notifications-bonds-event-v1@1.0.3':
     dependencies:
       '@marinade.finance/notifications-ts-message': 1.0.0
-      ajv: 8.18.0
-      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
 
   '@marinade.finance/notifications-header-v1@1.0.0': {}
 
   '@marinade.finance/notifications-ts-message@1.0.0':
     dependencies:
       '@marinade.finance/notifications-header-v1': 1.0.0
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
 
   '@marinade.finance/notifications-ts-subscription-client@1.0.3': {}
 
@@ -6746,13 +6742,13 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ajv-formats@2.1.1(ajv@8.18.0):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
-  ajv-formats@3.0.1(ajv@8.18.0):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv@6.12.6:
     dependencies:
@@ -6761,7 +6757,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.18.0:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0


### PR DESCRIPTION
A follow-up to marinade-notifications changes at https://github.com/marinade-finance/marinade-notifications/pull/39

Adding events and processing of details for risk fee and cap changing.