### PR TITLE
[pipelines] adjust verify processing [GEN-7963]

### DIFF
--- a/.buildkite/verify-settlements.yml
+++ b/.buildkite/verify-settlements.yml
@@ -61,7 +61,8 @@ steps:
       echo "Claim Type: '$$claim_type'/'$$config_pubkey', Slack Feed: '$$slack_feed'"
       echo "# RPC_URL='$$printable_rpc_url'"
     - |
-      buildkite-agent meta-data set --redacted-vars='' non_funded_threshold "${NON_FUNDED_THRESHOLD:-7}"
+      buildkite-agent meta-data set --redacted-vars='' non_funded_per_epoch "${NON_FUNDED_PER_EPOCH:-15}"
+      buildkite-agent meta-data set --redacted-vars='' non_funded_sol_per_epoch "${NON_FUNDED_SOL_PER_EPOCH:-5}"
       buildkite-agent meta-data set --redacted-vars='' non_existing_to_report "${NON_EXISTING_TO_REPORT:-0}"
 
   - label: ":memo: Annotate retry parameters"
@@ -70,7 +71,8 @@ steps:
     commands:
       - claim_type=$(buildkite-agent meta-data get claim_type)
       - slack_feed=$(buildkite-agent meta-data get slack_feed)
-      - non_funded_threshold=$(buildkite-agent meta-data get non_funded_threshold)
+      - non_funded_per_epoch=$(buildkite-agent meta-data get non_funded_per_epoch)
+      - non_funded_sol_per_epoch=$(buildkite-agent meta-data get non_funded_sol_per_epoch)
       - non_existing_to_report=$(buildkite-agent meta-data get non_existing_to_report)
       - printable_rpc_url=$(./scripts/printable-rpc-url.sh "$$RPC_URL")
       - |
@@ -82,7 +84,8 @@ steps:
         CLAIM_TYPE=$$claim_type
         SLACK_FEED=$$slack_feed
         NOTIFY_FEED=${NOTIFY_FEED:-false}
-        NON_FUNDED_THRESHOLD=$$non_funded_threshold
+        NON_FUNDED_PER_EPOCH=$$non_funded_per_epoch
+        NON_FUNDED_SOL_PER_EPOCH=$$non_funded_sol_per_epoch
         NON_EXISTING_TO_REPORT=$$non_existing_to_report
         # RPC_URL='$$printable_rpc_url'
         \`\`\`
@@ -199,10 +202,16 @@ steps:
     - check_command_execution_status "$$command_name" || true
     - slack_feed=$(buildkite-agent meta-data get slack_feed)
     - claim_type=$(buildkite-agent meta-data get claim_type)
-    - non_funded_threshold=$(buildkite-agent meta-data get non_funded_threshold)
+    - non_funded_per_epoch=$(buildkite-agent meta-data get non_funded_per_epoch)
+    - non_funded_sol_per_epoch=$(buildkite-agent meta-data get non_funded_sol_per_epoch)
     - non_existing_to_report=$(buildkite-agent meta-data get non_existing_to_report)
     - chmod +x ./scripts/parse-verify-alerts.sh
-    - source ./scripts/parse-verify-alerts.sh -f ./verify-report.json -n "$$non_funded_threshold" -e "$$non_existing_to_report" || alert_exit_code=$?
+    - |
+      source ./scripts/parse-verify-alerts.sh \
+        -f ./verify-report.json \
+        -x "$$non_funded_per_epoch" \
+        -s "$$non_funded_sol_per_epoch" \
+        -e "$$non_existing_to_report" || alert_exit_code=$?
     - |
       if [ "$${alert_exit_code:-0}" -ne 0 ]; then
         curl $${SLACK_API} -X POST -H 'Content-type: application/json; charset=utf-8' \
@@ -221,7 +230,7 @@ steps:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Summary:* '"$$unknown_count"' unknown | '"$$non_verified_count"' non-verified epochs | '"$$non_existing_count"' non-existing (threshold: '"$$non_existing_to_report"') | '"$$non_funded_count"' non-funded (threshold: '"$$non_funded_threshold"')"
+                    "text": "*Summary:* '"$$unknown_count"' unknown | '"$$non_verified_count"' non-verified epochs | '"$$non_existing_in_alert"' non-existing (≥ '"$$non_existing_to_report"' threshold; '"$$non_existing_count"' seen) | '"$$non_funded_settlements_alerting"' non-funded across '"$$non_funded_epochs_alert"' epoch(s) over threshold (per-epoch: ≥ '"$$non_funded_per_epoch"' or ≥ '"$$non_funded_sol_per_epoch"' SOL; '"$$non_funded_count"' seen)"
                   }
                 },
                 {

--- a/scripts/parse-verify-alerts.sh
+++ b/scripts/parse-verify-alerts.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-# Parse settlement verification alerts from JSON report of 'verify-settlement' command
-# Usage: parse-verify-alerts.sh -f <verify-report.json> [-n <non-funded-items-to-report>] [-e <non-existing-items-to-report>] [-m <max-display-items>]
-
+# Parse settlement verification alerts from JSON report of 'verify-settlement' command.
+# Non-funded settlements are classified per epoch; any epoch crossing a threshold
+# raises an alert that is posted to Slack and fails the build:
+#   * count >= -x   --> alert (Slack + build fail)
+#   * sol   >= -s   --> alert (Slack + build fail)
+# Unknown/non-verified settlements always alert; non-existing uses -e threshold.
 
 # Detect if being sourced
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
@@ -12,22 +15,26 @@ else
     _EXIT_CMD="exit"
 fi
 
-# Default values
+# Defaults
 REPORT_FILE=""
-NON_FUNDED_TO_REPORT=0
+NON_FUNDED_PER_EPOCH=30
+NON_FUNDED_SOL_PER_EPOCH=10
 NON_EXISTING_TO_REPORT=0
 MAX_DISPLAY=20
 
-# Parse command-line arguments
-while getopts "f:n:e:m:h" opt; do
+while getopts "f:x:s:e:m:h" opt; do
     case $opt in
         f)
             REPORT_FILE="$OPTARG"
             [ -f "$REPORT_FILE" ] || { echo "Error: Report file not found: $REPORT_FILE" >&2; $_EXIT_CMD 1; }
             ;;
-        n)
-            [[ "$OPTARG" =~ ^[0-9]+$ ]] && [ "$OPTARG" -ge 0 ] || { echo "Error: -n must be a non-negative integer" >&2; $_EXIT_CMD 1; }
-            NON_FUNDED_TO_REPORT="$OPTARG"
+        x)
+            [[ "$OPTARG" =~ ^[0-9]+$ ]] && [ "$OPTARG" -ge 0 ] || { echo "Error: -x must be a non-negative integer" >&2; $_EXIT_CMD 1; }
+            NON_FUNDED_PER_EPOCH="$OPTARG"
+            ;;
+        s)
+            [[ "$OPTARG" =~ ^[0-9]+(\.[0-9]+)?$ ]] || { echo "Error: -s must be a non-negative number" >&2; $_EXIT_CMD 1; }
+            NON_FUNDED_SOL_PER_EPOCH="$OPTARG"
             ;;
         e)
             [[ "$OPTARG" =~ ^[0-9]+$ ]] && [ "$OPTARG" -ge 0 ] || { echo "Error: -e must be a non-negative integer" >&2; $_EXIT_CMD 1; }
@@ -39,14 +46,19 @@ while getopts "f:n:e:m:h" opt; do
             ;;
         h)
             cat >&2 <<EOF
-Usage: $0 -f <report-file> [-n <non-funded-items-to-report>] [-e <non-existing-items-to-report>] [-m <max-display-items>]
+Usage: $0 -f <report-file> [-x <count-threshold>] [-s <sol-threshold>] [-e <non-existing-min>] [-m <max-display>]
 
 Options:
-  -f <file>                 Path to the verify-report.json file (required)
-  -n <non-funded-items>     Minimum non-funded items to trigger alert (default: 0)
-  -e <non-existing-items>   Minimum non-existing items to trigger alert (default: 0)
-  -m <max-display-items>    Maximum items to display per alert section (default: 20)
-  -h                        Show this help message
+  -f <file>          Path to the verify-report.json file (required)
+  -x <int>           Non-funded count threshold per epoch (default: 30) - Slack + fail
+  -s <number>        Non-funded SOL threshold per epoch  (default: 10) - Slack + fail
+  -e <int>           Non-existing settlements threshold to alert on (default: 0)
+  -m <int>           Max items to display in unknown/non-existing sections (default: 20)
+  -h                 Show this help message
+
+Exit codes:
+  0  no alerts
+  2  alert raised (Slack + build fail)
 EOF
             $_EXIT_CMD 0
             ;;
@@ -57,22 +69,32 @@ done
 
 [ -n "$REPORT_FILE" ] || { echo "Error: -f <report-file> is required. Use -h for help" >&2; $_EXIT_CMD 1; }
 
-echo "Parsing report: $REPORT_FILE (non-funded threshold: $NON_FUNDED_TO_REPORT, non-existing threshold: $NON_EXISTING_TO_REPORT, max display: $MAX_DISPLAY)" >&2
+# SOL threshold in lamports (integer math is easier in bash)
+sol_threshold_lamports=$(awk -v sol="$NON_FUNDED_SOL_PER_EPOCH" 'BEGIN { printf "%.0f", sol * 1e9 }')
 
+echo "Parsing report: $REPORT_FILE" >&2
+echo "  non-funded thresholds (per epoch): count >= $NON_FUNDED_PER_EPOCH or SOL >= ${NON_FUNDED_SOL_PER_EPOCH}" >&2
+echo "  non-existing threshold: $NON_EXISTING_TO_REPORT, max display: $MAX_DISPLAY" >&2
 
-# Count alerts by category
 unknown_count=$(jq '.summary.unknown_settlements | length' "$REPORT_FILE")
 non_verified_count=$(jq '.summary.non_verified_epochs | length' "$REPORT_FILE")
 non_existing_count=$(jq '.summary.non_existing_settlements | length' "$REPORT_FILE")
 non_funded_count=$(jq '.summary.non_funded_settlements | length' "$REPORT_FILE")
 
-# Determine if any alerts to report
-is_to_alert=false
+# Stale-report detection: pre-claims_lamports reports lose the SOL threshold silently.
+if [ "$non_funded_count" -gt 0 ]; then
+    non_funded_with_lamports=$(jq '[.summary.non_funded_settlements[] | select(has("claims_lamports") and .claims_lamports != null)] | length' "$REPORT_FILE")
+    if [ "$non_funded_with_lamports" -eq 0 ]; then
+        echo "⚠️  Warning: non-funded settlements carry no 'claims_lamports' field; SOL threshold (-s) is inactive for this report (likely produced by a pre-SOL-threshold binary)." >&2
+    fi
+fi
 
-# Build alert sections JSON
+is_to_alert=false
+non_existing_in_alert=0
+non_funded_settlements_alerting=0
 alert_sections=""
 
-# Unknown settlements (on-chain but not in JSON)
+# Unknown settlements (on-chain but not in JSON) - always critical
 if [ "$unknown_count" -gt 0 ]; then
     is_to_alert=true
     echo " => $unknown_count unknown settlements found (CRITICAL)" >&2
@@ -90,7 +112,7 @@ if [ "$unknown_count" -gt 0 ]; then
                 },'
 fi
 
-# Non-verified epochs (no settlements in JSON for epoch)
+# Non-verified epochs (no settlements in JSON for epoch) - always critical
 if [ "$non_verified_count" -gt 0 ]; then
     is_to_alert=true
     echo " => $non_verified_count non-verified epochs found" >&2
@@ -105,15 +127,17 @@ if [ "$non_verified_count" -gt 0 ]; then
                 },'
 fi
 
-# Non-existing settlements (in JSON but not on-chain)
+# Non-existing settlements (in JSON but not on-chain) - alert only if at/above threshold
 if [ "$non_existing_count" -gt 0 ]; then
-    [ "$non_existing_count" -ge "$NON_EXISTING_TO_REPORT" ] && is_to_alert=true
     echo " => $non_existing_count non-existing settlements found" >&2
-    non_existing_list=$(jq -r '.summary.non_existing_settlements[] | "Epoch \(.epoch): \(.address)"' "$REPORT_FILE" | head -n "$MAX_DISPLAY")
-    if [ "$non_existing_count" -gt "$MAX_DISPLAY" ]; then
-        non_existing_list="$non_existing_list"$'\n'"... and $((non_existing_count - MAX_DISPLAY)) more"
-    fi
-    alert_sections="$alert_sections"'
+    if [ "$non_existing_count" -ge "$NON_EXISTING_TO_REPORT" ]; then
+        is_to_alert=true
+        non_existing_in_alert=$non_existing_count
+        non_existing_list=$(jq -r '.summary.non_existing_settlements[] | "Epoch \(.epoch): \(.address)"' "$REPORT_FILE" | head -n "$MAX_DISPLAY")
+        if [ "$non_existing_count" -gt "$MAX_DISPLAY" ]; then
+            non_existing_list="$non_existing_list"$'\n'"... and $((non_existing_count - MAX_DISPLAY)) more"
+        fi
+        alert_sections="$alert_sections"'
                 {
                   "type": "section",
                   "text": {
@@ -121,43 +145,79 @@ if [ "$non_existing_count" -gt 0 ]; then
                     "text": "*🟡 Non-Existing Settlements ('"$non_existing_count"'):*\n_In JSON but not found on-chain_\n```'"$non_existing_list"'```"
                   }
                 },'
+    fi
 fi
 
-# Non-funded settlements (on-chain but not funded)
+# Non-funded settlements: aggregate per epoch, alert when any epoch crosses
+non_funded_epochs_total=0
+non_funded_epochs_alert=0
+non_funded_summary=""
 if [ "$non_funded_count" -gt 0 ]; then
-    [ "$non_funded_count" -ge "$NON_FUNDED_TO_REPORT" ] && is_to_alert=true
-    echo " => $non_funded_count non-funded settlements found" >&2
-    non_funded_list=$(jq -r '.summary.non_funded_settlements[] | "Epoch \(.epoch): \(.address)"' "$REPORT_FILE" | head -n "$MAX_DISPLAY")
-    if [ "$non_funded_count" -gt "$MAX_DISPLAY" ]; then
-        non_funded_list="$non_funded_list"$'\n'"... and $((non_funded_count - MAX_DISPLAY)) more"
-    fi
-    alert_sections="$alert_sections"'
+    echo " => $non_funded_count non-funded settlements found; classifying per epoch" >&2
+
+    # Per-epoch aggregation: "<epoch> <count> <lamports>" lines, sorted by epoch
+    per_epoch=$(jq -r '
+        .summary.non_funded_settlements
+        | group_by(.epoch)
+        | map({
+            epoch: .[0].epoch,
+            count: length,
+            lamports: (map(.claims_lamports // 0) | add)
+        })
+        | sort_by(.epoch)
+        | .[]
+        | "\(.epoch) \(.count) \(.lamports)"
+    ' "$REPORT_FILE")
+
+    while IFS=' ' read -r epoch count lamports; do
+        [ -z "$epoch" ] && continue
+        non_funded_epochs_total=$((non_funded_epochs_total + 1))
+
+        sol=$(awk -v l="$lamports" 'BEGIN { printf "%.4f", l / 1e9 }')
+
+        if [ "$count" -ge "$NON_FUNDED_PER_EPOCH" ] || [ "$lamports" -ge "$sol_threshold_lamports" ]; then
+            non_funded_epochs_alert=$((non_funded_epochs_alert + 1))
+            non_funded_settlements_alerting=$((non_funded_settlements_alerting + count))
+            is_to_alert=true
+            echo "    epoch=$epoch count=$count sol=$sol ALERT" >&2
+            non_funded_summary="${non_funded_summary}Epoch ${epoch}: ${count} settlements / ${sol} SOL
+"
+        else
+            echo "    epoch=$epoch count=$count sol=$sol (below threshold)" >&2
+        fi
+    done <<< "$per_epoch"
+
+    if [ -n "$non_funded_summary" ]; then
+        non_funded_summary="${non_funded_summary%$'\n'}"
+        alert_sections="$alert_sections"'
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*🟠 Non-Funded Settlements ('"$non_funded_count"'):*\n_On-chain but not funded_\n```'"$non_funded_list"'```"
+                    "text": "*🟠 Non-Funded Settlements per Epoch:*\n_thresholds: ≥ '"$NON_FUNDED_PER_EPOCH"'/epoch or ≥ '"$NON_FUNDED_SOL_PER_EPOCH"' SOL/epoch_\n```'"$non_funded_summary"'```"
                   }
                 },'
+    fi
 fi
 
-total_alerts=$((unknown_count + non_verified_count + non_existing_count + non_funded_count))
-echo "Total alerts: $total_alerts" >&2
+total_alerts=$((unknown_count + non_verified_count + non_existing_in_alert + non_funded_settlements_alerting))
+echo "Totals: unknown=$unknown_count non-verified=$non_verified_count non-existing=$non_existing_count (in-alert=$non_existing_in_alert) non-funded=$non_funded_count (alerting=$non_funded_settlements_alerting across $non_funded_epochs_alert of $non_funded_epochs_total epoch(s))" >&2
 
 export unknown_count
 export non_verified_count
 export non_existing_count
+export non_existing_in_alert
 export non_funded_count
+export non_funded_epochs_alert
+export non_funded_settlements_alerting
 export total_alerts
 # Remove trailing comma from last section
 export alert_sections="${alert_sections%,}"
 
 if [ "$is_to_alert" = 'true' ]; then
-    echo "❌ Some settlements verification failure" >&2
-    # Return with error code if alerts exist
+    echo "⛔ Settlement verification failure" >&2
     $_EXIT_CMD 2
 else
     echo "✅ All settlements verified successfully" >&2
-    # If no alerts, return with success
     $_EXIT_CMD 0
 fi

--- a/scripts/parse-verify-alerts.sh
+++ b/scripts/parse-verify-alerts.sh
@@ -180,8 +180,7 @@ if [ "$non_funded_count" -gt 0 ]; then
             non_funded_settlements_alerting=$((non_funded_settlements_alerting + count))
             is_to_alert=true
             echo "    epoch=$epoch count=$count sol=$sol ALERT" >&2
-            non_funded_summary="${non_funded_summary}Epoch ${epoch}: ${count} settlements / ${sol} SOL
-"
+            non_funded_summary="${non_funded_summary}Epoch ${epoch}: ${count} settlements / ${sol} SOL"$'\n'
         else
             echo "    epoch=$epoch count=$count sol=$sol (below threshold)" >&2
         fi

--- a/settlement-pipelines/src/bin/verify_settlement.rs
+++ b/settlement-pipelines/src/bin/verify_settlement.rs
@@ -52,6 +52,8 @@ struct SettlementEpoch {
     vote_account: Option<Pubkey>,
     #[serde(with = "option_pubkey_string_conversion")]
     bond: Option<Pubkey>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    claims_lamports: Option<u64>,
 }
 
 impl SettlementEpoch {
@@ -66,7 +68,13 @@ impl SettlementEpoch {
             address,
             vote_account,
             bond,
+            claims_lamports: None,
         }
+    }
+
+    fn with_claims_lamports(mut self, claims_lamports: u64) -> Self {
+        self.claims_lamports = Some(claims_lamports);
+        self
     }
 }
 
@@ -152,12 +160,15 @@ fn verify_epoch_settlements(
                         "Existing JSON settlement {} emitted on-chain but not funded (epoch: {})",
                         listed_settlement.settlement_address, epoch_to_verify
                     );
-                    non_funded_settlements.push(SettlementEpoch::new(
-                        epoch_to_verify,
-                        listed_settlement.settlement_address,
-                        Some(listed_settlement.vote_account_address),
-                        Some(listed_settlement.bond_address),
-                    ));
+                    non_funded_settlements.push(
+                        SettlementEpoch::new(
+                            epoch_to_verify,
+                            listed_settlement.settlement_address,
+                            Some(listed_settlement.vote_account_address),
+                            Some(listed_settlement.bond_address),
+                        )
+                        .with_claims_lamports(listed_settlement.claims_lamports),
+                    );
                 }
             } else {
                 error!(


### PR DESCRIPTION
The verify pipeline started failing too often and creating noise that is hard to determine whether it is wrong or not. Making it less verbose while still keeping it relevant to inform about issues.
