### PR TITLE
[cli] banner to strip markdown when provided [trivial]

### DIFF
--- a/packages/validator-bonds-cli-core/__tests__/markdownStrip.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/markdownStrip.spec.ts
@@ -1,0 +1,57 @@
+import { stripMarkdownForTerminal } from '../src/banner'
+
+describe('stripMarkdownForTerminal', () => {
+  it('rewrites markdown links to "label (url)"', () => {
+    expect(
+      stripMarkdownForTerminal(
+        'See [the docs](https://docs.example.com/foo) for details.',
+      ),
+    ).toBe('See the docs (https://docs.example.com/foo) for details.')
+  })
+
+  it('drops the label when it is identical to the url', () => {
+    expect(stripMarkdownForTerminal('[https://x.test](https://x.test)')).toBe(
+      'https://x.test',
+    )
+  })
+
+  it('strips bold and italic emphasis', () => {
+    expect(stripMarkdownForTerminal('**bold** and *italic*')).toBe(
+      'bold and italic',
+    )
+    expect(stripMarkdownForTerminal('__also bold__ and _also italic_')).toBe(
+      'also bold and also italic',
+    )
+  })
+
+  it('does not eat intra-word underscores', () => {
+    expect(stripMarkdownForTerminal('user_id and ENV_VAR')).toBe(
+      'user_id and ENV_VAR',
+    )
+  })
+
+  it('strips inline code, strikethrough, headings and blockquotes', () => {
+    expect(stripMarkdownForTerminal('use `npm install`')).toBe(
+      'use npm install',
+    )
+    expect(stripMarkdownForTerminal('~~old~~ new')).toBe('old new')
+    expect(stripMarkdownForTerminal('## Heading\nbody')).toBe('Heading\nbody')
+    expect(stripMarkdownForTerminal('> a quote\n> second')).toBe(
+      'a quote\nsecond',
+    )
+  })
+
+  it('handles a realistic notification message', () => {
+    const input =
+      '**Action required**: top up your bond. See [the bond docs](https://docs.marinade.finance/bond) before epoch 965.'
+    expect(stripMarkdownForTerminal(input)).toBe(
+      'Action required: top up your bond. See the bond docs (https://docs.marinade.finance/bond) before epoch 965.',
+    )
+  })
+
+  it('leaves plain text untouched', () => {
+    expect(
+      stripMarkdownForTerminal('Plain text — nothing to strip here.'),
+    ).toBe('Plain text — nothing to strip here.')
+  })
+})

--- a/packages/validator-bonds-cli-core/src/banner.ts
+++ b/packages/validator-bonds-cli-core/src/banner.ts
@@ -29,8 +29,10 @@ export async function printNotificationBanners(
 
     const banners = notifications.map(notification =>
       getBanner({
-        title: notification.title ?? undefined,
-        text: notification.message,
+        title: notification.title
+          ? stripMarkdownForTerminal(notification.title)
+          : undefined,
+        text: stripMarkdownForTerminal(notification.message),
         width: 80,
         centerText: false,
         textColor: Color.Bold,
@@ -211,4 +213,42 @@ function coloredText(text: string, color?: Color): string {
     return `${color}${text}${RESET}`
   }
   return text
+}
+
+/**
+ * Strips a small subset of markdown syntax so notification messages render
+ * cleanly in a terminal banner. This is intentionally not a full markdown
+ * parser — it targets only the constructs the notifications API is known to
+ * emit.
+ */
+export function stripMarkdownForTerminal(text: string): string {
+  let out = text
+
+  // Links: [label](url) → "label (url)", or just "url" if label equals the url.
+  out = out.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    (_match: string, label: string, url: string) =>
+      label === url ? url : `${label} (${url})`,
+  )
+
+  // Bold: **x** or __x__ → x
+  out = out.replace(/\*\*([^*]+)\*\*/g, '$1')
+  out = out.replace(/__([^_]+)__/g, '$1')
+
+  // Italic: *x* or _x_ → x. Avoid eating intra-word underscores by requiring
+  // word boundaries around the underscore form.
+  out = out.replace(/(?<![*\w])\*([^*\n]+)\*(?!\w)/g, '$1')
+  out = out.replace(/(?<![_\w])_([^_\n]+)_(?!\w)/g, '$1')
+
+  // Strikethrough: ~~x~~ → x
+  out = out.replace(/~~([^~]+)~~/g, '$1')
+
+  // Inline code: `x` → x
+  out = out.replace(/`([^`]+)`/g, '$1')
+
+  // Heading markers and blockquote prefixes at line starts.
+  out = out.replace(/^#{1,6} +/gm, '')
+  out = out.replace(/^> ?/gm, '')
+
+  return out
 }


### PR DESCRIPTION
When the announcement stores the markdown content, it will be better displayed in the CLI output.
...not sure about this, maybe not needed, will be testing...