### PR TITLE
fix: Disable CommissionSamIncreaseSettlement penalty markup [GEN-8158]

### DIFF
--- a/settlement-config.yaml
+++ b/settlement-config.yaml
@@ -59,5 +59,5 @@ settlements:
     grace_increase_bps: 100 # 1 %
     covered_range_bps: [0, 10000] # 0 % - 100 %
     extra_penalty_threshold_bps: 700 # 7%
-    base_markup_bps: 1000 # 10%
-    penalty_markup_bps: 10000 # 100%
+    base_markup_bps: 0 # 0%
+    penalty_markup_bps: 0 # 0%


### PR DESCRIPTION
This just changes configuration which should disable the markups.