### PR TITLE
ci: make cargo-deny pass under the org static-analysis workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap 4.5.50",
  "env_logger 0.10.2",
  "gcp-bigquery-client",
  "governor",
@@ -489,10 +490,9 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "settlement-common",
  "solana-sdk",
- "structopt",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -901,7 +901,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "settlement-common",
  "snapshot-parser-validator-cli",
  "solana-sdk",
@@ -1013,10 +1013,9 @@ dependencies = [
  "log",
  "rust_decimal",
  "serde",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "solana-client",
  "solana-sdk",
- "structopt",
  "tokio",
  "tracing",
  "tracing-log 0.1.4",
@@ -2080,7 +2079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3461,12 +3460,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4614,7 +4607,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5130,7 +5123,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5168,7 +5161,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.7",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -5230,7 +5223,7 @@ dependencies = [
  "rustls 0.23.33",
  "rustls-native-certs 0.8.2",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.7",
+ "rustls-webpki 0.103.13",
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
@@ -5266,9 +5259,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5491,18 +5484,6 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
@@ -5525,7 +5506,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "snapshot-parser-validator-cli",
  "solana-sdk",
  "utoipa",
@@ -5548,7 +5529,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "settlement-common",
  "shellexpand",
  "solana-cli-output",
@@ -6172,7 +6153,7 @@ dependencies = [
  "dirs-next",
  "serde",
  "serde_derive",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "solana-clap-utils",
  "solana-commitment-config",
  "url",
@@ -9768,30 +9749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9933,7 +9890,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11466,15 +11423,6 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.2",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ rust_decimal = { version = "1.37.1", features = ["db-postgres"] }
 rust_decimal_macros = "1.37.1"
 serde = "1.0.197"
 serde_json = "1.0.114"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 settlement-common = { path = "settlement-distributions/settlement-common" }
 snapshot-parser-validator-cli = { git = "https://github.com/marinade-finance/solana-snapshot-parser", tag = "solana-2.3.x" }
 shellexpand = "3.1.0"
@@ -63,7 +63,6 @@ solana-security-txt = "1.1.1"
 solana-transaction-executor = { git = "https://github.com/marinade-finance/solana-transaction-executor", tag = "solana-2.3.x" }
 solana-transaction-builder = { git = "https://github.com/marinade-finance/solana-transaction-builder", tag = "solana-2.3.x" }
 solana-transaction-builder-executor = { git = "https://github.com/marinade-finance/solana-transaction-builder", tag = "solana-2.3.x" }
-structopt = "0.3.21"
 tokio = { version = "1", features = ["full"] }
 tokio-postgres = { version = "0.7.7", features = ["with-chrono-0_4"] }
 tracing = "0.1.37"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "api"
 version = "0.0.0"
 edition = "2021"
@@ -13,6 +14,7 @@ path = "src/bin/cli.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+clap = { workspace = true }
 chrono = { workspace = true }
 env_logger = { workspace = true }
 gcp-bigquery-client = { workspace = true }
@@ -29,7 +31,6 @@ settlement-common = { workspace = true }
 openssl = { workspace = true }
 postgres-openssl = { workspace = true }
 solana-sdk = { workspace = true }
-structopt = { workspace = true }
 tokio = { workspace = true }
 tokio-postgres = { workspace = true }
 tracing = { workspace = true }

--- a/api/src/bin/api.rs
+++ b/api/src/bin/api.rs
@@ -5,31 +5,31 @@ use api::rate_limit::{
     public_routes_limiter, recover_rate_limited, spawn_limiter_gc, with_rate_limit,
 };
 use api::repositories::protected_events::spawn_protected_events_cache;
+use clap::Parser;
 use env_logger::Env;
 use log::{error, info};
 use openssl::ssl::{SslConnector, SslMethod};
 use postgres_openssl::MakeTlsConnector;
 use std::convert::Infallible;
 use std::sync::Arc;
-use structopt::StructOpt;
 use tokio::sync::RwLock;
 use warp::Filter;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Params {
-    #[structopt(long = "postgres-url")]
+    #[arg(long = "postgres-url")]
     pub postgres_url: String,
 
-    #[structopt(long = "postgres-ssl-root-cert", env = "PG_SSLROOTCERT")]
+    #[arg(long = "postgres-ssl-root-cert", env = "PG_SSLROOTCERT")]
     pub postgres_ssl_root_cert: String,
 
-    #[structopt(long = "gcp-project-id")]
+    #[arg(long = "gcp-project-id")]
     pub gcp_project_id: Option<String>,
 
-    #[structopt(long = "gcp-sa-key")]
+    #[arg(long = "gcp-sa-key")]
     pub gcp_sa_key: Option<String>,
 
-    #[structopt(long = "port", default_value = "8000")]
+    #[arg(long = "port", default_value = "8000")]
     pub port: u16,
 }
 
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     info!("Launching API");
 
-    let params = Params::from_args();
+    let params = Params::parse();
 
     let mut builder = SslConnector::builder(SslMethod::tls())?;
     builder.set_ca_file(&params.postgres_ssl_root_cert)?;

--- a/api/src/bin/cli.rs
+++ b/api/src/bin/cli.rs
@@ -1,24 +1,24 @@
 use api::repositories::{bond::store_bonds, common::CommonStoreOptions};
-use structopt::StructOpt;
+use clap::{Args, Parser, Subcommand};
 use tracing_log::LogTracer;
 use validator_bonds_common::cli_result::CliResult;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Common {
-    #[structopt(short = "v")]
+    #[arg(short = 'v')]
     verbose: bool,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Params {
-    #[structopt(flatten)]
+    #[command(flatten)]
     common: Common,
 
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 pub enum Command {
     StoreBonds(CommonStoreOptions),
 }
@@ -29,7 +29,7 @@ async fn main() -> CliResult {
 }
 
 async fn real_main() -> anyhow::Result<()> {
-    let params = Params::from_args();
+    let params = Params::parse();
     LogTracer::init().expect("Setting up log compatibility failed");
     let subscriber = tracing_subscriber::fmt::Subscriber::builder()
         .with_target(false)

--- a/api/src/repositories/common.rs
+++ b/api/src/repositories/common.rs
@@ -1,13 +1,13 @@
-use structopt::StructOpt;
+use clap::Args;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct CommonStoreOptions {
-    #[structopt(long = "input-file")]
+    #[arg(long = "input-file")]
     pub input_path: String,
 
-    #[structopt(long = "postgres-url")]
+    #[arg(long = "postgres-url")]
     pub postgres_url: String,
 
-    #[structopt(long = "postgres-ssl-root-cert", env = "PG_SSLROOTCERT")]
+    #[arg(long = "postgres-ssl-root-cert", env = "PG_SSLROOTCERT")]
     pub postgres_ssl_root_cert: String,
 }

--- a/bonds-collector/Cargo.toml
+++ b/bonds-collector/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "bonds-collector"
 version = "0.0.0"
 edition = "2021"
@@ -13,7 +14,6 @@ clap = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
-structopt = { workspace = true }
 solana-sdk = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true }

--- a/bonds-collector/src/bin/cli.rs
+++ b/bonds-collector/src/bin/cli.rs
@@ -1,25 +1,25 @@
 use bonds_collector::commands::bonds::collect_bonds;
 use bonds_collector::commands::common::CommonCollectOptions;
-use structopt::StructOpt;
+use clap::{Args, Parser, Subcommand};
 use tracing_log::LogTracer;
 use validator_bonds_common::cli_result::CliResult;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Common {
-    #[structopt(short = "v")]
+    #[arg(short = 'v')]
     verbose: bool,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Params {
-    #[structopt(flatten)]
+    #[command(flatten)]
     common: Common,
 
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 pub enum Command {
     CollectBonds(CommonCollectOptions),
 }
@@ -30,7 +30,7 @@ async fn main() -> CliResult {
 }
 
 async fn real_main() -> anyhow::Result<()> {
-    let params = Params::from_args();
+    let params = Params::parse();
     LogTracer::init().expect("Setting up log compatibility failed");
     let subscriber = tracing_subscriber::fmt::Subscriber::builder()
         .with_target(false)

--- a/bonds-collector/src/commands/common.rs
+++ b/bonds-collector/src/commands/common.rs
@@ -1,18 +1,26 @@
+use clap::Args;
 use solana_sdk::commitment_config::CommitmentLevel;
-use structopt::StructOpt;
 use validator_bonds_common::dto::BondType;
 
-#[derive(Debug, StructOpt)]
+// BondType's FromStr error is anyhow::Error, which doesn't implement
+// std::error::Error, so clap's derive can't use the FromStr value parser
+// directly. Wrap it in a parser that maps the error to a String.
+fn parse_bond_type(s: &str) -> Result<BondType, String> {
+    s.parse::<BondType>().map_err(|e| e.to_string())
+}
+
+#[derive(Debug, Args)]
 pub struct CommonCollectOptions {
-    #[structopt(short = "u", env = "RPC_URL")]
+    #[arg(short = 'u', env = "RPC_URL")]
     pub rpc_url: String,
 
-    #[structopt(long = "commitment", default_value = "confirmed")]
+    #[arg(long = "commitment", default_value = "confirmed")]
     pub commitment: CommitmentLevel,
 
-    #[structopt(
-        short = "t",
+    #[arg(
+        short = 't',
         long = "bond-type",
+        value_parser = parse_bond_type,
         help = "Type of bond to collect (bidding or institutional)"
     )]
     pub bond_type: BondType,

--- a/common-rs/Cargo.toml
+++ b/common-rs/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "validator-bonds-common"
 version = "0.0.0"
 edition = "2021"

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "merkle-tree"
 version = "0.0.0"
 edition = "2021"

--- a/programs/validator-bonds/Cargo.toml
+++ b/programs/validator-bonds/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "validator-bonds"
 version = "2.2.1"
 description = "Marinade validator bonds program protecting validators performance"

--- a/settlement-distributions/bid-distribution/Cargo.toml
+++ b/settlement-distributions/bid-distribution/Cargo.toml
@@ -3,6 +3,7 @@ name = "bid-distribution-cli"
 path = "src/bin/cli.rs"
 
 [package]
+publish = false
 name = "bid-distribution"
 version = "0.0.0"
 edition = "2021"

--- a/settlement-distributions/institutional-distribution/Cargo.toml
+++ b/settlement-distributions/institutional-distribution/Cargo.toml
@@ -3,6 +3,7 @@ name = "institutional-distribution-cli"
 path = "src/bin/cli.rs"
 
 [package]
+publish = false
 name = "institutional-distribution"
 version = "0.0.0"
 edition = "2021"

--- a/settlement-distributions/merkle-generator/Cargo.toml
+++ b/settlement-distributions/merkle-generator/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "merkle-generator"
 version = "0.1.0"
 edition = "2021"

--- a/settlement-distributions/settlement-common/Cargo.toml
+++ b/settlement-distributions/settlement-common/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "settlement-common"
 version = "0.0.0"
 edition = "2021"

--- a/settlement-pipelines/Cargo.toml
+++ b/settlement-pipelines/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false
 name = "settlement-pipelines"
 version = "0.0.1"
 description = "Off-chain pipelines to Validator Bonds Program"


### PR DESCRIPTION
## What

validator-bonds half of stabilizing the org static-analysis process. Goal:
`cargo-deny` passes here, and the shared `deny.toml` in `marinade-finance/.github`
is set up sensibly for a generic Anchor repo — not over-fit to this one.

This repo exercises cases tx-router didn't:
- **`github.com/marinade-finance` git dependencies** (`solana-transaction-executor`,
  `solana-transaction-builder`, `snapshot-parser-validator-cli`), which the
  shared `deny.toml` currently denies (`sources.unknown-git = "deny"`, empty
  `allow-git`).
- An **Anchor** workspace, so `sec3-xray` / `solana-lints` / `verifiable-build`
  also run.

## Process

1. Dummy commit opens this PR and triggers the org `static-analysis-required`
   workflow.
2. We read the cargo-deny failures and split fixes between the shared
   `.github` `deny.toml` (anything org-wide, e.g. allowing the marinade git
   org as a source) and this repo (anything repo-specific).

> The shared workflow + `deny.toml` are temporarily pinned to the
> `.github` wrapper branch during this stabilization; they'll move to `@main`
> before that PR merges.

https://claude.ai/code/session_019SKDWNXjfpWXpv5sUJu2nt

---
_Generated by [Claude Code](https://claude.ai/code/session_019SKDWNXjfpWXpv5sUJu2nt)_