### PR TITLE
Add plugin/marketplace manifests + skill audit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "marinade",
+  "description": "Marinade Finance plugins — Validator Bonds protocol knowledge skills.",
+  "owner": {
+    "name": "Marinade Finance",
+    "url": "https://github.com/marinade-finance"
+  },
+  "plugins": [
+    {
+      "name": "validator-bonds",
+      "source": "./plugins/validator-bonds",
+      "description": "Validator Bonds protocol knowledge skills (marinade-sam-bond, marinade-ecosystem)."
+    }
+  ]
+}

--- a/SKILL_AUDIT.md
+++ b/SKILL_AUDIT.md
@@ -1,0 +1,184 @@
+# Validator Bonds Skill — Audit, Findings & Install Path
+
+**Scope:** Audit of the `marinade-sam-bond` and `marinade-ecosystem` knowledge skills (`plugins/validator-bonds/skills/`) — are they accurate, is each fact backed by code, and do they install via the plugin marketplace?
+**Date:** 2026-06-15 · **Skill branch:** `origin/20260312_skill`
+**Method:** (1) ran the skill against its 19 eval cases; (2) traced every fact to source in this repo; (3) cloned upstream `ds-sam` and verified facts that don't live here; (4) ran 3 real end-user tests against live validators using the bonds + SAM scores APIs; (5) tested the marketplace install path end-to-end.
+
+---
+
+## 1. Headline
+
+The skill is **accurate on facts that live in this repo's own code** (on-chain program, settlement distribution, merkle, PSR/downtime/commission, config). It is **wrong, incomplete, or out of its depth on facts whose logic lives upstream** (`ds-sam` / `ds-scoring` / `sam-blacklist` / `institutional-staking`) — it restates upstream behavior as if it were local, and the highest-stakes validator question (*"is my bond big enough / why no stake?"*) it cannot reliably answer.
+
+**Eval tally (19 cases):** 11 confirmed in-repo · 3 verified upstream in ds-sam · 1 doc-confirmed locally · 2 unverifiable (private repos) · 4 correctness/completeness defects.
+
+---
+
+## 2. TO-DO LIST (skill changes)
+
+### 🔴 Must fix
+
+**TODO-1 — Bond sizing / stake cap (the big one).** Current text: *"Min bond balance — 7 SOL; below this, stake cap is reduced, not eligibility revoked."*
+- ✅ **Keep the 7 SOL** — confirmed it is the **live production value** (`minBondBalanceSol: 7`) in the SAM scoring config. But label it *"production SAM config value,"* not a validator-bonds constant (the code default is `0`; on-chain floor is `MIN_STAKE_LAMPORTS = 1 SOL`).
+- ❌ **Fix the behavior** — below **80% of min (5.6 SOL)** the stake cap is **revoked to 0**, not "reduced." (`refs/ds-sam/.../constraints.ts:275` `clipBondStakeCap`.) Proven live: validator `DeEpSdaw…` at 0.673 SOL gets **zero** stake.
+- ➕ **Add the capacity formula + bond-vs-bid distinction** — see TODO-7.
+
+**TODO-2 — BidTooLowPenalty trigger is wrong.** Current: *"Bid below minimum threshold."* Real trigger: validator **lowers its bid vs the previous epoch** (`refs/ds-sam/.../calculations.ts:248`, comment *"penalizes validators who reduce their commitment compared to the last epochs"*). The eval case had this right; the skill was wrong.
+
+### 🟠 Should fix
+
+**TODO-3 — Add the `PriorityFee` settlement type.** The enum has **7** top-level variants; the skill lists 6 (`settlement-distributions/settlement-common/src/settlement_collection.rs:32`). Confirmed live: validator `BLX5…` has 12 real PriorityFee charges.
+
+**TODO-4 — "3-epoch lockup" is configurable.** It's `config.withdraw_lockup_epochs` (`programs/validator-bonds/src/state/config.rs:17`), currently ~3. Reword to *"lockup = `config.withdraw_lockup_epochs` (currently ~3)."*
+
+**TODO-7 — The skill cannot answer "how much bond do I need for max stake."** (New, from the end-user tests.) It knows only the 7 SOL floor — it has no bond→stake **capacity formula** and no notion of the **auction clearing price**, so it cannot tell a *bond-constrained* validator apart from a *bid-constrained* one. Either:
+- (a) add the capacity formula (`bondStakeCapSam`, `refs/ds-sam/.../constraints.ts:212`) and the "is your blocker the bond or the bid?" distinction, **or**
+- (b) explicitly state this question needs the live SAM scores API and point operators there — rather than implying bond is always the lever.
+
+### 🟡 Nice to have
+
+**TODO-5 — Mark upstream-determined facts as upstream** (BidTooLowPenalty, BlacklistPenalty, BondRiskFee triggers, clearing price → ds-sam/ds-scoring/sam-blacklist; InstitutionalPayout APY → institutional-staking). The 50bps figure itself is fine (`packages/validator-bonds-cli-institutional/README.md:237`).
+
+**TODO-6 — Blacklist reasons ("sandwich, slow slots")** are unverified (sam-blacklist is private); flag as upstream-sourced.
+
+### ⚪ Eval-side (separate hand-off to eval owner)
+- `cases/bond-risk-fee.yaml` fact `"insufficient"` is unverified (ds-scoring private); the skill's *"risk premium (scoring-calculated)"* is more defensible.
+- `cases/settlement-types.yaml` should add `PriorityFee` to its `facts` (TODO-3).
+- `cases/bid-too-low-penalty.yaml` facts (`reduces`, `previous epoch`) were **correct** — confirms TODO-2.
+
+---
+
+## 3. Code-vs-eval audit (19 cases)
+
+✅ Confirmed in this repo · 🔻 Upstream (true, logic not here) · ⚠️ Problem
+
+| # | Case | Verdict | Evidence |
+|---|---|---|---|
+| 1 | program-id | ✅ | `programs/validator-bonds/src/lib.rs:38` |
+| 2 | bond-authority | ✅ | `programs/validator-bonds/src/checks.rs:109` |
+| 3 | fund-bond | ✅ | `programs/validator-bonds/src/instructions/bond/fund_bond.rs:98` |
+| 4 | withdrawal-steps | ⚠️ | lockup configurable (TODO-4) |
+| 5 | bond-sizing | ⚠️ | 7 SOL real in prod config; "not revoked" false (TODO-1) |
+| 6 | settlement-types | ⚠️ | `PriorityFee` omitted (TODO-3) — `settlement-common/src/settlement_collection.rs:32` |
+| 7 | psr-definition | ✅ | `settlement-common/src/protected_events.rs:224` |
+| 8 | downtime-revenue-impact | ✅ | `settlement-config.yaml:40` |
+| 9 | commission-increase-penalty | ✅ | `settlement-common/src/protected_events.rs:175`, `settlement-config.yaml:55` |
+| 10 | merkle-settlements | ✅ | `merkle-generator/src/merkle_generator.rs:98` + `.../claim_settlement.rs:238` |
+| 11 | epoch-lifecycle | ✅ | `epochs_to_claim_settlement` gates claim/close |
+| 12 | cpmpe-definition | ✅ | CLI README + `/1000` in code |
+| 13 | last-price-clearing | ✅ (upstream) | `refs/ds-sam/.../auction.ts:72` |
+| 14 | bidding-settlement | ✅ | `Bidding` variant, funder `ValidatorBond` |
+| 15 | bid-too-low-penalty | 🔻→⚠️ | trigger in ds-sam (`calculations.ts:248`); skill mislabels (TODO-2) |
+| 16 | bond-risk-fee | 🔻 | `bid-distribution/src/sam_meta.rs:66`; trigger in ds-scoring (private) |
+| 17 | blacklist-penalty | 🔻 | `bid-distribution/src/generators/sam_penalties.rs:86`; reasons in sam-blacklist (private) |
+| 18 | institutional-payout | ✅ / 🔻 | defined here; 50bps in `cli-institutional/README.md:237`; calc upstream |
+| 19 | two-staker-populations | ✅ | separate engines + SettlementReasons |
+
+---
+
+## 4. Upstream verification (`refs/ds-sam`, public)
+
+`ds-scoring`, `sam-blacklist`, `institutional-staking` are **private** — not clonable without GitHub auth.
+
+| Fact | Verdict | Source |
+|---|---|---|
+| bid-too-low = "reduces bid vs previous epoch" | ✅ CONFIRMED (eval right, skill wrong) | `calculations.ts:248` |
+| last-price clearing = last winning group's PMPE | ✅ CONFIRMED (uniform clearing) | `auction.ts:72` / `:103` |
+| minBondBalance behavior "reduced not revoked" | ❌ REFUTED — tiered, <80% → cap `0` | `constraints.ts:275` |
+| minBondBalance = **7 SOL** | ✅ CONFIRMED as **live production value** | SAM scoring config (`scoring.marinade.finance`) |
+| bond → stake capacity formula | ✅ found (`bondStakeCapSam`) | `constraints.ts:212` |
+| bond-risk-fee = "insufficient" | 🔒 unverifiable | ds-scoring (private) |
+| blacklist "sandwich / slow slots" | 🔒 unverifiable | sam-blacklist (private) |
+
+**Production SAM config (live, epoch 987):** `minBondBalanceSol: 7`, `minBondEpochs: 4`, `idealBondEpochs: 12`, `bondRiskFeeMult: 0.2`, `maxMarinadeTvlSharePerValidatorDec: 0.15`.
+
+---
+
+## 5. End-user case studies (live data)
+
+Data: `validator-bonds-api.marinade.finance/{bonds,protected-events}` and `scoring.marinade.finance/api/v1/scores/sam`. Epoch 987.
+
+### Case A — `BLX5PkLh7GsHaqCpLDxiW3UjxfT2GMyteVAhRZBYhCts` — *"Why did you take my stake?"*
+Bond ~9.04 SOL funded (effective 0). **~215.6 SOL charged across 223 settlements:**
+
+| Reason | Charged | Events |
+|---|---|---|
+| Bidding (paying the winning bid — not a penalty) | 190.24 SOL | 205 |
+| ProtectedEvent: CommissionSamIncrease | 10.54 SOL | 2 |
+| BidTooLowPenalty | 10.40 SOL | 2 |
+| BondRiskFee | 4.10 SOL | 2 |
+| PriorityFee | 0.35 SOL | 12 |
+
+**Smoking gun — epoch 983 (13.87 SOL):** validator raised **inflation commission 4% → 100%** (98.3% reward loss to stakers) → `CommissionSamIncrease` charged 10.36 SOL from the bond, with markup penalty.
+
+**Skill verdict:** ✅ explains CommissionSamIncrease correctly · ❌ **omits PriorityFee entirely** (12 real charges) · ⚠️ **mislabels BidTooLowPenalty** cause.
+
+### Case B — `DeEpSdaw8uBLQ5T2HQhDf8fBSVbm13jGqJwoSF3HTpL5` — *"How much extra bond for max stake?"*
+Bond **0.673 SOL**, wants **5,500 SOL**, getting **0** (`constraints: "BOND"`).
+- Bond 0.673 < 5.6 (=0.8×7) → `clipBondStakeCap` returns **0** → zero stake.
+- Capacity to back 5,500 SOL needs only ~3.3 SOL — so the **7 SOL floor is what binds**.
+- At 7 SOL the bond supports ~11,500–16,400 SOL (well over the 5,500 request).
+
+**Answer: add ~6.33 SOL** (0.673 → 7.0). **Bond-constrained.**
+**Skill verdict:** ✅ *incidentally* right ("get to 7 SOL"), because the floor dominates here — but it has no capacity formula and misframes "revoked vs reduced."
+
+### Case C — `EARNynHRWg6GfyJCmrrizcZxARB3HVzcaasvNa8kBS72` — *"How much extra bond for max stake?"*
+Bond **399.86 SOL**, wants **500,000 SOL**, getting **0** (`constraints: ""` — *not* bond-limited).
+- Bond backs ~650,000–933,000 SOL; backing 500,000 needs only ~307 SOL → **already covered**.
+- Real blocker: **bid**. Auction clearing price ≈ **0.3436** totalPmpe; theirs = **0.3428** — loses by ~0.0008.
+
+**Answer: add 0 bond — raise the bid.** **Bid-constrained.**
+**Skill verdict:** ❌ cannot answer — no auction model; would say *"you're above 7 SOL, you're fine"* and miss the real cause, risking the operator wasting SOL on bond that does nothing.
+
+### The contrast (the core lesson → TODO-7)
+| Validator | Real constraint | Correct answer | Skill |
+|---|---|---|---|
+| `DeEpSdaw…` | **Bond** (0.673 < 7 floor) | +6.3 SOL bond | ✅ incidentally right |
+| `EARNynHR…` | **Bid** (totalPmpe < clearing) | +0 bond, raise bid | ❌ would mislead |
+
+Answering "how much bond for max stake" correctly requires telling **bond-constrained** from **bid-constrained**, which needs the SAM scores API + ds-sam logic. The skill has neither.
+
+---
+
+## 6. Install path — plugin marketplace (tested ✅)
+
+The skill ships as a plugin but **lacked the manifests a marketplace requires**. Added and validated:
+
+**`.claude-plugin/marketplace.json`** (repo root)
+```json
+{
+  "name": "marinade",
+  "description": "Marinade Finance plugins — Validator Bonds protocol knowledge skills.",
+  "owner": { "name": "Marinade Finance", "url": "https://github.com/marinade-finance" },
+  "plugins": [
+    {
+      "name": "validator-bonds",
+      "source": "./plugins/validator-bonds",
+      "description": "Validator Bonds protocol knowledge skills (marinade-sam-bond, marinade-ecosystem)."
+    }
+  ]
+}
+```
+
+**`plugins/validator-bonds/.claude-plugin/plugin.json`**
+```json
+{
+  "name": "validator-bonds",
+  "version": "0.1.0",
+  "description": "Marinade Validator Bonds protocol knowledge — SAM auction, settlement types, PSR, bond lifecycle, and ecosystem map.",
+  "author": { "name": "Marinade Finance" }
+}
+```
+
+**Verified flow:** `plugin validate` (both ✔) → `marketplace add ./` → `plugin install validator-bonds@marinade` → installed, enabled, 2 skills detected (~339 tok always-on).
+
+**To publish:** these manifests + the skills must be committed to the branch users install from (currently the skills live only on `20260312_skill`, with no manifests). Then anyone can `claude plugin marketplace add marinade-finance/validator-bonds`.
+
+---
+
+## 7. Artifacts
+- Skills installed (test): plugin `validator-bonds@marinade` (user scope).
+- Manifests: `.claude-plugin/marketplace.json`, `plugins/validator-bonds/.claude-plugin/plugin.json`.
+- Bundle: `validator-bonds-plugin.zip` (marketplace-installable).
+- Upstream clone: `refs/ds-sam` (public). Other upstream repos require GitHub auth.
+- Eval harness: `plugins/validator-bonds/evals/` (`bun runner.ts`).

--- a/plugins/validator-bonds/.claude-plugin/plugin.json
+++ b/plugins/validator-bonds/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "validator-bonds",
+  "version": "0.1.0",
+  "description": "Marinade Validator Bonds protocol knowledge — SAM auction, settlement types, PSR, bond lifecycle, and ecosystem map.",
+  "author": {
+    "name": "Marinade Finance"
+  }
+}

--- a/plugins/validator-bonds/evals/README.md
+++ b/plugins/validator-bonds/evals/README.md
@@ -1,0 +1,97 @@
+# Validator Bonds Skill Evals
+
+Automated eval runner for Claude Code skill routing. Asks Claude questions and
+checks that answers contain expected facts — testing whether skills trigger and
+surface the right content.
+
+## Quick Start
+
+```bash
+cd plugins/validator-bonds/evals
+
+# Run all cases (default: ./cases/)
+bun runner.ts
+
+# Run only first 2 cases
+bun runner.ts -2
+
+# Single case
+bun runner.ts cases/bidding-settlement.yaml
+
+# Baseline — disable all skills for comparison
+bun runner.ts --no-skills
+
+# Explicit plugin dir — override which plugin is loaded
+bun runner.ts --plugin-dir ../../..
+
+# Custom output tag (default: YYYYMMDD)
+bun runner.ts -t baseline-20260527
+```
+
+Output: pass/fail per case, missing facts printed inline, detailed YAML log at
+`./report/<tag>/eval-<timestamp>.yml`.
+
+## Clean Isolation (dockbox)
+
+`claude -p` in the project dir picks up `~/.claude/skills/` (global skills).
+To test only validator-bonds skills, run in dockbox — fresh home directory
+means no global skills load, only `--plugin-dir` content.
+
+```bash
+dockbox run --env ANTHROPIC_API_KEY -v $(pwd)/../../../:/repo \
+  bun /repo/plugins/validator-bonds/evals/runner.ts \
+    --plugin-dir /repo/plugins/validator-bonds
+```
+
+## Case Format
+
+```yaml
+question: >
+  What is a Bidding settlement? Which staker population receives it,
+  how is the payout determined, and what backs the payment?
+facts:
+  - Bidding
+  - native stakers
+  - effective_bid_pmpe
+  - bond
+```
+
+`facts` are checked case-insensitively (substring). Misses go to Haiku as a
+semantic judge. A case passes only when all facts pass.
+
+Facts must be grounded in the skill's SKILL.md — if the content isn't there,
+the model can't be expected to produce it from skill routing alone.
+
+## Adding Cases
+
+1. Create `cases/<name>.yaml` with `question` and `facts`.
+2. Verify the facts appear verbatim or semantically in
+   `skills/marinade-sam-bond/SKILL.md` or `skills/marinade-ecosystem/SKILL.md`.
+3. Run the single case to confirm it passes.
+
+Question inspiration: `skills/marinade-sam-bond/evals/questions.md` and
+`skills/marinade-ecosystem/evals/questions.md`.
+
+## Log Format
+
+```yaml
+meta:
+  mode: plugin:../../.. # or 'no-skills' or 'default'
+  flags: [--plugin-dir, ../../..]
+  plugin_dir: ../../..
+  tag: '20260527'
+  started_at: 2026-05-27T10:00:00.000Z
+cases:
+  - case: bidding-settlement
+    result: pass # pass | fail | error
+    question: '...'
+    answer: '...'
+    facts:
+      - fact: Bidding
+        passed: true
+        method: exact # exact | haiku | error
+      - fact: ValidatorBond
+        passed: true
+        method: haiku
+        haiku_verdict: YES
+```

--- a/plugins/validator-bonds/evals/cases/bid-too-low-penalty.yaml
+++ b/plugins/validator-bonds/evals/cases/bid-too-low-penalty.yaml
@@ -1,0 +1,5 @@
+question: 'What triggers a BidTooLowPenalty settlement?'
+facts:
+  - 'BidTooLowPenalty'
+  - 'reduces'
+  - 'previous epoch'

--- a/plugins/validator-bonds/evals/cases/bidding-settlement.yaml
+++ b/plugins/validator-bonds/evals/cases/bidding-settlement.yaml
@@ -1,0 +1,9 @@
+question: >
+  What is a Bidding settlement in the SAM auction? Which staker population
+  receives it, how is the payout amount determined, and what on-chain account
+  backs the payment?
+facts:
+  - Bidding
+  - mSOL stakers
+  - bid amount
+  - bond

--- a/plugins/validator-bonds/evals/cases/blacklist-penalty.yaml
+++ b/plugins/validator-bonds/evals/cases/blacklist-penalty.yaml
@@ -1,0 +1,7 @@
+question: 'What triggers a BlacklistPenalty and who receives the settlement?'
+facts:
+  - 'blacklisted'
+  - 'sandwich'
+  - 'slow slots'
+  - 'stakers'
+  - 'ValidatorBond'

--- a/plugins/validator-bonds/evals/cases/bond-authority.yaml
+++ b/plugins/validator-bonds/evals/cases/bond-authority.yaml
@@ -1,0 +1,4 @@
+question: "Who can sign bond management transactions?"
+facts:
+  - "bond.authority"
+  - "validator identity"

--- a/plugins/validator-bonds/evals/cases/bond-risk-fee.yaml
+++ b/plugins/validator-bonds/evals/cases/bond-risk-fee.yaml
@@ -1,0 +1,5 @@
+question: 'What is the BondRiskFee settlement and when does it trigger?'
+facts:
+  - 'BondRiskFee'
+  - 'insufficient'
+  - "validator's bond"

--- a/plugins/validator-bonds/evals/cases/bond-sizing.yaml
+++ b/plugins/validator-bonds/evals/cases/bond-sizing.yaml
@@ -1,0 +1,5 @@
+question: 'My bond dropped below 7 SOL — will I be excluded from the next auction?'
+facts:
+  - '7 SOL'
+  - 'minimum'
+  - 'stake cap'

--- a/plugins/validator-bonds/evals/cases/commission-increase-penalty.yaml
+++ b/plugins/validator-bonds/evals/cases/commission-increase-penalty.yaml
@@ -1,0 +1,5 @@
+question: "What triggers a CommissionSamIncrease protected event?"
+facts:
+  - "commission raised above declared bid"
+  - "markup penalty"
+  - "stakers"

--- a/plugins/validator-bonds/evals/cases/cpmpe-definition.yaml
+++ b/plugins/validator-bonds/evals/cases/cpmpe-definition.yaml
@@ -1,0 +1,8 @@
+question: >
+  What does CPMPE mean and how is it used as a bid in the SAM auction?
+  Explain the unit, how the winning price is determined, and whether bids
+  must be a fixed amount or can be expressed differently.
+facts:
+  - lamports per 1000 SOL per epoch
+  - dynamic commission
+  - auction

--- a/plugins/validator-bonds/evals/cases/downtime-revenue-impact.yaml
+++ b/plugins/validator-bonds/evals/cases/downtime-revenue-impact.yaml
@@ -1,0 +1,7 @@
+question: 'What is a DowntimeRevenueImpact protected event and how is it funded?'
+facts:
+  - 'fewer credits than expected'
+  - 'ValidatorBond'
+  - 'Marinade'
+  - 'ProtectedEvent'
+  - '0-50%'

--- a/plugins/validator-bonds/evals/cases/epoch-lifecycle.yaml
+++ b/plugins/validator-bonds/evals/cases/epoch-lifecycle.yaml
@@ -1,0 +1,11 @@
+question: >
+  Explain the full epoch lifecycle for Validator Bonds settlements: how are
+  settlement trees generated, how do they reach the chain, what is the
+  claiming window, and what happens to unclaimed funds after it closes?
+facts:
+  - merkle
+  - claiming window
+  - off-chain
+  - on-chain
+  - ~4 epochs
+  - unclaimed funds return to bond

--- a/plugins/validator-bonds/evals/cases/fund-bond.yaml
+++ b/plugins/validator-bonds/evals/cases/fund-bond.yaml
@@ -1,0 +1,6 @@
+question: "What does fund_bond do and how is a bond recovered?"
+facts:
+  - "stake ownership"
+  - "bonds PDA"
+  - "withdraw request"
+  - "3-epoch lockup"

--- a/plugins/validator-bonds/evals/cases/institutional-payout.yaml
+++ b/plugins/validator-bonds/evals/cases/institutional-payout.yaml
@@ -1,0 +1,6 @@
+question: 'What is an InstitutionalPayout settlement and who is it for?'
+facts:
+  - 'institutional stakers'
+  - 'Select'
+  - '50bps'
+  - 'APY'

--- a/plugins/validator-bonds/evals/cases/last-price-clearing.yaml
+++ b/plugins/validator-bonds/evals/cases/last-price-clearing.yaml
@@ -1,0 +1,5 @@
+question: 'How does the last-price clearing mechanism work in the SAM auction?'
+facts:
+  - 'clearing price'
+  - 'bid'
+  - 'winningTotalPmpe'

--- a/plugins/validator-bonds/evals/cases/merkle-settlements.yaml
+++ b/plugins/validator-bonds/evals/cases/merkle-settlements.yaml
@@ -1,0 +1,6 @@
+question: "How do merkle settlements work in the Validator Bonds protocol?"
+facts:
+  - "off-chain generated"
+  - "on-chain verified"
+  - "merkle proof"
+  - "claim"

--- a/plugins/validator-bonds/evals/cases/program-id.yaml
+++ b/plugins/validator-bonds/evals/cases/program-id.yaml
@@ -1,0 +1,3 @@
+question: "What is the Validator Bonds program ID?"
+facts:
+  - "vBoNdEvzMrSai7is21XgVYik65mqtaKXuSdMBJ1xkW4"

--- a/plugins/validator-bonds/evals/cases/psr-definition.yaml
+++ b/plugins/validator-bonds/evals/cases/psr-definition.yaml
@@ -1,0 +1,7 @@
+question: >
+  What is PSR (Protected Staking Rewards)? Explain what triggers a PSR
+  payout, how the underperformance threshold is calculated, and what staker
+  population is covered.
+facts:
+  - network average
+  - underperformance

--- a/plugins/validator-bonds/evals/cases/settlement-types.yaml
+++ b/plugins/validator-bonds/evals/cases/settlement-types.yaml
@@ -1,0 +1,10 @@
+question: 'What are all the settlement types in the Validator Bonds protocol?'
+facts:
+  - 'Bidding'
+  - 'BidTooLowPenalty'
+  - 'BlacklistPenalty'
+  - 'BondRiskFee'
+  - 'InstitutionalPayout'
+  - 'ProtectedEvent'
+  - 'DowntimeRevenueImpact'
+  - 'CommissionSamIncrease'

--- a/plugins/validator-bonds/evals/cases/two-staker-populations.yaml
+++ b/plugins/validator-bonds/evals/cases/two-staker-populations.yaml
@@ -1,0 +1,8 @@
+question: 'What are the two staker populations in Validator Bonds and how do they differ?'
+facts:
+  - 'mSOL'
+  - 'institutional'
+  - 'liquid staking'
+  - 'native staking'
+  - '50bps'
+  - 'bidding settlements'

--- a/plugins/validator-bonds/evals/cases/withdrawal-steps.yaml
+++ b/plugins/validator-bonds/evals/cases/withdrawal-steps.yaml
@@ -1,0 +1,4 @@
+question: 'What are the steps to withdraw from a validator bond?'
+facts:
+  - '3-epoch lockup'
+  - 'withdraw request'

--- a/plugins/validator-bonds/evals/runner.ts
+++ b/plugins/validator-bonds/evals/runner.ts
@@ -1,0 +1,197 @@
+#!/usr/bin/env bun
+// Usage: bun runner.ts [--plugin-dir <path>] [--no-skills] [-t <tag>] [-N] [cases-dir|file.yaml...]
+// Each .yaml: { question: string, facts: string[] }
+// --plugin-dir  load only this plugin; skills auto-trigger based on routing
+// --no-skills   disable all skills (baseline comparison)
+// -t <tag>      output tag (default: YYYYMMDD); written to ./report/<tag>/
+// -N            run only first N cases (e.g. -1, -2, -3)
+// Positionals default to ./cases relative to this script.
+// Run in dockbox for clean isolation (fresh home = no global skills, ANTHROPIC_API_KEY forwarded).
+// Facts: case-insensitive includes() first; semantic misses go to haiku with XML delimiters.
+
+import { parseArgs } from 'node:util'
+import { parse, stringify } from 'yaml'
+import { $ } from 'bun'
+import { readdir, readFile, stat, mkdir, writeFile } from 'fs/promises'
+import { join, basename, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+interface Case {
+  question: string
+  facts: string[]
+}
+
+interface FactResult {
+  fact: string
+  passed: boolean
+  method: 'exact' | 'haiku' | 'error'
+  haiku_verdict?: string
+  error?: string
+}
+
+interface CaseResult {
+  case: string
+  result: 'pass' | 'fail' | 'error'
+  question: string
+  answer?: string
+  error?: string
+  facts: FactResult[]
+}
+
+interface RunMeta {
+  mode: string
+  flags: string[]
+  plugin_dir?: string
+  tag: string
+  started_at: string
+}
+
+// Extract -N flags (e.g. -1, -2) before parseArgs since they're not valid option names
+const rawArgs = Bun.argv.slice(2)
+let limit: number | null = null
+const filteredArgs = rawArgs.filter(a => {
+  const m = a.match(/^-(\d+)$/)
+  if (m) {
+    limit = parseInt(m[1], 10)
+    return false
+  }
+  return true
+})
+
+const { values, positionals } = parseArgs({
+  args: filteredArgs,
+  options: {
+    'plugin-dir': { type: 'string' },
+    'no-skills': { type: 'boolean', default: false },
+    t: { type: 'string' },
+  },
+  allowPositionals: true,
+})
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const defaultCasesDir = join(scriptDir, 'cases')
+const casePaths = positionals.length > 0 ? positionals : [defaultCasesDir]
+
+const today = new Date()
+const defaultTag = `${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(today.getDate()).padStart(2, '0')}`
+const tag = values.t ?? defaultTag
+
+const pluginDir = values['plugin-dir']
+const baseFlags = values['no-skills']
+  ? ['--disable-slash-commands']
+  : pluginDir
+    ? ['--plugin-dir', pluginDir]
+    : []
+
+const ask = async (question: string): Promise<string> =>
+  $`claude ${baseFlags} -p ${question}`
+    .env({ ...process.env, CLAUDE_EVAL: '1' })
+    .text()
+
+const judgePrompt =
+  'You are a strict fact-checker. Given a fact and a response, output the single word YES if the response explicitly and accurately conveys that fact, or the single word NO if absent, contradicted, or only vaguely implied. No other output.'
+
+const supports = async (answer: string, fact: string): Promise<FactResult> => {
+  if (answer.toLowerCase().includes(fact.toLowerCase()))
+    return { fact, passed: true, method: 'exact' }
+  try {
+    const prompt = `<fact>${fact}</fact>\n<response>${answer}</response>`
+    const raw =
+      await $`claude --system-prompt ${judgePrompt} --model claude-haiku-4-5-20251001 -p ${prompt}`
+        .env({ ...process.env, CLAUDE_EVAL: '1' })
+        .text()
+    const verdict = raw.trim()
+    return {
+      fact,
+      passed: verdict.toUpperCase() === 'YES',
+      method: 'haiku',
+      haiku_verdict: verdict,
+    }
+  } catch (e) {
+    const error = e instanceof Error ? e.message : String(e)
+    return { fact, passed: false, method: 'error', error }
+  }
+}
+
+const expand = async (p: string): Promise<string[]> => {
+  const s = await stat(p)
+  if (s.isDirectory())
+    return (await readdir(p))
+      .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'))
+      .sort()
+      .map(f => join(p, f))
+  if (!p.endsWith('.yaml') && !p.endsWith('.yml'))
+    throw new Error(`not a YAML file: ${p}`)
+  return [p]
+}
+
+let files = (await Promise.all(casePaths.map(expand))).flat()
+
+if (files.length === 0) throw new Error('No .yaml files found')
+if (limit !== null) files = files.slice(0, limit)
+
+let passed = 0
+let failed = 0
+const meta: RunMeta = {
+  mode: values['no-skills']
+    ? 'no-skills'
+    : pluginDir
+      ? `plugin:${pluginDir}`
+      : 'default',
+  flags: baseFlags,
+  ...(pluginDir ? { plugin_dir: pluginDir } : {}),
+  tag,
+  started_at: new Date().toISOString(),
+}
+const log: { meta: RunMeta; cases: CaseResult[] } = { meta, cases: [] }
+
+for (const file of files) {
+  const { question, facts } = parse(await readFile(file, 'utf8')) as Case
+  if (!question || !Array.isArray(facts))
+    throw new Error('invalid case file: missing question or facts')
+  let entry: CaseResult
+  try {
+    const answer = await ask(question)
+    const factResults = await Promise.all(facts.map(f => supports(answer, f)))
+    const ok = factResults.every(r => r.passed)
+    entry = {
+      case: basename(file).replace(/\.ya?ml$/, ''),
+      result: ok ? 'pass' : 'fail',
+      question,
+      answer: answer.trim(),
+      facts: factResults,
+    }
+    if (ok) {
+      console.log(`✓  ${entry.case}`)
+      passed++
+    } else {
+      console.log(`✗  ${entry.case}`)
+      factResults.forEach(r => {
+        if (!r.passed) console.log(`     missing: ${r.fact}`)
+      })
+      failed++
+    }
+  } catch (e) {
+    const error = e instanceof Error ? e.message : String(e)
+    entry = {
+      case: basename(file).replace(/\.ya?ml$/, ''),
+      result: 'error',
+      question,
+      error,
+      facts: [],
+    }
+    console.log(`!  ${entry.case}  (error: ${error.slice(0, 80)})`)
+    failed++
+  }
+  log.cases.push(entry)
+}
+
+const reportDir = join('./report', tag)
+await mkdir(reportDir, { recursive: true })
+const logPath = join(
+  reportDir,
+  `eval-${new Date().toISOString().replace(/[:.]/g, '-')}.yml`,
+)
+await writeFile(logPath, stringify(log))
+console.log(`\n${passed}/${passed + failed} passed  →  ${logPath}`)
+if (failed > 0) process.exit(1)

--- a/plugins/validator-bonds/skills/marinade-ecosystem/SKILL.md
+++ b/plugins/validator-bonds/skills/marinade-ecosystem/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: marinade-ecosystem
+description: Marinade Finance public ecosystem map — repos, program IDs, SDKs, APIs, issue filing. NOT for settlement mechanics, SAM auction internals, or bond lifecycle (use marinade-sam-bond).
+when_to_use: marinade-finance GitHub org, liquid-staking-program, institutional-staking, marinade.finance site, filing an issue, program IDs, mSOL mint, MNDE token, marinade-ts-sdk, psr.marinade.finance, scoring.marinade.finance, cross-repo navigation, how repos relate
+---
+
+# Marinade Ecosystem
+
+Non-custodial liquid staking protocol on Solana. Three products:
+mSOL (liquid staking), native staking, SAM (stake auction marketplace).
+
+## Public Sites & Links
+
+| Resource         | URL                                                                                    |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| Main app         | https://marinade.finance/                                                              |
+| Docs             | https://docs.marinade.finance/                                                         |
+| Docs (beta)      | https://docs-beta.marinade.finance/                                                    |
+| PSR Dashboard    | https://psr.marinade.finance/                                                          |
+| Bonds API        | https://validator-bonds-api.marinade.finance/docs                                      |
+| SAM scoring API  | https://scoring.marinade.finance/api/v1/scores/sam?epoch=X                             |
+| GitHub org       | https://github.com/marinade-finance/                                                   |
+| npm packages     | https://www.npmjs.com/package/@marinade.finance/validator-bonds-cli                    |
+| PSR explainer    | https://marinade.finance/how-it-works/psr                                              |
+| PSR blog post    | https://marinade.finance/blog/introducing-protected-staking-rewards/                   |
+| SAM docs         | https://docs.marinade.finance/marinade-protocol/protocol-overview/stake-auction-market |
+| Discord PSR feed | https://discord.com/channels/823564092379627520/1223330302890348754                    |
+| GCS epoch data   | https://console.cloud.google.com/storage/browser/marinade-validator-bonds-mainnet      |
+
+ALWAYS verify addresses at https://docs-beta.marinade.finance/developers/contracts/
+
+## Filing Issues
+
+- **Bugs / feature requests:** Open an issue at https://github.com/marinade-finance/<repo>/issues
+- **Validator bonds specifically:** https://github.com/marinade-finance/validator-bonds/issues
+- **Community support:** Discord PSR feed channel (link above) for PSR/bond questions
+- **Notifications:** Validators can subscribe via CLI (`bonds subscribe --type telegram --address <handle>`) for bond event alerts
+
+## Domain Concepts
+
+- **mSOL** — liquid staking token, stake SOL get mSOL for DeFi
+- **SAM** — stake auction marketplace, epoch-based validator bidding
+- **PSR** — protected staking rewards, bond collateral for underperformance
+
+## Program IDs & Tokens
+
+| Name                 | Address                                       |
+| -------------------- | --------------------------------------------- |
+| Liquid Staking       | `MarBmsSgKXdrN1egZf5sqe1TMai9K1rChYNDJgjq7aD` |
+| Native Staking Proxy | `mnspJQyF1KdDEs5c6YJPocYdY1esBgVQFufM2dY9oDk` |
+| Directed Stake       | `dstK1PDHNoKN9MdmftRzsEbXP5T1FTBiQBm1Ee3meVd` |
+| Validator Bonds      | `vBoNdEvzMrSai7is21XgVYik65mqtaKXuSdMBJ1xkW4` |
+| mSOL Mint            | `mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So` |
+| MNDE Token           | `MNDEFzGvMt87ueuHvVU9VcTqsAP5b3fTGPsHuuPA5ey` |
+
+## Public Repos
+
+All at https://github.com/marinade-finance/
+
+### On-chain Programs
+
+- **liquid-staking-program** — core mSOL staking + swap pool (Anchor/Rust)
+- **validator-bonds** — bond accounts + settlement pipeline (Anchor/Rust, TS SDK/CLI, Rust API)
+- **vote-aggregator** — aggregated delegation plugin for spl-governance
+- **voter-stake-registry** — vote weight plugin, token lockups
+- **tokadapt** — 1:1 token swap contract
+
+### Delegation & Scoring
+
+- **ds-sam** — SAM evaluation CLI + SDK (`ds-sam-sdk`), APIS/FILES modes
+- **ds-sam-pipeline** — SAM pipeline orchestration
+- **ds-scoring** — NestJS scoring service for validators
+- **delegation-strategy-2** — validator scoring API, stake allocation
+- **sam-blacklist** — blacklist generator (sandwich + slow slot data)
+- **marcrank** — management CLI for liquid-staking-program delegation (internal)
+- **malicious-validators** — validator abuse tracking (internal)
+
+### SDKs & Libraries
+
+- **marinade-ts-sdk** — liquid staking TS SDK (deposit, unstake, liquidity)
+- **marinade-ts-cli** — TS CLI client for Marinade
+- **typescript-common** — pnpm monorepo of `@marinade.finance/*` packages
+- **go-common** — reusable Go packages (config, logger)
+- **solana-transaction-builder** — Rust tx builder utility
+- **solana-transaction-executor** — Rust tx execution
+- **marinade-common-rs-cli** — Rust common CLI library
+
+### Products & Services
+
+- **native-staking** — native staking app, validator selection via SAM
+- **institutional-staking** — institutional staking product (calc + API)
+- **marinade-web** — marinade.finance frontend
+- **staking-rewards** — rewards collector backend
+- **staking-rewards-facade** — NestJS GraphQL API (filters, CSV/XLSX/PDF)
+- **apy-api** — APY wrapper using @glitchful-dev/sol-apy-sdk
+- **psr-dashboard** — PSR validator bond dashboard
+- **marinade-sam-bot** — optimal SAM bid calculator
+
+### Infrastructure & Data
+
+- **stakes-etl** — ETL pipelines to Google BigQuery
+- **solana-snapshot-manager** — Solana snapshot parser + API (internal/unconfirmed)
+- **solana-snapshot-parser** — low-level snapshot parsing (internal/unconfirmed)
+- **kedgeree** — reverse PDA/seeded address calculation (internal/unconfirmed)
+- **solana-sandwich-report** — validator sandwich rate API + epoch charts
+- **spl-gov-notifier** — SPL governance event notification bot
+
+## Public SDKs
+
+| Package                                | Purpose                                     |
+| -------------------------------------- | ------------------------------------------- |
+| `@marinade.finance/marinade-ts-sdk`    | Liquid staking: deposit, unstake, liquidity |
+| `@marinade.finance/native-staking-sdk` | Native staking integration                  |
+| `ds-sam-sdk`                           | SAM delegation strategy evaluation          |
+
+## @marinade.finance Packages
+
+Published from `typescript-common` monorepo:
+
+| Package         | Purpose                                                |
+| --------------- | ------------------------------------------------------ |
+| `cli-common`    | CLI helpers: keypair loading, tx confirmation, logging |
+| `ts-common`     | Shared TS utils: retry, sleep, error handling          |
+| `config-common` | `configGetter` pattern for typed env/config access     |
+| `nestjs-common` | NestJS modules: health, config, logging, APM           |
+| `web3js-kit`    | web3.js 2.x helpers: connection, transaction building  |
+| `web3js-1x`     | web3.js 1.x compat layer and helpers                   |
+| `anchor-common` | Anchor framework helpers: IDL loading, program access  |

--- a/plugins/validator-bonds/skills/marinade-ecosystem/evals/questions.md
+++ b/plugins/validator-bonds/skills/marinade-ecosystem/evals/questions.md
@@ -1,0 +1,61 @@
+# Eval Questions: marinade-ecosystem Skill
+
+## Factual Recall
+
+### Program IDs & Tokens
+
+1. What is the Validator Bonds program ID?
+2. What is the mSOL mint address?
+3. What is the Liquid Staking program ID?
+4. What is the MNDE token address?
+5. Where should I verify program addresses before using them?
+
+### Public Links & Sites
+
+6. What is the URL for the Marinade developer docs?
+7. Where can I find the PSR Dashboard?
+8. What is the Bonds API docs URL?
+9. How do I get SAM scoring data for a specific epoch?
+10. Where is the GCS bucket for epoch data?
+11. Where can I find the Discord PSR feed channel?
+12. What npm package contains the validator-bonds CLI?
+
+### Repo Navigation
+
+13. Which repo implements the core mSOL staking program?
+14. Which repo is the SAM evaluation CLI and SDK in?
+15. Where is the validator scoring API and stake allocation logic?
+16. Which repo generates the SAM blacklist?
+17. Where does the institutional staking product live?
+18. Which repo is the PSR Dashboard frontend?
+19. What repo would I look at to understand how SAM auction results flow into delegation?
+
+### Packages & SDKs
+
+20. Which package provides the `configGetter` pattern?
+21. What is `@marinade.finance/cli-common` used for?
+22. Which SDK would I use to integrate liquid staking (deposit, unstake) from TypeScript?
+23. What is `ds-sam-sdk` for?
+24. Which package is `web3js-kit` and when would I use it over `web3js-1x`?
+
+## Issue Filing
+
+25. How do I file a bug against the validator bonds repo?
+26. How can a validator subscribe to bond event notifications?
+27. Where do validators go for community support about PSR/bond questions?
+
+## Pattern Knowledge
+
+28. How does the `configGetter` pattern work — show an example with `RPC_URL` (required) and `PORT` (default 3000)?
+29. What database library does Marinade use and what's the key rule for queries?
+30. All TS repos use pnpm workspaces — what command targets a specific package?
+31. When should a new service use Bun vs Node.js?
+
+## Cross-Repo Navigation (Scenario)
+
+32. I need to debug why a validator isn't getting SAM stake — which repos and tools should I look at?
+33. I want to build a TS integration that deposits SOL for mSOL — what SDK and package do I start with?
+34. A user reports that their bond was charged for a PSR event they didn't expect — where do I find the PSR event data and which repos handle that flow?
+35. I want to add a new endpoint to the Bonds API — which repo and what language/framework is it in?
+36. The SAM auction config changed and I want to see the history — where do I look?
+37. A validator wants to know their current bid price and expected stake allocation — what public tool or API do they use?

--- a/plugins/validator-bonds/skills/marinade-sam-bond/SKILL.md
+++ b/plugins/validator-bonds/skills/marinade-sam-bond/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: marinade-sam-bond
+description: Validator Bonds protocol internals — settlement types, SAM auction, bond collateral, PSR, epoch lifecycle. NOT for ecosystem navigation or issue filing (use marinade-ecosystem).
+when_to_use: CPMPE, PMPE, totalPmpe, PSR, SAM auction, ValidatorBond, SettlementReason, ProtectedEvent, BidTooLowPenalty, BlacklistPenalty, BondRiskFee, InstitutionalPayout, fund_bond, withdraw_request, init_withdraw_request, claim_withdraw_request, merkle settlement, bid-distribution, settlement-config.yaml, programs/validator-bonds/, settlement-distributions/, settlement-pipelines/, packages/validator-bonds-*, mSOL stakers, native staking, Select stakers, institutional stakers, bond collateral, clearing price, winningTotalPmpe, validator bid, dynamic commission, dynamic bids, minimum bond balance, minBondBalance, 7 SOL, program ID, vBoNdEvzMrSai7is21XgVYik65mqtaKXuSdMBJ1xkW4
+---
+
+# Validator Bonds Protocol Context
+
+Validators post SOL bonds as collateral to compete for Marinade's delegated stake via SAM (Stake Auction Marketplace). Bonds guarantee mSOL holders earn at minimum network-average rewards (PSR), and provide a 50bps APY guarantee for institutional/Select stakers -- underperformance triggers automatic compensation from the bond.
+
+**Two staker populations:** mSOL holders (liquid staking, bidding settlements) and institutional/Select stakers (native staking, 50bps APY guarantee).
+
+## Settlement Types
+
+Top-level `SettlementReason` variants (`settlement-common/src/settlement_collection.rs`): `Bidding`, `BidTooLowPenalty`, `BlacklistPenalty`, `BondRiskFee`, `InstitutionalPayout`, and `ProtectedEvent(...)` which wraps a protected-event sub-kind.
+
+| Type                  | SettlementReason          | Trigger                                 | Funder                                     | Recipient                     |
+| --------------------- | ------------------------- | --------------------------------------- | ------------------------------------------ | ----------------------------- |
+| Bidding               | `Bidding`                 | Validator wins auction, owes bid amount | ValidatorBond                              | mSOL stakers                  |
+| BidTooLowPenalty      | `BidTooLowPenalty`        | Bid below minimum threshold             | ValidatorBond                              | Stakers + Marinade/DAO fee    |
+| BlacklistPenalty      | `BlacklistPenalty`        | Blacklisted (sandwich, slow slots)      | ValidatorBond                              | Stakers                       |
+| BondRiskFee           | `BondRiskFee`             | Bond risk premium (scoring-calculated)  | ValidatorBond                              | Stakers                       |
+| DowntimeRevenueImpact | `ProtectedEvent` sub-kind | Fewer credits than expected             | ValidatorBond (0-50%) / Marinade (50-100%) | Stakers                       |
+| CommissionSamIncrease | `ProtectedEvent` sub-kind | Commission raised above declared bid    | ValidatorBond                              | Stakers (with markup penalty) |
+| InstitutionalPayout   | `InstitutionalPayout`     | Select program APY settlement           | ValidatorBond                              | Institutional stakers         |
+
+`ProtectedEvent` (`settlement-common/src/protected_events.rs`) also contains legacy `CommissionIncrease` and `LowCredits` (v1, no longer emitted).
+
+## Epoch Lifecycle
+
+1. **Epoch X**: Validators bid (static CPMPE or dynamic commission, since Jan 2026), SAM allocates stake
+2. **Epoch X+1**: Off-chain pipelines calculate charges from epoch X performance
+3. Merkle trees generated, Settlement accounts created on-chain
+4. Bond stake accounts fund settlements (deactivated)
+5. **Claiming window** (~4 epochs): stakers prove merkle membership, claim rewards
+6. Expired settlements closed, unclaimed funds return to bond
+
+## Key Concepts
+
+- **CPMPE** -- lamports per 1000 SOL per epoch, the validator's fixed bid price
+- **Clearing price** -- `winningTotalPmpe`: PMPE of the last validator group to receive stake in the auction
+- **Program ID** -- `vBoNdEvzMrSai7is21XgVYik65mqtaKXuSdMBJ1xkW4`
+- **Min bond balance** -- 7 SOL (production `minBondBalance`); below this, stake cap is reduced, not eligibility revoked
+- **Bond authority** -- `bond.authority` field or validator identity can sign
+- **fund_bond** transfers stake ownership to bonds PDA; recovery via withdraw request (3-epoch lockup)
+- **PSR** -- Protected Staking Rewards, ensures network-average inflation regardless of validator performance
+- **Merkle settlements** -- off-chain generated, on-chain verified, efficient for large claim sets
+
+## Direct Data Dependencies
+
+Repos that feed data directly into the validator-bonds pipeline. All at `https://github.com/marinade-finance/`. Clone under `./refs/` when deeper context needed.
+
+**Direct data dependencies:**
+
+- **ds-sam** -- SAM evaluation CLI + SDK, produces auction scores for bid-distribution-cli
+- **ds-sam-pipeline** -- SAM pipeline data (auction inputs/outputs by epoch)
+- **ds-scoring** -- NestJS scoring service feeding SAM scores API
+- **institutional-staking** -- institutional staking calc + API, produces payout data
+- **stakes-etl** -- ETL pipelines producing reward files in GCS
+- **solana-snapshot-parser** -- produces stakes.json / validators.json snapshots
+
+**On-chain programs sharing state:**
+
+- **liquid-staking-program** -- core mSOL staking
+
+**SDKs/libraries:**
+
+- **solana-transaction-builder** / **solana-transaction-executor** -- Rust tx builder/executor (workspace deps)
+- **typescript-common** -- `@marinade.finance/*` packages (cli-common, web3js, anchor-common)
+
+**Downstream consumers:**
+
+- **psr-dashboard** -- PSR validator bond dashboard (reads bonds API)


### PR DESCRIPTION
- Add .claude-plugin/marketplace.json and plugins/validator-bonds/.claude-plugin/plugin.json so the skill plugin installs via the Claude Code plugin marketplace (validated + install-tested).
- Add SKILL_AUDIT.md: code-vs-eval audit of marinade-sam-bond, upstream (ds-sam) verification, three live validator case studies, and a prioritized to-do list of skill corrections.
- Include the two knowledge skills (marinade-sam-bond, marinade-ecosystem) and the eval suite.