### PR TITLE
Adjust settlement fee and yield premium configuration

### DIFF
--- a/settlement-config.yaml
+++ b/settlement-config.yaml
@@ -3,7 +3,7 @@ fee_config:
   min_fee_bps: 200
   max_fee_bps: 1000
   # PMPE premium added to ssi/ssr target. Range: -0.1..0.1 (~±2% APY).
-  min_yield_premium_over_ssr_pmpe: -0.008
+  min_yield_premium_over_ssr_pmpe: -0.015
   marinade:
     stake_authority: BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x
     withdraw_authority: BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x

--- a/settlement-config.yaml
+++ b/settlement-config.yaml
@@ -1,9 +1,9 @@
 ---
 fee_config:
   min_fee_bps: 200
-  max_fee_bps: 800
+  max_fee_bps: 1000
   # PMPE premium added to ssi/ssr target. Range: -0.1..0.1 (~±2% APY).
-  min_yield_premium_over_ssr_pmpe: 0
+  min_yield_premium_over_ssr_pmpe: -0.008
   marinade:
     stake_authority: BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x
     withdraw_authority: BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x


### PR DESCRIPTION
## Summary
Updates settlement configuration parameters to reflect new fee and yield premium targets for the bid-distribution settlement engine.

## Changes
- **Max fee basis points:** increased from 800 to 1000 bps
- **Minimum yield premium over SSR PMPE:** lowered from 0 to -0.015 (allowing up to ~0.3% APY below SSR target)

These configuration changes in `settlement-config.yaml` will be loaded by the bid-distribution engine (`settlement-distributions/bid-distribution/src/settlement_config.rs`) and applied to settlement computations for bidding and PSR event distributions.

https://claude.ai/code/session_016zmJA3TXuuNyAVqah6iwgQ