### PR TITLE
[pipeline] fix for historical check oom

### DIFF
--- a/.buildkite/sanity-unified.yml
+++ b/.buildkite/sanity-unified.yml
@@ -90,6 +90,8 @@ steps:
 
   - label: ":broom: :two: Sanity Check - Historical Comparison"
     key: "sanity-check-2"
+    env:
+      NODE_OPTIONS: "--max-old-space-size=12288"
     commands:
       - buildkite-agent artifact download --include-retried-jobs unified-merkle-trees.json .
       - buildkite-agent artifact download --include-retried-jobs 'past-merkle-trees/*.json' . || true

--- a/packages/validator-bonds-sanity-check/src/commands/checkMerkleTree.ts
+++ b/packages/validator-bonds-sanity-check/src/commands/checkMerkleTree.ts
@@ -335,25 +335,28 @@ async function manageCheckMerkleTree({
       `Comparing against ${resolvedPaths.length} historical merkle tree file(s)...`,
     )
 
-    const historicalDtos: UnifiedMerkleTreesDto[] = []
+    const currentMetrics = extractMetrics(merkleTreesDto)
+
+    // Extract metrics per file and discard each large DTO before loading the next
+    // one; retaining all of them at once exhausts the heap on multi-GB inputs.
+    const historicalMetrics: MerkleTreeMetrics[] = []
+    let previousMetrics: MerkleTreeMetrics | undefined
     for (const pastPath of resolvedPaths) {
       logger.info(`Loading past merkle tree: ${pastPath}`)
       const dto = await loadAndValidateUnifiedMerkleTree(pastPath)
-      historicalDtos.push(dto)
+      const metrics = extractMetrics(dto)
+      historicalMetrics.push(metrics)
+      if (dto.epoch === merkleTreesDto.epoch - 1) {
+        previousMetrics = metrics
+      }
     }
-
-    const currentMetrics = extractMetrics(merkleTreesDto)
-    const historicalMetrics = historicalDtos.map(extractMetrics)
 
     // Epoch-over-epoch hop guardrail: stricter than the statistical check below,
     // catches large N-1 -> N jumps that high-variance windows can dilute under z-score.
-    const previousDto = historicalDtos.find(
-      d => d.epoch === merkleTreesDto.epoch - 1,
-    )
-    if (previousDto) {
+    if (previousMetrics) {
       const { violations, report } = checkEpochHopGuardrail({
         currentMetrics,
-        previousMetrics: extractMetrics(previousDto),
+        previousMetrics,
         hopThreshold: epochHopThreshold,
       })
       logger.info(report)

--- a/packages/validator-bonds-sanity-check/src/commands/checkMerkleTree.ts
+++ b/packages/validator-bonds-sanity-check/src/commands/checkMerkleTree.ts
@@ -351,6 +351,10 @@ async function manageCheckMerkleTree({
       }
     }
 
+    // Resolved paths can be unordered (glob/CLI order, mixed digit-length epochs);
+    // the recent-epochs heuristic relies on chronological order.
+    historicalMetrics.sort((a, b) => a.epoch - b.epoch)
+
     // Epoch-over-epoch hop guardrail: stricter than the statistical check below,
     // catches large N-1 -> N jumps that high-variance windows can dilute under z-score.
     if (previousMetrics) {


### PR DESCRIPTION
Hopefully omitting OOM in pipeline

```
> @0.0.1 cli:check /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements
> pnpm ts-node ./packages/validator-bonds-sanity-check/src/ check-merkle-tree --merkle-trees ./unified-merkle-trees.json --past-merkle-trees ./past-merkle-trees/973-unified-merkle-trees.json ./past-merkle-trees/974-unified-merkle-trees.json ./past-merkle-trees/975-unified-merkle-trees.json ./past-merkle-trees/976-unified-merkle-trees.json ./past-merkle-trees/977-unified-merkle-trees.json ./past-merkle-trees/978-unified-merkle-trees.json ./past-merkle-trees/979-unified-merkle-trees.json ./past-merkle-trees/980-unified-merkle-trees.json ./past-merkle-trees/981-unified-merkle-trees.json ./past-merkle-trees/982-unified-merkle-trees.json --correlation-threshold 0.15 --score-threshold 2.0 --min-absolute-deviation 0.05 --epoch-hop-threshold 1.5
[2026-06-08 13:18:57.191 +0000] INFO (288614): Loading merkle tree file: ./unified-merkle-trees.json
[2026-06-08 13:19:32.512 +0000] INFO (288614): Loaded unified merkle trees: epoch 983, sources: bid-distribution-settlements.json, count: 78
[2026-06-08 13:19:32.512 +0000] INFO (288614): Checking internal consistency...
[2026-06-08 13:19:32.664 +0000] INFO (288614): ✓ Internal consistency check passed for 78 merkle trees
[2026-06-08 13:19:32.664 +0000] INFO (288614):   Total validators: 78, Total claims: 221361, Total amount: 222640982243 lamports
[2026-06-08 13:19:32.665 +0000] INFO (288614): Comparing against 10 historical merkle tree file(s)...
[2026-06-08 13:19:32.665 +0000] INFO (288614): Loading past merkle tree: /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements/past-merkle-trees/973-unified-merkle-trees.json
[2026-06-08 13:20:07.648 +0000] INFO (288614): Loading past merkle tree: /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements/past-merkle-trees/974-unified-merkle-trees.json
[2026-06-08 13:20:42.052 +0000] INFO (288614): Loading past merkle tree: /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements/past-merkle-trees/975-unified-merkle-trees.json
[2026-06-08 13:21:20.685 +0000] INFO (288614): Loading past merkle tree: /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements/past-merkle-trees/976-unified-merkle-trees.json
[2026-06-08 13:21:58.661 +0000] INFO (288614): Loading past merkle tree: /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements/past-merkle-trees/977-unified-merkle-trees.json
[2026-06-08 13:22:36.744 +0000] INFO (288614): Loading past merkle tree: /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements/past-merkle-trees/978-unified-merkle-trees.json
[2026-06-08 13:23:16.248 +0000] INFO (288614): Loading past merkle tree: /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements/past-merkle-trees/979-unified-merkle-trees.json
[2026-06-08 13:23:58.059 +0000] INFO (288614): Loading past merkle tree: /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements/past-merkle-trees/980-unified-merkle-trees.json
[2026-06-08 13:24:40.355 +0000] INFO (288614): Loading past merkle tree: /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements/past-merkle-trees/981-unified-merkle-trees.json
[2026-06-08 13:25:28.311 +0000] INFO (288614): Loading past merkle tree: /var/lib/buildkite-agent/builds/build01-marinadetech-com-7/marinade-finance/init-settlements/past-merkle-trees/982-unified-merkle-trees.json
<--- Last few GCs --->
[288614:0x3b345000]   443864 ms: Mark-Compact 3964.2 (4136.1) -> 3949.6 (4137.1) MB, pooled: 0 MB, 1073.28 / 0.00 ms  (average mu = 0.062, current mu = 0.012) allocation failure; scavenge might not succeed
[288614:0x3b345000]   444584 ms: Mark-Compact 3965.4 (4137.1) -> 3950.7 (4138.4) MB, pooled: 0 MB, 706.60 / 0.00 ms  (average mu = 0.043, current mu = 0.019) allocation failure; scavenge might not succeed
<--- JS stacktrace --->
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----
 1: 0xe36196 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
 2: 0x123f4a0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 3: 0x123f777 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 4: 0x146d1a5  [node]
 5: 0x146d1d3  [node]
 6: 0x148628a  [node]
 7: 0x1489458  [node]
 8: 0x1cc6071  [node]
undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command was killed with SIGABRT (Aborted): ts-node ./packages/validator-bonds-sanity-check/src/ check-merkle-tree --merkle-trees ./unified-merkle-trees.json --past-merkle-trees ./past-merkle-trees/973-unified-merkle-trees.json ./past-merkle-trees/974-unified-merkle-trees.json ./past-merkle-trees/975-unified-merkle-trees.json ./past-merkle-trees/976-unified-merkle-trees.json ./past-merkle-trees/977-unified-merkle-trees.json ./past-merkle-trees/978-unified-merkle-trees.json ./past-merkle-trees/979-unified-merkle-trees.json ./past-merkle-trees/980-unified-merkle-trees.json ./past-merkle-trees/981-unified-merkle-trees.json ./past-merkle-trees/982-unified-merkle-trees.json --correlation-threshold 0.15 --score-threshold 2.0 --min-absolute-deviation 0.05 --epoch-hop-threshold 1.5
 ELIFECYCLE  Command failed with exit code 1.
🚨 Error: The command exited with status 1
user command error: exit status 1
```