### PR TITLE
Set min_fee_bps to 0 in settlement-config.yaml [trivial]

### DIFF
--- a/settlement-config.yaml
+++ b/settlement-config.yaml
@@ -1,6 +1,6 @@
 ---
 fee_config:
-  min_fee_bps: 200
+  min_fee_bps: 0
   max_fee_bps: 800
   # PMPE premium added to ssi/ssr target. Range: -0.1..0.1 (~±2% APY).
   min_yield_premium_over_ssr_pmpe: 0


### PR DESCRIPTION
Need to cut minimal fees as otherwise we are not able to meet SSR.