### PR TITLE
[events] fix for non defined data [GEN-7600][trivial]

### DIFF
--- a/packages/bonds-eventing/__tests__/persist-events.spec.ts
+++ b/packages/bonds-eventing/__tests__/persist-events.spec.ts
@@ -1,0 +1,60 @@
+import { sanitizeForJsonb } from '../src/persist-events'
+
+describe('sanitizeForJsonb', () => {
+  it('replaces NaN with null', () => {
+    expect(sanitizeForJsonb(NaN)).toBeNull()
+  })
+
+  it('replaces ±Infinity with null', () => {
+    expect(sanitizeForJsonb(Infinity)).toBeNull()
+    expect(sanitizeForJsonb(-Infinity)).toBeNull()
+  })
+
+  it('passes finite numbers through', () => {
+    expect(sanitizeForJsonb(0)).toBe(0)
+    expect(sanitizeForJsonb(-1.5)).toBe(-1.5)
+    expect(sanitizeForJsonb(1e20)).toBe(1e20)
+  })
+
+  it('preserves non-number primitives and null', () => {
+    expect(sanitizeForJsonb(null)).toBeNull()
+    expect(sanitizeForJsonb(undefined)).toBeUndefined()
+    expect(sanitizeForJsonb('x')).toBe('x')
+    expect(sanitizeForJsonb(true)).toBe(true)
+  })
+
+  it('recursively sanitizes nested objects and arrays', () => {
+    const event = {
+      type: 'bonds',
+      data: {
+        details: {
+          total_penalty_sol: NaN,
+          bid_too_low_penalty_pmpe: NaN,
+          bond_balance_sol: 10,
+          history: [1, NaN, Infinity, { x: -Infinity }],
+        },
+      },
+    }
+    expect(sanitizeForJsonb(event)).toEqual({
+      type: 'bonds',
+      data: {
+        details: {
+          total_penalty_sol: null,
+          bid_too_low_penalty_pmpe: null,
+          bond_balance_sol: 10,
+          history: [1, null, null, { x: null }],
+        },
+      },
+    })
+  })
+
+  it('produces an output that JSON.stringify accepts in strict mode', () => {
+    // Mimics slonik's safe-stable-stringify strict behavior: regular JSON
+    // already throws on BigInt and silently nulls NaN — we only need to
+    // assert that nothing remains that strict mode would reject.
+    const sanitized = sanitizeForJsonb({ a: NaN, b: [Infinity, { c: NaN }] })
+    expect(JSON.stringify(sanitized)).toBe(
+      JSON.stringify({ a: null, b: [null, { c: null }] }),
+    )
+  })
+})

--- a/packages/bonds-eventing/src/commands/bidding.ts
+++ b/packages/bonds-eventing/src/commands/bidding.ts
@@ -126,40 +126,40 @@ async function manageBidding(opts: Record<string, unknown>) {
   const hasDb = !!config.postgresUrl
   let pool: Awaited<ReturnType<typeof createPool>> | null = null
 
-  if (hasDb) {
-    const postgresUrl = config.postgresUrl as string
-    const poolConfig: Parameters<typeof createPool>[1] = {
-      typeParsers: [
-        ...createTypeParserPreset(),
-        {
-          name: 'timestamptz',
-          parse: (timestamp: string) => new Date(timestamp).toISOString(),
-        },
-        {
-          name: 'numeric',
-          parse: (numeric: string) => numeric,
-        },
-      ],
-      maximumPoolSize: 5,
-    }
-
-    if (config.postgresSslRootCert) {
-      const ca = fs.readFileSync(config.postgresSslRootCert, 'utf8')
-      ;(poolConfig as Record<string, unknown>).ssl = {
-        rejectUnauthorized: true,
-        ca: [ca],
-      }
-    }
-
-    pool = await createPool(postgresUrl, poolConfig)
-    previousState = await loadPreviousState(pool, bondType, logger)
-  } else {
-    logger.warn(
-      'No POSTGRES_URL configured, running without state (all validators will be first_seen)',
-    )
-  }
-
   try {
+    if (hasDb) {
+      const postgresUrl = config.postgresUrl as string
+      const poolConfig: Parameters<typeof createPool>[1] = {
+        typeParsers: [
+          ...createTypeParserPreset(),
+          {
+            name: 'timestamptz',
+            parse: (timestamp: string) => new Date(timestamp).toISOString(),
+          },
+          {
+            name: 'numeric',
+            parse: (numeric: string) => numeric,
+          },
+        ],
+        maximumPoolSize: 5,
+      }
+
+      if (config.postgresSslRootCert) {
+        const ca = fs.readFileSync(config.postgresSslRootCert, 'utf8')
+        ;(poolConfig as Record<string, unknown>).ssl = {
+          rejectUnauthorized: true,
+          ca: [ca],
+        }
+      }
+
+      pool = await createPool(postgresUrl, poolConfig)
+      previousState = await loadPreviousState(pool, bondType, logger)
+    } else {
+      logger.warn(
+        'No POSTGRES_URL configured, running without state (all validators will be first_seen)',
+      )
+    }
+
     // 3. Evaluate deltas
     const events = evaluateDeltas(
       validators,
@@ -217,6 +217,20 @@ async function manageBidding(opts: Record<string, unknown>) {
     logger.info(
       `Eventing complete: ${events.length} events (${sent} sent, ${failed} failed)`,
     )
+  } catch (err) {
+    // Surface the stack and any structured payload so log scrapers see more
+    // than just `err.message` (the top-level handler in `index.ts` only logs
+    // the message, which made past slonik failures untraceable).
+    logger.error(
+      {
+        err:
+          err instanceof Error
+            ? { name: err.name, message: err.message, stack: err.stack }
+            : err,
+      },
+      'Eventing failed',
+    )
+    throw err
   } finally {
     if (pool) {
       await pool.end()

--- a/packages/bonds-eventing/src/persist-events.ts
+++ b/packages/bonds-eventing/src/persist-events.ts
@@ -3,6 +3,27 @@ import { type DatabasePool, sql, type SerializableValue } from 'slonik'
 import type { BondsEventV1, EmitResult } from './types'
 import type { LoggerWrapper } from '@marinade.finance/ts-common'
 
+// slonik's `sql.jsonb(...)` uses safe-stable-stringify in strict mode, which
+// throws on NaN / ±Infinity. Native `JSON.stringify` (used by the emit step)
+// silently maps them to null — this helper aligns the persisted payload with
+// what the notifications API already receives.
+export function sanitizeForJsonb(value: unknown): unknown {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeForJsonb)
+  }
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = sanitizeForJsonb(v)
+  }
+  return out
+}
+
 export async function persistEvents(
   pool: DatabasePool,
   results: Map<BondsEventV1, EmitResult>,
@@ -22,7 +43,7 @@ export async function persistEvents(
       ${event.bond_pubkey},
       ${event.bond_type},
       ${event.epoch},
-      ${sql.jsonb(event as unknown as SerializableValue)},
+      ${sql.jsonb(sanitizeForJsonb(event) as SerializableValue)},
       ${result.status},
       ${result.error ?? null},
       NOW()


### PR DESCRIPTION
There are still events that exploit NaN (due to Slonik’s strict behavior). Sanitizing it for JSON compilation.
