### PR TITLE
Update settlement-config.yaml [GEN-7676]

### DIFF
--- a/settlement-config.yaml
+++ b/settlement-config.yaml
@@ -1,7 +1,7 @@
 ---
 fee_config:
   min_fee_bps: 0
-  max_fee_bps: 630
+  max_fee_bps: 580
   # PMPE premium added to ssi/ssr target. Range: -0.1..0.1 (~±2% APY).
   min_yield_premium_over_ssr_pmpe: 0
   marinade:


### PR DESCRIPTION
We need 24bps improvement which means we need to cut the fee by 24bps/6.4% which approx 30% and we overcut so that we land clear.