### PR TITLE
fix(track-mixpanel): strip plugin namespace from skill name

### DIFF
--- a/plugins/validator-bonds/scripts/track-mixpanel.py
+++ b/plugins/validator-bonds/scripts/track-mixpanel.py
@@ -72,7 +72,10 @@ def skill_invocations(transcript_path):
                         skill = (b.get("input") or {}).get("skill", "")
                         tid = b.get("id")
                         if skill and tid:
-                            yield tid, skill
+                            # skill may be plugin-namespaced (e.g.
+                            # "validator-bonds:find") — strip to the bare name
+                            # so it matches TRACKED_SKILLS.
+                            yield tid, skill.split(":")[-1]
     except OSError:
         return
 


### PR DESCRIPTION
## Bug
The skill-usage Stop hook silently sent **nothing** for real invocations.

Claude Code records skill tool-uses **namespaced** — `validator-bonds:marinade-sam-bond` — but `TRACKED_SKILLS` holds bare names (`marinade-sam-bond`, …), so `skill in TRACKED_SKILLS` rejected every real event. The original tests passed only because they used bare names in synthetic transcripts.

## Fix
Strip the `<plugin>:` prefix before matching/reporting (`skill.split(":")[-1]`).

## Verified
- Namespaced names (`validator-bonds:marinade-docs`, etc.) → now emit, batched, `http=200 body=1`.
- Bare names still work.
- Confirmed against a real session transcript that fired three skills (all previously dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)