### PR TITLE
20260623 pre fund [TBD]

### DIFF
--- a/packages/validator-bonds-sdk/__tests__/bankrun/reserveReap.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/reserveReap.spec.ts
@@ -5,7 +5,6 @@ import {
 } from '@marinade.finance/bankrun-utils'
 import { createUserAndFund, pubkey } from '@marinade.finance/web3js-1x'
 import { Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js'
-import BN from 'bn.js'
 
 import { initBankrunTest } from './bankrun'
 import {
@@ -32,10 +31,10 @@ import type { BankrunExtendedProvider } from '@marinade.finance/bankrun-utils'
 import type { PublicKey } from '@solana/web3.js'
 
 // Reserve front (Coord Goal 2) money-flow, end to end at the program level:
-// init inflates the on-chain max_total_claim by R, the reserve fronts R from
-// marinade_wallet as an undelegated stake, and the unclaimed R is reaped back to
-// marinade_wallet at close. The merkle root still commits only to the real claims
-// (sum C), so R is never claimable and the reserve is made whole at close.
+// the fund pass creates an undelegated stake of R from marinade_wallet so stakers
+// can claim immediately; max_total_claim stays C (no inflation); at close the
+// undelegated leftover reaps back to marinade_wallet. The merkle root commits only
+// to the real claims (sum C), so claims can drain at most C from the settlement.
 describe('Validator Bonds reserve front reap', () => {
   const epochsToClaimSettlement = 1
   const reserveFront = 2 * LAMPORTS_PER_SOL // R
@@ -70,10 +69,11 @@ describe('Validator Bonds reserve front reap', () => {
     })
   })
 
-  it('inflates max by R and reaps the front to marinade_wallet at close', async () => {
-    // Real claim sum C (committed by the merkle root) and the inflated max C + R.
+  it('reaps the undelegated reserve front to marinade_wallet at close', async () => {
+    // max_total_claim == real claim sum C; the reserve R sits as extra undelegated
+    // lamports outside that max (never claimable via merkle proofs, reaped at close).
     const realClaimSum = totalClaimVoteAccount2
-    const maxTotalClaim = realClaimSum.add(new BN(reserveFront))
+    const maxTotalClaim = realClaimSum
     const rentCollector = Keypair.generate()
 
     const { settlementAccount } = await executeInitSettlement({
@@ -89,7 +89,7 @@ describe('Validator Bonds reserve front reap', () => {
       maxTotalClaim,
     })
 
-    // init set the on-chain max to exactly C + R
+    // init set the on-chain max to exactly C (no inflation)
     const settlement = await getSettlement(program, settlementAccount)
     expect(settlement.maxTotalClaim.toString()).toEqual(
       maxTotalClaim.toString(),

--- a/packages/validator-bonds-sdk/__tests__/bankrun/reserveReap.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/reserveReap.spec.ts
@@ -1,0 +1,141 @@
+import {
+  assertNotExist,
+  currentEpoch,
+  warpOffsetEpoch,
+} from '@marinade.finance/bankrun-utils'
+import { createUserAndFund, pubkey } from '@marinade.finance/web3js-1x'
+import { Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js'
+import BN from 'bn.js'
+
+import { initBankrunTest } from './bankrun'
+import {
+  closeSettlementV2Instruction,
+  getSettlement,
+  withdrawStakeInstruction,
+} from '../../src'
+import {
+  MERKLE_ROOT_VOTE_ACCOUNT_2_BUF,
+  totalClaimVoteAccount2,
+} from '../utils/merkleTreeTestData'
+import {
+  createSettlementFundedInitializedStake,
+  createVoteAccount,
+} from '../utils/staking'
+import {
+  executeInitBondInstruction,
+  executeInitConfigInstruction,
+  executeInitSettlement,
+} from '../utils/testTransactions'
+
+import type { ValidatorBondsProgram } from '../../src'
+import type { BankrunExtendedProvider } from '@marinade.finance/bankrun-utils'
+import type { PublicKey } from '@solana/web3.js'
+
+// Reserve front (Coord Goal 2) money-flow, end to end at the program level:
+// init inflates the on-chain max_total_claim by R, the reserve fronts R from
+// marinade_wallet as an undelegated stake, and the unclaimed R is reaped back to
+// marinade_wallet at close. The merkle root still commits only to the real claims
+// (sum C), so R is never claimable and the reserve is made whole at close.
+describe('Validator Bonds reserve front reap', () => {
+  const epochsToClaimSettlement = 1
+  const reserveFront = 2 * LAMPORTS_PER_SOL // R
+  let provider: BankrunExtendedProvider
+  let program: ValidatorBondsProgram
+  let configAccount: PublicKey
+  let operatorAuthority: Keypair
+  let voteAccount: PublicKey
+  let validatorIdentity: Keypair
+
+  beforeAll(async () => {
+    ;({ provider, program } = await initBankrunTest())
+  })
+
+  beforeEach(async () => {
+    ;({ configAccount, operatorAuthority } = await executeInitConfigInstruction(
+      {
+        program,
+        provider,
+        epochsToClaimSettlement,
+      },
+    ))
+    ;({ voteAccount, validatorIdentity } = await createVoteAccount({
+      provider,
+    }))
+    await executeInitBondInstruction({
+      program,
+      provider,
+      configAccount,
+      voteAccount,
+      validatorIdentity,
+    })
+  })
+
+  it('inflates max by R and reaps the front to marinade_wallet at close', async () => {
+    // Real claim sum C (committed by the merkle root) and the inflated max C + R.
+    const realClaimSum = totalClaimVoteAccount2
+    const maxTotalClaim = realClaimSum.add(new BN(reserveFront))
+    const rentCollector = Keypair.generate()
+
+    const { settlementAccount } = await executeInitSettlement({
+      configAccount,
+      program,
+      provider,
+      voteAccount,
+      operatorAuthority,
+      currentEpoch: await currentEpoch(provider),
+      rentCollector: rentCollector.publicKey,
+      merkleRoot: MERKLE_ROOT_VOTE_ACCOUNT_2_BUF,
+      maxMerkleNodes: 5,
+      maxTotalClaim,
+    })
+
+    // init set the on-chain max to exactly C + R
+    const settlement = await getSettlement(program, settlementAccount)
+    expect(settlement.maxTotalClaim.toString()).toEqual(
+      maxTotalClaim.toString(),
+    )
+
+    // the reserve front: an undelegated stake of R funded to the settlement
+    const reserveStake = await createSettlementFundedInitializedStake({
+      program,
+      provider,
+      configAccount,
+      settlementAccount,
+      lamports: reserveFront,
+    })
+
+    // marinade_wallet funds the front; the reap must make it whole again
+    const marinadeWallet = await createUserAndFund({
+      provider,
+      lamports: LAMPORTS_PER_SOL,
+    })
+
+    // close needs the claim window to have passed
+    await warpOffsetEpoch(provider, epochsToClaimSettlement + 1)
+    const { instruction: closeIx } = await closeSettlementV2Instruction({
+      program,
+      settlementAccount,
+      rentCollector: rentCollector.publicKey,
+    })
+    await provider.sendIx([], closeIx)
+    await assertNotExist(provider, settlementAccount)
+
+    // reap: the unclaimed reserve stake is withdrawn back to marinade_wallet
+    const { instruction: withdrawIx } = await withdrawStakeInstruction({
+      program,
+      configAccount,
+      stakeAccount: reserveStake,
+      operatorAuthority: operatorAuthority.publicKey,
+      settlementAccount,
+      withdrawTo: pubkey(marinadeWallet),
+    })
+    await provider.sendIx([operatorAuthority], withdrawIx)
+    await assertNotExist(provider, reserveStake)
+
+    // marinade recovers exactly the fronted R (the reserve stake's full balance)
+    expect(
+      (await provider.connection.getAccountInfo(pubkey(marinadeWallet)))
+        ?.lamports,
+    ).toEqual(LAMPORTS_PER_SOL + reserveFront)
+  })
+})

--- a/settlement-pipelines/README.md
+++ b/settlement-pipelines/README.md
@@ -33,6 +33,92 @@ There are 6 pipelines used for the binary commands.
   from gcloud and checking if the on-chain state does not contain some unknown `Settlement` in comparison
   to gcloud list.
 
+## Reserve Front (Coord Goal 2)
+
+The reserve front makes mSOL bid-settlement APY realize on time. Without it,
+validators must fund their bond stake before stakers can claim, adding a 2–6
+epoch lag. The reserve eliminates that lag by pre-funding each bond settlement
+from `marinade_wallet`.
+
+### Epoch-by-epoch timeline
+
+```
+Epoch N  — settlement created
+  init-settlement
+    on-chain: max_total_claim = C   (real merkle sum, no inflation)
+              lamports_funded  = 0
+
+  fund-settlement  run 1   (on_chain lamports_funded == 0 → reserve fires)
+    marinade_wallet → undelegated stake R+min_stake  [reserve front]
+      staker = settlement_staker_authority
+      immediately claimable (undelegated from the start)
+    validator bond → FundSettlement C-R
+      FundSettlement deactivates the bond stake so it becomes
+      undelegated and withdrawable in epoch N+1
+      on-chain lamports_funded = C-R
+
+Epoch N+1  — bond stake finishes deactivating
+  Both pools now undelegated, both claimable via ClaimSettlementV2:
+    reserve front   R   lamports  (undelegated since epoch N)
+    bond stake    C-R   lamports  (deactivated in epoch N, now undelegated)
+  Total available = C = max_total_claim
+
+  Stakers claim (may begin as early as epoch N from the reserve front):
+    ClaimSettlementV2 calls StakeWithdraw on any stake with
+    staker == settlement_staker_authority.
+    Bound: lamports_claimed + claim ≤ max_total_claim = C.
+    No check against lamports_funded — reserve lamports count toward claims
+    even though they are not tracked by lamports_funded.
+
+  fund-settlement  run 2+  (lamports_funded = C-R ≠ 0 → reserve does not re-fire)
+    bond funds remaining R → lamports_funded = C = max_total_claim
+    The bond's second-run R is what ultimately reimburses marinade at close.
+
+Epoch N + epochsToClaimSettlement + 1  — claim window closed
+  close-settlement
+    CloseSettlementV2 closes the on-chain Settlement account.
+    All remaining stakes still carry staker = settlement_staker_authority.
+
+    Undelegated stakes → WithdrawStake → marinade_wallet:
+      • reserve front remainder  (if stakers did not consume it)
+      • bond stake remainder     (bond funded C total; claims consumed C;
+        exactly R of bond-originated lamports remains → reaps to marinade)
+
+    Delegated stakes (bond stakes not yet deactivated) → ResetStake → bond.
+
+    Net: marinade recovers R; bond reimburses through its second fund run. ✓
+```
+
+### Invariants
+
+| #   | Invariant                            | How enforced                                                |
+| --- | ------------------------------------ | ----------------------------------------------------------- |
+| 1   | `max_total_claim = C` — no inflation | `init-settlement` applies no reserve inflation              |
+| 2   | Reserve fires at most once           | guard: `on_chain lamports_funded == 0`                      |
+| 3   | Total claims bounded to C            | program: `lamports_claimed + claim ≤ max_total_claim`       |
+| 4   | Bond reaches `lamports_funded = C`   | fund pipeline retries until max is reached                  |
+| 5   | R reaps to marinade at close         | pipeline: undelegated → `WithdrawStake` → `marinade_wallet` |
+
+### CLI flags
+
+`init-settlement` and `fund-settlement` both accept:
+
+```
+--reserve-prefund-lamports <LAMPORTS>
+    env: RESERVE_PREFUND_LAMPORTS   default: 0 (disabled)
+```
+
+Zero is a no-op: no reserve front, pipeline behaves exactly as before.
+
+### Known POC limitation
+
+`ClaimSettlementV2` accepts any stake with `staker == settlement_staker_authority`
+as the claim source, including the reserve front. In practice the Marinade-operated
+claim pipeline uses bond stakes (available once deactivated in epoch N+1), leaving
+the reserve front intact for the close reap. A complete fix requires a `reserve: u64`
+field on the `Settlement` account so the reserve amount is unclaimable on-chain
+(future program change).
+
 ## Usage
 
 ```bash

--- a/settlement-pipelines/README.md
+++ b/settlement-pipelines/README.md
@@ -79,25 +79,32 @@ Epoch N + epochsToClaimSettlement + 1  — claim window closed
     CloseSettlementV2 closes the on-chain Settlement account.
     All remaining stakes still carry staker = settlement_staker_authority.
 
-    Undelegated stakes → WithdrawStake → marinade_wallet:
-      • reserve front remainder  (if stakers did not consume it)
-      • bond stake remainder     (bond funded C total; claims consumed C;
-        exactly R of bond-originated lamports remains → reaps to marinade)
+    Stake-state categorisation (by StakeStateV2 variant, not by provenance):
+      Initialized (never-delegated) → WithdrawStake → marinade_wallet
+        • the reserve front (undelegated from creation)
+      StakeStateV2::Stake (delegated / deactivated bond stakes) → ResetStake → bond
 
-    Delegated stakes (bond stakes not yet deactivated) → ResetStake → bond.
+    The claim pipeline sorts claimable stakes so bond stakes (Stake-state,
+    deactivated) are drained first, leaving the Initialized reserve-front
+    stake intact for the close-pipeline's WithdrawStake → marinade reap.
 
-    Net: marinade recovers R via the bond's second fund run. ✓
+    Net: the reserve-front lamports (R) circulate as:
+      marinade_wallet → reserve stake (undelegated)
+      → (unclaimed remainder) → WithdrawStake back → marinade_wallet  ✓
+
+    The bond's second run fills the R-gap in lamports_funded (→ C total).
+    At close, those bond lamports reset to the bond (not to marinade).
 ```
 
 ### Invariants
 
-| #   | Invariant                            | How enforced                                                |
-| --- | ------------------------------------ | ----------------------------------------------------------- |
-| 1   | `max_total_claim = C` — no inflation | `init-settlement` applies no reserve inflation              |
-| 2   | Reserve fires at most once           | guard: `on_chain lamports_funded == 0`                      |
-| 3   | Total claims bounded to C            | program: `lamports_claimed + claim ≤ max_total_claim`       |
-| 4   | Bond reaches `lamports_funded = C`   | fund pipeline retries until max is reached                  |
-| 5   | R reaps to marinade at close         | pipeline: undelegated → `WithdrawStake` → `marinade_wallet` |
+| #   | Invariant                            | How enforced                                                                                          |
+| --- | ------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| 1   | `max_total_claim = C` — no inflation | `init-settlement` applies no reserve inflation                                                        |
+| 2   | Reserve fires at most once           | guard: `on_chain lamports_funded == 0`                                                                |
+| 3   | Total claims bounded to C            | program: `lamports_claimed + claim ≤ max_total_claim`                                                 |
+| 4   | Bond reaches `lamports_funded = C`   | fund pipeline retries until max is reached                                                            |
+| 5   | R reaps to marinade at close         | close: `Initialized` stake → `WithdrawStake` → `marinade_wallet`; claim sorts to leave reserve intact |
 
 ### CLI flags
 
@@ -113,9 +120,10 @@ Zero is a no-op: no reserve front, pipeline behaves exactly as before.
 ### Limitation
 
 `ClaimSettlementV2` accepts any stake with `staker == settlement_staker_authority`
-as the claim source, including the reserve front. In practice the Marinade-operated
-claim pipeline uses bond stakes (available once deactivated in epoch N+1), leaving
-the reserve front intact for the close reap. A complete fix requires a `reserve: u64`
+as the claim source, including the reserve front. The claim pipeline sorts claimable
+stakes to drain Stake-state (bond) accounts first, preserving the Initialized
+reserve-front stake for the close-pipeline reap. This ordering is a pipeline
+convention, not an on-chain constraint. A complete fix requires a `reserve: u64`
 field on the `Settlement` account so the reserve amount is unclaimable on-chain
 (future program change).
 

--- a/settlement-pipelines/README.md
+++ b/settlement-pipelines/README.md
@@ -33,7 +33,7 @@ There are 6 pipelines used for the binary commands.
   from gcloud and checking if the on-chain state does not contain some unknown `Settlement` in comparison
   to gcloud list.
 
-## Reserve Front (Coord Goal 2)
+## Reserve Front
 
 The reserve front makes mSOL bid-settlement APY realize on time. Without it,
 validators must fund their bond stake before stakers can claim, adding a 2–6
@@ -86,7 +86,7 @@ Epoch N + epochsToClaimSettlement + 1  — claim window closed
 
     Delegated stakes (bond stakes not yet deactivated) → ResetStake → bond.
 
-    Net: marinade recovers R; bond reimburses through its second fund run. ✓
+    Net: marinade recovers R via the bond's second fund run. ✓
 ```
 
 ### Invariants
@@ -110,7 +110,7 @@ Epoch N + epochsToClaimSettlement + 1  — claim window closed
 
 Zero is a no-op: no reserve front, pipeline behaves exactly as before.
 
-### Known POC limitation
+### Limitation
 
 `ClaimSettlementV2` accepts any stake with `staker == settlement_staker_authority`
 as the claim source, including the reserve front. In practice the Marinade-operated

--- a/settlement-pipelines/src/bin/claim_settlement.rs
+++ b/settlement-pipelines/src/bin/claim_settlement.rs
@@ -1,3 +1,4 @@
+use anchor_client::anchor_lang::solana_program::stake::state::StakeStateV2;
 use anchor_client::{DynSigner, Program};
 use anyhow::anyhow;
 use clap::Parser;
@@ -192,6 +193,14 @@ async fn real_main(
 
     let mut settlement_claimed_amounts: HashMap<Pubkey, u64> = HashMap::new();
     let mut stake_accounts_to_cache = StakeAccountsCache::default();
+
+    // Drain delegated (deactivated) bond stakes before Initialized reserve-front stakes so
+    // the reserve front stays intact for the close-pipeline's WithdrawStake → marinade reap.
+    for claimable_settlement in &mut claimable_settlements {
+        claimable_settlement
+            .stake_accounts
+            .sort_by_key(|(_, _, state)| matches!(state, StakeStateV2::Initialized(_)) as u8);
+    }
 
     for claimable_settlement in claimable_settlements {
         let json_matching_settlement = match get_settlement_from_json(

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -156,7 +156,7 @@ async fn real_main(
     let mut settlement_records_per_epoch =
         load_merkle_tree_with_on_chain(rpc_client.clone(), &collections, args.epoch).await?;
 
-    // Option B: inflate max_total_claim by the reserve prefund so the assert against
+    // Inflate max_total_claim by the reserve prefund so the assert against
     // the on-chain max (set at init) holds and the bond funds toward the inflated max.
     let reserve = ReserveConfig::load(&args.reserve_opts)?;
     if let Some(reserve) = &reserve {

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -20,7 +20,9 @@ use settlement_pipelines::reporting::{
     ReportSerializable,
 };
 use settlement_pipelines::reporting_data::{ReportingReasonSettlement, SettlementsReportData};
-use settlement_pipelines::reserve::{apply_reserve_inflation, ReserveConfig, ReserveOpts};
+use settlement_pipelines::reserve::{
+    apply_reserve_inflation, reserve_front_lamports, ReserveConfig, ReserveOpts,
+};
 use settlement_pipelines::settlement_data::{
     reason_display, SettlementFunderMarinade, SettlementFunderType, SettlementFunderValidatorBond,
     SettlementRecord,
@@ -156,10 +158,11 @@ async fn real_main(
 
     // Option B: inflate max_total_claim by the reserve prefund so the assert against
     // the on-chain max (set at init) holds and the bond funds toward the inflated max.
-    if let Some(reserve) = ReserveConfig::load(&args.reserve_opts)? {
+    let reserve = ReserveConfig::load(&args.reserve_opts)?;
+    if let Some(reserve) = &reserve {
         settlement_records_per_epoch
             .values_mut()
-            .for_each(|records| apply_reserve_inflation(records, &reserve));
+            .for_each(|records| apply_reserve_inflation(records, reserve));
     }
 
     let transaction_executor = get_executor(rpc_client.clone(), tip_policy);
@@ -181,6 +184,7 @@ async fn real_main(
         &config,
         fee_payer.clone(),
         operator_authority.clone(),
+        reserve.as_ref(),
         &priority_fee_policy,
         reporting,
     )
@@ -215,6 +219,7 @@ async fn prepare_funding(
     config: &Config,
     fee_payer: Arc<Keypair>,
     operator_authority: Arc<Keypair>,
+    reserve: Option<&ReserveConfig>,
     priority_fee_policy: &PriorityFeePolicy,
     reporting: &mut ReportHandler<FundSettlementsReport>,
 ) -> anyhow::Result<()> {
@@ -283,24 +288,44 @@ async fn prepare_funding(
             continue;
         }
 
+        // derive from on-chain fields; stake-account balances under-reserve for
+        // stakes funded before a minimum_stake_lamports increase and underflowed
         let settlement_amount_funded = settlement_record
             .settlement_account
             .as_ref()
             .map_or(0, |s| s.lamports_funded.saturating_sub(s.lamports_claimed));
-        let amount_to_fund = settlement_record.settlement_account.as_ref().map_or(
-            settlement_record.max_total_claim_sum,
-            |settlement| {
+
+        // Reserve front (Coord Goal 2): on first touch of a reserve-enabled bond
+        // settlement, the reserve fronts R from marinade_wallet (emitted in
+        // fund_settlements) so stakers can claim on time. The bond then funds the
+        // remainder toward the inflated max (its reimbursement), so the bond target
+        // is reduced by the front to avoid double-funding within this run.
+        let reserve_front = reserve_front_lamports(
+            reserve,
+            &settlement_record.vote_account_address,
+            matches!(
+                settlement_record.funder,
+                SettlementFunderType::ValidatorBond(_)
+            ),
+            settlement_amount_funded,
+        );
+        settlement_record.reserve_front_lamports = reserve_front;
+
+        let amount_to_fund = settlement_record
+            .settlement_account
+            .as_ref()
+            .map_or(settlement_record.max_total_claim_sum, |settlement| {
                 assert_eq!(
                     settlement.max_total_claim,
-                    settlement_record.max_total_claim_sum,
+                    settlement_record.max_total_claim_sum
                 );
                 settlement
                     .max_total_claim
                     .saturating_sub(settlement.lamports_funded)
-            },
-        );
+            })
+            .saturating_sub(reserve_front);
 
-        if amount_to_fund == 0 {
+        if amount_to_fund == 0 && reserve_front == 0 {
             info!(
                 "Settlement {} (vote account {}, epoch {}, funder {:?}) already funded by {}, skipping funding",
                 settlement_record.settlement_address,
@@ -572,6 +597,9 @@ async fn prepare_funding(
 }
 
 fn is_for_funding(settlement_record: &SettlementRecord) -> bool {
+    if settlement_record.reserve_front_lamports > 0 {
+        return true;
+    }
     match &settlement_record.funder {
         SettlementFunderType::Marinade(data) => {
             if let Some(SettlementFunderMarinade { amount_to_fund }) = data {
@@ -627,6 +655,39 @@ async fn fund_settlements(
                 settlement_record.funder
             );
             continue;
+        }
+        // Reserve front (Coord Goal 2): create a stake account funded from
+        // marinade_wallet so a reserve-enabled settlement is claimable immediately.
+        // The bond funds the remainder below; at close the unclaimed leftover (the
+        // fronted amount) is reaped back to marinade_wallet via WithdrawStake.
+        if settlement_record.reserve_front_lamports > 0 {
+            let new_stake_account_keypair = Arc::new(Keypair::new());
+            transaction_builder.add_signer_checked(&new_stake_account_keypair);
+            info!(
+                "Settlement: {} (vote account {}, epoch {}) reserve front {} from marinade_wallet, stake account {}",
+                settlement_record.settlement_address,
+                settlement_record.vote_account_address,
+                settlement_record.epoch,
+                build_balance_message(settlement_record.reserve_front_lamports, false, false),
+                new_stake_account_keypair.pubkey()
+            );
+            let instructions = create_stake_account_instructions(
+                &marinade_wallet.pubkey(),
+                &new_stake_account_keypair.pubkey(),
+                &Authorized {
+                    withdrawer: withdrawer_authority,
+                    staker: settlement_record.settlement_staker_authority,
+                },
+                &Lockup {
+                    unix_timestamp: 0,
+                    epoch: 0,
+                    custodian: withdrawer_authority,
+                },
+                // after claiming the rest has to be still a living stake account
+                settlement_record.reserve_front_lamports + minimal_stake_lamports,
+            );
+            transaction_builder.add_instructions(instructions)?;
+            transaction_builder.finish_instruction_pack();
         }
         match &settlement_record.funder {
             SettlementFunderType::Marinade(Some(SettlementFunderMarinade { amount_to_fund })) => {

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -584,6 +584,52 @@ async fn prepare_funding(
     Ok(())
 }
 
+/// Create a stake account funded from marinade_wallet, authorized to the
+/// settlement, and push it as its own instruction pack. `label` distinguishes
+/// the reserve-front front-loading from the Marinade-PSR funder in the log.
+fn add_marinade_funded_stake_account(
+    transaction_builder: &mut TransactionBuilder,
+    marinade_wallet: &Keypair,
+    withdrawer_authority: &Pubkey,
+    settlement_record: &SettlementRecord,
+    amount: u64,
+    minimal_stake_lamports: u64,
+    label: &str,
+) -> anyhow::Result<()> {
+    let new_stake_account_keypair = Arc::new(Keypair::new());
+    transaction_builder.add_signer_checked(&new_stake_account_keypair);
+    info!(
+        "Settlement: {} (vote account {}, bond {}, epoch {}, reason: {}, funder: {}), {} {} from marinade_wallet, stake account {}",
+        settlement_record.settlement_address,
+        settlement_record.vote_account_address,
+        settlement_record.bond_address,
+        settlement_record.epoch,
+        reason_display(&settlement_record.reason),
+        settlement_record.funder,
+        label,
+        build_balance_message(amount, false, false),
+        new_stake_account_keypair.pubkey()
+    );
+    let instructions = create_stake_account_instructions(
+        &marinade_wallet.pubkey(),
+        &new_stake_account_keypair.pubkey(),
+        &Authorized {
+            withdrawer: *withdrawer_authority,
+            staker: settlement_record.settlement_staker_authority,
+        },
+        &Lockup {
+            unix_timestamp: 0,
+            epoch: 0,
+            custodian: *withdrawer_authority,
+        },
+        // after claiming the rest has to be still a living stake account
+        amount + minimal_stake_lamports,
+    );
+    transaction_builder.add_instructions(instructions)?;
+    transaction_builder.finish_instruction_pack();
+    Ok(())
+}
+
 fn is_for_funding(settlement_record: &SettlementRecord) -> bool {
     if settlement_record.reserve_front > 0 {
         return true;
@@ -648,65 +694,27 @@ async fn fund_settlements(
         // bond settlement is claimable immediately. The bond funds the remainder
         // below; at close the unclaimed leftover is reaped back to marinade_wallet.
         if settlement_record.reserve_front > 0 {
-            let new_stake_account_keypair = Arc::new(Keypair::new());
-            transaction_builder.add_signer_checked(&new_stake_account_keypair);
-            info!(
-                "Settlement: {} (vote account {}, epoch {}) reserve front {} from marinade_wallet, stake account {}",
-                settlement_record.settlement_address,
-                settlement_record.vote_account_address,
-                settlement_record.epoch,
-                build_balance_message(settlement_record.reserve_front, false, false),
-                new_stake_account_keypair.pubkey()
-            );
-            let instructions = create_stake_account_instructions(
-                &marinade_wallet.pubkey(),
-                &new_stake_account_keypair.pubkey(),
-                &Authorized {
-                    withdrawer: withdrawer_authority,
-                    staker: settlement_record.settlement_staker_authority,
-                },
-                &Lockup {
-                    unix_timestamp: 0,
-                    epoch: 0,
-                    custodian: withdrawer_authority,
-                },
-                // after claiming the rest has to be still a living stake account
-                settlement_record.reserve_front + minimal_stake_lamports,
-            );
-            transaction_builder.add_instructions(instructions)?;
-            transaction_builder.finish_instruction_pack();
+            add_marinade_funded_stake_account(
+                &mut transaction_builder,
+                &marinade_wallet,
+                &withdrawer_authority,
+                settlement_record,
+                settlement_record.reserve_front,
+                minimal_stake_lamports,
+                "reserve front",
+            )?;
         }
         match &settlement_record.funder {
             SettlementFunderType::Marinade(Some(SettlementFunderMarinade { amount_to_fund })) => {
-                let new_stake_account_keypair = Arc::new(Keypair::new());
-                transaction_builder.add_signer_checked(&new_stake_account_keypair);
-                info!(
-                    "Settlement: {} (vote account {}, bond {}, epoch {}, reason: {}, funder: {}), creating Marinade stake account {}",
-                    settlement_record.settlement_address,
-                    settlement_record.vote_account_address,
-                    settlement_record.bond_address,
-                    settlement_record.epoch,
-                    reason_display(&settlement_record.reason),
-                    settlement_record.funder,
-                    new_stake_account_keypair.pubkey()
-                );
-                let instructions = create_stake_account_instructions(
-                    &marinade_wallet.pubkey(),
-                    &new_stake_account_keypair.pubkey(),
-                    &Authorized {
-                        withdrawer: withdrawer_authority,
-                        staker: settlement_record.settlement_staker_authority,
-                    },
-                    &Lockup {
-                        unix_timestamp: 0,
-                        epoch: 0,
-                        custodian: withdrawer_authority,
-                    },
-                    // after claiming the rest has to be still living stake account
-                    amount_to_fund + minimal_stake_lamports,
-                );
-                transaction_builder.add_instructions(instructions)?;
-                transaction_builder.finish_instruction_pack();
+                add_marinade_funded_stake_account(
+                    &mut transaction_builder,
+                    &marinade_wallet,
+                    &withdrawer_authority,
+                    settlement_record,
+                    *amount_to_fund,
+                    minimal_stake_lamports,
+                    "creating Marinade stake account",
+                )?;
             }
             SettlementFunderType::ValidatorBond(validator_bonds_funders) => {
                 for SettlementFunderValidatorBond {

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -158,7 +158,7 @@ async fn real_main(
 
     // Inflate max_total_claim by the reserve prefund so the assert against
     // the on-chain max (set at init) holds and the bond funds toward the inflated max.
-    let reserve = ReserveConfig::load(&args.reserve_opts)?;
+    let reserve = ReserveConfig::load(&args.reserve_opts);
     if let Some(reserve) = &reserve {
         settlement_records_per_epoch
             .values_mut()
@@ -288,27 +288,16 @@ async fn prepare_funding(
             continue;
         }
 
-        // derive from on-chain fields; stake-account balances under-reserve for
-        // stakes funded before a minimum_stake_lamports increase and underflowed
         let settlement_amount_funded = settlement_record
             .settlement_account
             .as_ref()
             .map_or(0, |s| s.lamports_funded.saturating_sub(s.lamports_claimed));
 
-        // Reserve front (Coord Goal 2): on first touch of a reserve-enabled bond
-        // settlement, the reserve fronts R from marinade_wallet (emitted in
-        // fund_settlements) so stakers can claim on time. The bond then funds the
-        // remainder toward the inflated max (its reimbursement), so the bond target
-        // is reduced by the front to avoid double-funding within this run.
-        let reserve_front = reserve_front_lamports(
-            reserve,
-            &settlement_record.vote_account_address,
-            matches!(
-                settlement_record.funder,
-                SettlementFunderType::ValidatorBond(_)
-            ),
-            settlement_amount_funded,
-        );
+        // Reserve fronts R from marinade_wallet on first touch so stakers claim on
+        // time; the bond funds the rest toward the inflated max, so its target is
+        // reduced by the front to avoid double-funding within this run.
+        let reserve_front =
+            reserve_front_lamports(reserve, settlement_record, settlement_amount_funded);
         settlement_record.reserve_front_lamports = reserve_front;
 
         let amount_to_fund = settlement_record
@@ -656,10 +645,9 @@ async fn fund_settlements(
             );
             continue;
         }
-        // Reserve front (Coord Goal 2): create a stake account funded from
-        // marinade_wallet so a reserve-enabled settlement is claimable immediately.
-        // The bond funds the remainder below; at close the unclaimed leftover (the
-        // fronted amount) is reaped back to marinade_wallet via WithdrawStake.
+        // Reserve front: create a stake account funded from marinade_wallet so a
+        // bond settlement is claimable immediately. The bond funds the remainder
+        // below; at close the unclaimed leftover is reaped back to marinade_wallet.
         if settlement_record.reserve_front_lamports > 0 {
             let new_stake_account_keypair = Arc::new(Keypair::new());
             transaction_builder.add_signer_checked(&new_stake_account_keypair);

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -20,6 +20,7 @@ use settlement_pipelines::reporting::{
     ReportSerializable,
 };
 use settlement_pipelines::reporting_data::{ReportingReasonSettlement, SettlementsReportData};
+use settlement_pipelines::reserve::{apply_reserve_inflation, ReserveConfig, ReserveOpts};
 use settlement_pipelines::settlement_data::{
     reason_display, SettlementFunderMarinade, SettlementFunderType, SettlementFunderValidatorBond,
     SettlementRecord,
@@ -89,6 +90,9 @@ struct Args {
     rent_payer: Option<String>,
 
     #[clap(flatten)]
+    reserve_opts: ReserveOpts,
+
+    #[clap(flatten)]
     report_opts: ReportOpts,
 }
 
@@ -149,6 +153,14 @@ async fn real_main(
 
     let mut settlement_records_per_epoch =
         load_merkle_tree_with_on_chain(rpc_client.clone(), &collections, args.epoch).await?;
+
+    // Option B: inflate max_total_claim by the reserve prefund so the assert against
+    // the on-chain max (set at init) holds and the bond funds toward the inflated max.
+    if let Some(reserve) = ReserveConfig::load(&args.reserve_opts)? {
+        settlement_records_per_epoch
+            .values_mut()
+            .for_each(|records| apply_reserve_inflation(records, &reserve));
+    }
 
     let transaction_executor = get_executor(rpc_client.clone(), tip_policy);
 

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -20,7 +20,7 @@ use settlement_pipelines::reporting::{
     ReportSerializable,
 };
 use settlement_pipelines::reporting_data::{ReportingReasonSettlement, SettlementsReportData};
-use settlement_pipelines::reserve::{apply_reserve_inflation, is_reserve_target, ReserveOpts};
+use settlement_pipelines::reserve::{is_reserve_target, ReserveOpts};
 use settlement_pipelines::settlement_data::{
     reason_display, SettlementFunderMarinade, SettlementFunderType, SettlementFunderValidatorBond,
     SettlementRecord,
@@ -154,12 +154,7 @@ async fn real_main(
     let mut settlement_records_per_epoch =
         load_merkle_tree_with_on_chain(rpc_client.clone(), &collections, args.epoch).await?;
 
-    // Inflate max_total_claim by the reserve prefund so the assert against
-    // the on-chain max (set at init) holds and the bond funds toward the inflated max.
     let reserve_prefund_lamports = args.reserve_opts.reserve_prefund_lamports;
-    settlement_records_per_epoch
-        .values_mut()
-        .for_each(|records| apply_reserve_inflation(records, reserve_prefund_lamports));
 
     let transaction_executor = get_executor(rpc_client.clone(), tip_policy);
 
@@ -289,10 +284,14 @@ async fn prepare_funding(
             .as_ref()
             .map_or(0, |s| s.lamports_funded.saturating_sub(s.lamports_claimed));
 
-        // Reserve fronts R from marinade_wallet on first touch so stakers claim on
-        // time; the bond funds the rest toward the inflated max, so its target is
-        // reduced by the front to avoid double-funding within this run.
-        let reserve_front = if settlement_amount_funded == 0 && is_reserve_target(settlement_record)
+        // Reserve fronts R from marinade_wallet on first touch (lamports_funded == 0,
+        // i.e., bond has not yet funded anything). Guard is on lamports_funded, not
+        // funded-claimed, so a post-claim rerun with funded==claimed never re-fronts.
+        let on_chain_lamports_funded = settlement_record
+            .settlement_account
+            .as_ref()
+            .map_or(0, |s| s.lamports_funded);
+        let reserve_front = if on_chain_lamports_funded == 0 && is_reserve_target(settlement_record)
         {
             reserve_prefund_lamports
         } else {

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -20,9 +20,7 @@ use settlement_pipelines::reporting::{
     ReportSerializable,
 };
 use settlement_pipelines::reporting_data::{ReportingReasonSettlement, SettlementsReportData};
-use settlement_pipelines::reserve::{
-    apply_reserve_inflation, reserve_front_lamports, ReserveConfig, ReserveOpts,
-};
+use settlement_pipelines::reserve::{apply_reserve_inflation, is_reserve_target, ReserveOpts};
 use settlement_pipelines::settlement_data::{
     reason_display, SettlementFunderMarinade, SettlementFunderType, SettlementFunderValidatorBond,
     SettlementRecord,
@@ -158,12 +156,10 @@ async fn real_main(
 
     // Inflate max_total_claim by the reserve prefund so the assert against
     // the on-chain max (set at init) holds and the bond funds toward the inflated max.
-    let reserve = ReserveConfig::load(&args.reserve_opts);
-    if let Some(reserve) = &reserve {
-        settlement_records_per_epoch
-            .values_mut()
-            .for_each(|records| apply_reserve_inflation(records, reserve));
-    }
+    let reserve_prefund_lamports = args.reserve_opts.reserve_prefund_lamports;
+    settlement_records_per_epoch
+        .values_mut()
+        .for_each(|records| apply_reserve_inflation(records, reserve_prefund_lamports));
 
     let transaction_executor = get_executor(rpc_client.clone(), tip_policy);
 
@@ -184,7 +180,7 @@ async fn real_main(
         &config,
         fee_payer.clone(),
         operator_authority.clone(),
-        reserve.as_ref(),
+        reserve_prefund_lamports,
         &priority_fee_policy,
         reporting,
     )
@@ -219,7 +215,7 @@ async fn prepare_funding(
     config: &Config,
     fee_payer: Arc<Keypair>,
     operator_authority: Arc<Keypair>,
-    reserve: Option<&ReserveConfig>,
+    reserve_prefund_lamports: u64,
     priority_fee_policy: &PriorityFeePolicy,
     reporting: &mut ReportHandler<FundSettlementsReport>,
 ) -> anyhow::Result<()> {
@@ -296,9 +292,13 @@ async fn prepare_funding(
         // Reserve fronts R from marinade_wallet on first touch so stakers claim on
         // time; the bond funds the rest toward the inflated max, so its target is
         // reduced by the front to avoid double-funding within this run.
-        let reserve_front =
-            reserve_front_lamports(reserve, settlement_record, settlement_amount_funded);
-        settlement_record.reserve_front_lamports = reserve_front;
+        let reserve_front = if settlement_amount_funded == 0 && is_reserve_target(settlement_record)
+        {
+            reserve_prefund_lamports
+        } else {
+            0
+        };
+        settlement_record.reserve_front = reserve_front;
 
         let amount_to_fund = settlement_record
             .settlement_account
@@ -586,7 +586,7 @@ async fn prepare_funding(
 }
 
 fn is_for_funding(settlement_record: &SettlementRecord) -> bool {
-    if settlement_record.reserve_front_lamports > 0 {
+    if settlement_record.reserve_front > 0 {
         return true;
     }
     match &settlement_record.funder {
@@ -648,7 +648,7 @@ async fn fund_settlements(
         // Reserve front: create a stake account funded from marinade_wallet so a
         // bond settlement is claimable immediately. The bond funds the remainder
         // below; at close the unclaimed leftover is reaped back to marinade_wallet.
-        if settlement_record.reserve_front_lamports > 0 {
+        if settlement_record.reserve_front > 0 {
             let new_stake_account_keypair = Arc::new(Keypair::new());
             transaction_builder.add_signer_checked(&new_stake_account_keypair);
             info!(
@@ -656,7 +656,7 @@ async fn fund_settlements(
                 settlement_record.settlement_address,
                 settlement_record.vote_account_address,
                 settlement_record.epoch,
-                build_balance_message(settlement_record.reserve_front_lamports, false, false),
+                build_balance_message(settlement_record.reserve_front, false, false),
                 new_stake_account_keypair.pubkey()
             );
             let instructions = create_stake_account_instructions(
@@ -672,7 +672,7 @@ async fn fund_settlements(
                     custodian: withdrawer_authority,
                 },
                 // after claiming the rest has to be still a living stake account
-                settlement_record.reserve_front_lamports + minimal_stake_lamports,
+                settlement_record.reserve_front + minimal_stake_lamports,
             );
             transaction_builder.add_instructions(instructions)?;
             transaction_builder.finish_instruction_pack();

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -690,32 +690,34 @@ async fn fund_settlements(
             );
             continue;
         }
-        // Reserve front: create a stake account funded from marinade_wallet so a
-        // bond settlement is claimable immediately. The bond funds the remainder
-        // below; at close the unclaimed leftover is reaped back to marinade_wallet.
-        if settlement_record.reserve_front > 0 {
+        // Marinade-funded stake: either the reserve front fronted onto a bond
+        // settlement so it is claimable immediately (bond funds the remainder
+        // below; unclaimed leftover reaped to marinade_wallet at close), or a
+        // Marinade settlement funded in full from marinade_wallet. Mutually
+        // exclusive — a settlement triggers at most one.
+        let marinade_deposit = if settlement_record.reserve_front > 0 {
+            Some((settlement_record.reserve_front, "reserve front"))
+        } else if let SettlementFunderType::Marinade(Some(SettlementFunderMarinade {
+            amount_to_fund,
+        })) = &settlement_record.funder
+        {
+            Some((*amount_to_fund, "creating Marinade stake account"))
+        } else {
+            None
+        };
+        if let Some((amount, label)) = marinade_deposit {
             add_marinade_funded_stake_account(
                 &mut transaction_builder,
                 &marinade_wallet,
                 &withdrawer_authority,
                 settlement_record,
-                settlement_record.reserve_front,
+                amount,
                 minimal_stake_lamports,
-                "reserve front",
+                label,
             )?;
         }
         match &settlement_record.funder {
-            SettlementFunderType::Marinade(Some(SettlementFunderMarinade { amount_to_fund })) => {
-                add_marinade_funded_stake_account(
-                    &mut transaction_builder,
-                    &marinade_wallet,
-                    &withdrawer_authority,
-                    settlement_record,
-                    *amount_to_fund,
-                    minimal_stake_lamports,
-                    "creating Marinade stake account",
-                )?;
-            }
+            SettlementFunderType::Marinade(Some(_)) => {} // handled above
             SettlementFunderType::ValidatorBond(validator_bonds_funders) => {
                 for SettlementFunderValidatorBond {
                     stake_account_to_fund,
@@ -763,7 +765,7 @@ async fn fund_settlements(
                     )?;
                 }
             }
-            _ => {
+            SettlementFunderType::Marinade(None) => {
                 // reason should be already part of reporting and we don't want to double-add
                 error!(
                     "Not possible to fund settlement {} (vote account {}, bond {}, epoch {}, reason {}, funder {:?})",

--- a/settlement-pipelines/src/bin/init_settlement.rs
+++ b/settlement-pipelines/src/bin/init_settlement.rs
@@ -23,6 +23,7 @@ use settlement_pipelines::reporting::{
 use settlement_pipelines::reporting_data::{
     ReportingFunderSettlement, ReportingReasonSettlement, SettlementsReportData,
 };
+use settlement_pipelines::reserve::{apply_reserve_inflation, ReserveConfig, ReserveOpts};
 use settlement_pipelines::settlement_data::SettlementRecord;
 use solana_cli_output::display::build_balance_message;
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -69,6 +70,9 @@ struct Args {
     /// keypair payer for rent of accounts, if not provided, fee payer keypair is used
     #[arg(long)]
     rent_payer: Option<String>,
+
+    #[clap(flatten)]
+    reserve_opts: ReserveOpts,
 
     #[clap(flatten)]
     report_opts: ReportOpts,
@@ -130,6 +134,12 @@ async fn real_main(
     // Load on-chain data for Settlement accounts that we need to create
     let mut settlement_records =
         load_on_chain_data(rpc_client.clone(), &collections, args.epoch).await?;
+
+    // Option B: inflate max_total_claim by the reserve prefund for reserve-enabled
+    // settlements, so the created on-chain max matches what the bond funds and reaps.
+    if let Some(reserve) = ReserveConfig::load(&args.reserve_opts)? {
+        apply_reserve_inflation(&mut settlement_records, &reserve);
+    }
 
     let epoch = args
         .epoch

--- a/settlement-pipelines/src/bin/init_settlement.rs
+++ b/settlement-pipelines/src/bin/init_settlement.rs
@@ -135,7 +135,7 @@ async fn real_main(
     let mut settlement_records =
         load_on_chain_data(rpc_client.clone(), &collections, args.epoch).await?;
 
-    // Option B: inflate max_total_claim by the reserve prefund for reserve-enabled
+    // Inflate max_total_claim by the reserve prefund for reserve-enabled
     // settlements, so the created on-chain max matches what the bond funds and reaps.
     if let Some(reserve) = ReserveConfig::load(&args.reserve_opts)? {
         apply_reserve_inflation(&mut settlement_records, &reserve);

--- a/settlement-pipelines/src/bin/init_settlement.rs
+++ b/settlement-pipelines/src/bin/init_settlement.rs
@@ -23,7 +23,7 @@ use settlement_pipelines::reporting::{
 use settlement_pipelines::reporting_data::{
     ReportingFunderSettlement, ReportingReasonSettlement, SettlementsReportData,
 };
-use settlement_pipelines::reserve::{apply_reserve_inflation, ReserveConfig, ReserveOpts};
+use settlement_pipelines::reserve::{apply_reserve_inflation, ReserveOpts};
 use settlement_pipelines::settlement_data::SettlementRecord;
 use solana_cli_output::display::build_balance_message;
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -135,11 +135,12 @@ async fn real_main(
     let mut settlement_records =
         load_on_chain_data(rpc_client.clone(), &collections, args.epoch).await?;
 
-    // Inflate max_total_claim by the reserve prefund for reserve-enabled
-    // settlements, so the created on-chain max matches what the bond funds and reaps.
-    if let Some(reserve) = ReserveConfig::load(&args.reserve_opts) {
-        apply_reserve_inflation(&mut settlement_records, &reserve);
-    }
+    // Inflate max_total_claim by the reserve prefund for bond settlements, so the
+    // created on-chain max matches what the bond funds and reaps.
+    apply_reserve_inflation(
+        &mut settlement_records,
+        args.reserve_opts.reserve_prefund_lamports,
+    );
 
     let epoch = args
         .epoch

--- a/settlement-pipelines/src/bin/init_settlement.rs
+++ b/settlement-pipelines/src/bin/init_settlement.rs
@@ -23,7 +23,7 @@ use settlement_pipelines::reporting::{
 use settlement_pipelines::reporting_data::{
     ReportingFunderSettlement, ReportingReasonSettlement, SettlementsReportData,
 };
-use settlement_pipelines::reserve::{apply_reserve_inflation, ReserveOpts};
+use settlement_pipelines::reserve::ReserveOpts;
 use settlement_pipelines::settlement_data::SettlementRecord;
 use solana_cli_output::display::build_balance_message;
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -134,13 +134,6 @@ async fn real_main(
     // Load on-chain data for Settlement accounts that we need to create
     let mut settlement_records =
         load_on_chain_data(rpc_client.clone(), &collections, args.epoch).await?;
-
-    // Inflate max_total_claim by the reserve prefund for bond settlements, so the
-    // created on-chain max matches what the bond funds and reaps.
-    apply_reserve_inflation(
-        &mut settlement_records,
-        args.reserve_opts.reserve_prefund_lamports,
-    );
 
     let epoch = args
         .epoch

--- a/settlement-pipelines/src/bin/init_settlement.rs
+++ b/settlement-pipelines/src/bin/init_settlement.rs
@@ -137,7 +137,7 @@ async fn real_main(
 
     // Inflate max_total_claim by the reserve prefund for reserve-enabled
     // settlements, so the created on-chain max matches what the bond funds and reaps.
-    if let Some(reserve) = ReserveConfig::load(&args.reserve_opts)? {
+    if let Some(reserve) = ReserveConfig::load(&args.reserve_opts) {
         apply_reserve_inflation(&mut settlement_records, &reserve);
     }
 

--- a/settlement-pipelines/src/lib.rs
+++ b/settlement-pipelines/src/lib.rs
@@ -8,6 +8,7 @@ pub mod institutional_validators;
 pub mod json_data;
 pub mod reporting;
 pub mod reporting_data;
+pub mod reserve;
 pub mod settlement_data;
 pub mod settlements;
 pub mod stake_accounts;

--- a/settlement-pipelines/src/reserve.rs
+++ b/settlement-pipelines/src/reserve.rs
@@ -1,27 +1,14 @@
-use crate::arguments::load_pubkey;
 use crate::settlement_data::{SettlementFunderType, SettlementRecord};
-use anchor_client::anchor_lang::prelude::Pubkey;
-use anyhow::anyhow;
 use clap::Args;
 use log::info;
-use std::collections::HashSet;
-use std::fs;
-use std::path::PathBuf;
 
-/// CLI options for the global reserve that fronts mSOL bid payouts (Coord Goal 2).
-/// When the gate file is unset/empty or the prefund is zero, the feature is OFF
-/// and behavior is identical to today.
+/// CLI options for the global reserve that fronts mSOL bid payouts. A zero
+/// prefund turns the feature off and the pipeline behaves as it did before.
 #[derive(Debug, Clone, Args)]
 pub struct ReserveOpts {
-    /// File of vote accounts (one base58 pubkey per line; '#' comments allowed)
-    /// whose bond-funded settlements are fronted from the reserve. Absent/empty
-    /// => feature off.
-    #[arg(long, env)]
-    pub reserve_enabled_vote_accounts: Option<PathBuf>,
-
-    /// Lamports the reserve pre-funds per reserve-enabled settlement (R). The
-    /// on-chain max_total_claim is inflated by exactly this amount so the bond's
-    /// funding reimburses the reserve and the leftover is reaped back at close.
+    /// Lamports the reserve pre-funds per bond settlement (R). The on-chain
+    /// max_total_claim is inflated by exactly this amount so the bond's funding
+    /// reimburses the reserve and the leftover is reaped back at close.
     #[arg(long, env, default_value_t = 0)]
     pub reserve_prefund_lamports: u64,
 }
@@ -29,96 +16,63 @@ pub struct ReserveOpts {
 /// Resolved reserve configuration; build via [`ReserveConfig::load`].
 #[derive(Debug, Clone)]
 pub struct ReserveConfig {
-    enabled_vote_accounts: HashSet<Pubkey>,
     pub prefund_lamports: u64,
 }
 
 impl ReserveConfig {
-    /// Resolve [`ReserveOpts`]. Returns `None` when the feature is off (no gate
-    /// file, empty gate, or zero prefund), so callers skip all reserve behavior.
-    pub fn load(opts: &ReserveOpts) -> anyhow::Result<Option<Self>> {
-        let path = match &opts.reserve_enabled_vote_accounts {
-            Some(path) => path,
-            None => return Ok(None),
-        };
-        let contents = fs::read_to_string(path)
-            .map_err(|e| anyhow!("Could not read reserve gate file '{}': {e}", path.display()))?;
-        let enabled_vote_accounts = contents
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty() && !line.starts_with('#'))
-            .map(load_pubkey)
-            .collect::<anyhow::Result<HashSet<Pubkey>>>()?;
-        let config = Self::from_enabled(enabled_vote_accounts, opts.reserve_prefund_lamports);
-        if let Some(config) = &config {
-            info!(
-                "Reserve enabled for {} vote accounts, prefund {} lamports each",
-                config.enabled_vote_accounts.len(),
-                config.prefund_lamports,
-            );
+    /// Resolve [`ReserveOpts`]. Returns `None` when the prefund is zero, so
+    /// callers skip all reserve behavior.
+    pub fn load(opts: &ReserveOpts) -> Option<Self> {
+        if opts.reserve_prefund_lamports == 0 {
+            return None;
         }
-        Ok(config)
-    }
-
-    /// Build a config, returning `None` when the feature is effectively off
-    /// (no enabled vote accounts, or zero prefund).
-    fn from_enabled(enabled_vote_accounts: HashSet<Pubkey>, prefund_lamports: u64) -> Option<Self> {
-        if enabled_vote_accounts.is_empty() || prefund_lamports == 0 {
-            None
-        } else {
-            Some(Self {
-                enabled_vote_accounts,
-                prefund_lamports,
-            })
-        }
-    }
-
-    pub fn is_enabled(&self, vote_account: &Pubkey) -> bool {
-        self.enabled_vote_accounts.contains(vote_account)
+        info!(
+            "Reserve enabled for all bond settlements, prefund {} lamports each",
+            opts.reserve_prefund_lamports,
+        );
+        Some(Self {
+            prefund_lamports: opts.reserve_prefund_lamports,
+        })
     }
 }
 
-/// Inflate on-chain `max_total_claim` by the reserve prefund for every
-/// reserve-enabled, bond-funded settlement. The merkle root still commits to the
-/// real claims (their sum is unchanged); the extra `prefund_lamports` headroom is
-/// funded by the validator bond, never claimed (no merkle node covers it), and
-/// reaped back to the reserve at close.
+/// Whether the reserve fronts this settlement. Bond-funded only: Marinade-funded
+/// settlements (e.g. PSR) fund from `marinade_wallet` directly, are already
+/// claimable on time, and have no bond to reimburse a front.
+fn is_reserve_target(record: &SettlementRecord) -> bool {
+    matches!(record.funder, SettlementFunderType::ValidatorBond(_))
+}
+
+/// Inflate on-chain `max_total_claim` by the reserve prefund for every bond-funded
+/// settlement. The merkle root still commits to the real claims (their sum is
+/// unchanged); the extra `prefund_lamports` headroom is funded by the validator
+/// bond, never claimed (no merkle node covers it), and reaped back to the reserve
+/// at close.
 ///
-/// Gated to `ValidatorBond` funder so only the bond-funded staker payout is
-/// inflated, not Marinade-funded settlements (e.g. PSR).
-///
-/// INVARIANT: the inflation MUST equal the amount the reserve actually fronts from
-/// `marinade_wallet` during normal funding. If the reserve fronts less, the bond
-/// over-funds and the reserve over-recovers. Apply this in every binary that reads
-/// the on-chain `max_total_claim` (init sets it; fund targets it), so both sides
-/// stay consistent and the funding assert holds.
+/// INVARIANT: the inflation MUST equal what [`reserve_front_lamports`] fronts —
+/// same target, same `prefund_lamports` — so the bond funds toward exactly the
+/// inflated max and the funding assert holds.
 pub fn apply_reserve_inflation(records: &mut [SettlementRecord], reserve: &ReserveConfig) {
     for record in records.iter_mut() {
-        if reserve.is_enabled(&record.vote_account_address)
-            && matches!(record.funder, SettlementFunderType::ValidatorBond(_))
-        {
+        if is_reserve_target(record) {
             record.max_total_claim_sum += reserve.prefund_lamports;
         }
     }
 }
 
-/// Lamports to front from the reserve for this settlement on this funding run. Fronts
-/// the prefund R only for a reserve-enabled, bond-funded settlement that has nothing
-/// funded yet (`settlement_amount_funded == 0`); otherwise 0. Fronting only on first
-/// touch keeps inflate-by-R == front-by-R: later runs see `settlement_amount_funded > 0`,
-/// so the bond's normal funding target already accounts for the front.
+/// Lamports to front from the reserve for this settlement on this funding run.
+/// Fronts the prefund R only for a bond-funded settlement with nothing funded yet
+/// (`settlement_amount_funded == 0`); otherwise 0. Fronting only on first touch
+/// keeps front-by-R == inflate-by-R: later runs see `settlement_amount_funded > 0`
+/// (the bond's FundSettlement CPI bumped `lamports_funded`), so the normal funding
+/// target already accounts for the front.
 pub fn reserve_front_lamports(
     reserve: Option<&ReserveConfig>,
-    vote_account: &Pubkey,
-    is_validator_bond: bool,
+    record: &SettlementRecord,
     settlement_amount_funded: u64,
 ) -> u64 {
     match reserve {
-        Some(reserve)
-            if is_validator_bond
-                && settlement_amount_funded == 0
-                && reserve.is_enabled(vote_account) =>
-        {
+        Some(reserve) if settlement_amount_funded == 0 && is_reserve_target(record) => {
             reserve.prefund_lamports
         }
         _ => 0,
@@ -129,16 +83,13 @@ pub fn reserve_front_lamports(
 mod tests {
     use super::*;
     use crate::settlement_data::{SettlementFunderType, SettlementRecord};
+    use anchor_client::anchor_lang::prelude::Pubkey;
     use std::collections::HashMap;
 
-    fn cfg(votes: &[Pubkey], prefund: u64) -> ReserveConfig {
-        ReserveConfig::from_enabled(votes.iter().copied().collect(), prefund).unwrap()
-    }
-
-    fn record(vote: Pubkey, funder: SettlementFunderType, claim_sum: u64) -> SettlementRecord {
+    fn record(funder: SettlementFunderType, claim_sum: u64) -> SettlementRecord {
         SettlementRecord {
             epoch: 0,
-            vote_account_address: vote,
+            vote_account_address: Pubkey::new_unique(),
             bond_address: Pubkey::default(),
             bond_account: None,
             settlement_address: Pubkey::default(),
@@ -155,65 +106,58 @@ mod tests {
         }
     }
 
-    #[test]
-    fn from_enabled_gates_off_when_empty_or_zero() {
-        assert!(ReserveConfig::from_enabled(HashSet::new(), 1_000).is_none());
-        assert!(
-            ReserveConfig::from_enabled([Pubkey::new_unique()].into_iter().collect(), 0).is_none()
-        );
-        assert!(
-            ReserveConfig::from_enabled([Pubkey::new_unique()].into_iter().collect(), 1).is_some()
-        );
+    fn cfg(prefund: u64) -> ReserveConfig {
+        ReserveConfig {
+            prefund_lamports: prefund,
+        }
     }
 
     #[test]
-    fn inflation_targets_only_enabled_bond_settlements() {
-        let on = Pubkey::new_unique();
-        let off = Pubkey::new_unique();
-        let reserve = cfg(&[on], 1_000);
+    fn load_off_when_zero_prefund() {
+        assert!(ReserveConfig::load(&ReserveOpts {
+            reserve_prefund_lamports: 0
+        })
+        .is_none());
+        assert!(ReserveConfig::load(&ReserveOpts {
+            reserve_prefund_lamports: 1
+        })
+        .is_some());
+    }
+
+    #[test]
+    fn inflation_targets_only_bond_settlements() {
+        let reserve = cfg(1_000);
         let mut records = vec![
-            record(on, SettlementFunderType::ValidatorBond(vec![]), 100),
-            record(on, SettlementFunderType::Marinade(None), 100),
-            record(off, SettlementFunderType::ValidatorBond(vec![]), 100),
+            record(SettlementFunderType::ValidatorBond(vec![]), 100),
+            record(SettlementFunderType::Marinade(None), 100),
         ];
         apply_reserve_inflation(&mut records, &reserve);
-        assert_eq!(
-            records[0].max_total_claim_sum, 1_100,
-            "enabled bond inflated by R"
-        );
+        assert_eq!(records[0].max_total_claim_sum, 1_100, "bond inflated by R");
         assert_eq!(records[1].max_total_claim_sum, 100, "marinade not inflated");
-        assert_eq!(
-            records[2].max_total_claim_sum, 100,
-            "disabled vote not inflated"
-        );
     }
 
     #[test]
-    fn front_only_on_first_touch_of_enabled_bond() {
-        let on = Pubkey::new_unique();
-        let reserve = cfg(&[on], 1_000);
+    fn front_only_on_first_touch_of_bond() {
+        let reserve = cfg(1_000);
+        let bond = record(SettlementFunderType::ValidatorBond(vec![]), 100);
+        let marinade = record(SettlementFunderType::Marinade(None), 100);
         assert_eq!(
-            reserve_front_lamports(Some(&reserve), &on, true, 0),
+            reserve_front_lamports(Some(&reserve), &bond, 0),
             1_000,
-            "enabled+bond+unfunded"
+            "bond + unfunded"
         );
         assert_eq!(
-            reserve_front_lamports(Some(&reserve), &on, true, 1),
+            reserve_front_lamports(Some(&reserve), &bond, 1),
             0,
             "already funded: no front"
         );
         assert_eq!(
-            reserve_front_lamports(Some(&reserve), &on, false, 0),
+            reserve_front_lamports(Some(&reserve), &marinade, 0),
             0,
             "marinade: no front"
         );
         assert_eq!(
-            reserve_front_lamports(Some(&reserve), &Pubkey::new_unique(), true, 0),
-            0,
-            "disabled vote: no front"
-        );
-        assert_eq!(
-            reserve_front_lamports(None, &on, true, 0),
+            reserve_front_lamports(None, &bond, 0),
             0,
             "reserve off: no front"
         );

--- a/settlement-pipelines/src/reserve.rs
+++ b/settlement-pipelines/src/reserve.rs
@@ -78,7 +78,7 @@ impl ReserveConfig {
     }
 }
 
-/// Option B: inflate on-chain `max_total_claim` by the reserve prefund for every
+/// Inflate on-chain `max_total_claim` by the reserve prefund for every
 /// reserve-enabled, bond-funded settlement. The merkle root still commits to the
 /// real claims (their sum is unchanged); the extra `prefund_lamports` headroom is
 /// funded by the validator bond, never claimed (no merkle node covers it), and

--- a/settlement-pipelines/src/reserve.rs
+++ b/settlement-pipelines/src/reserve.rs
@@ -49,18 +49,28 @@ impl ReserveConfig {
             .filter(|line| !line.is_empty() && !line.starts_with('#'))
             .map(load_pubkey)
             .collect::<anyhow::Result<HashSet<Pubkey>>>()?;
-        if enabled_vote_accounts.is_empty() || opts.reserve_prefund_lamports == 0 {
-            return Ok(None);
+        let config = Self::from_enabled(enabled_vote_accounts, opts.reserve_prefund_lamports);
+        if let Some(config) = &config {
+            info!(
+                "Reserve enabled for {} vote accounts, prefund {} lamports each",
+                config.enabled_vote_accounts.len(),
+                config.prefund_lamports,
+            );
         }
-        info!(
-            "Reserve enabled for {} vote accounts, prefund {} lamports each",
-            enabled_vote_accounts.len(),
-            opts.reserve_prefund_lamports,
-        );
-        Ok(Some(Self {
-            enabled_vote_accounts,
-            prefund_lamports: opts.reserve_prefund_lamports,
-        }))
+        Ok(config)
+    }
+
+    /// Build a config, returning `None` when the feature is effectively off
+    /// (no enabled vote accounts, or zero prefund).
+    fn from_enabled(enabled_vote_accounts: HashSet<Pubkey>, prefund_lamports: u64) -> Option<Self> {
+        if enabled_vote_accounts.is_empty() || prefund_lamports == 0 {
+            None
+        } else {
+            Some(Self {
+                enabled_vote_accounts,
+                prefund_lamports,
+            })
+        }
     }
 
     pub fn is_enabled(&self, vote_account: &Pubkey) -> bool {
@@ -89,5 +99,123 @@ pub fn apply_reserve_inflation(records: &mut [SettlementRecord], reserve: &Reser
         {
             record.max_total_claim_sum += reserve.prefund_lamports;
         }
+    }
+}
+
+/// Lamports to front from the reserve for this settlement on this funding run. Fronts
+/// the prefund R only for a reserve-enabled, bond-funded settlement that has nothing
+/// funded yet (`settlement_amount_funded == 0`); otherwise 0. Fronting only on first
+/// touch keeps inflate-by-R == front-by-R: later runs see `settlement_amount_funded > 0`,
+/// so the bond's normal funding target already accounts for the front.
+pub fn reserve_front_lamports(
+    reserve: Option<&ReserveConfig>,
+    vote_account: &Pubkey,
+    is_validator_bond: bool,
+    settlement_amount_funded: u64,
+) -> u64 {
+    match reserve {
+        Some(reserve)
+            if is_validator_bond
+                && settlement_amount_funded == 0
+                && reserve.is_enabled(vote_account) =>
+        {
+            reserve.prefund_lamports
+        }
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settlement_data::{SettlementFunderType, SettlementRecord};
+    use std::collections::HashMap;
+
+    fn cfg(votes: &[Pubkey], prefund: u64) -> ReserveConfig {
+        ReserveConfig::from_enabled(votes.iter().copied().collect(), prefund).unwrap()
+    }
+
+    fn record(vote: Pubkey, funder: SettlementFunderType, claim_sum: u64) -> SettlementRecord {
+        SettlementRecord {
+            epoch: 0,
+            vote_account_address: vote,
+            bond_address: Pubkey::default(),
+            bond_account: None,
+            settlement_address: Pubkey::default(),
+            settlement_account: None,
+            settlement_staker_authority: Pubkey::default(),
+            merkle_root: [0u8; 32],
+            tree_nodes: vec![],
+            max_total_claim_sum: claim_sum,
+            max_total_claim: 0,
+            funder,
+            reason: None,
+            funding_sources: HashMap::new(),
+            reserve_front_lamports: 0,
+        }
+    }
+
+    #[test]
+    fn from_enabled_gates_off_when_empty_or_zero() {
+        assert!(ReserveConfig::from_enabled(HashSet::new(), 1_000).is_none());
+        assert!(
+            ReserveConfig::from_enabled([Pubkey::new_unique()].into_iter().collect(), 0).is_none()
+        );
+        assert!(
+            ReserveConfig::from_enabled([Pubkey::new_unique()].into_iter().collect(), 1).is_some()
+        );
+    }
+
+    #[test]
+    fn inflation_targets_only_enabled_bond_settlements() {
+        let on = Pubkey::new_unique();
+        let off = Pubkey::new_unique();
+        let reserve = cfg(&[on], 1_000);
+        let mut records = vec![
+            record(on, SettlementFunderType::ValidatorBond(vec![]), 100),
+            record(on, SettlementFunderType::Marinade(None), 100),
+            record(off, SettlementFunderType::ValidatorBond(vec![]), 100),
+        ];
+        apply_reserve_inflation(&mut records, &reserve);
+        assert_eq!(
+            records[0].max_total_claim_sum, 1_100,
+            "enabled bond inflated by R"
+        );
+        assert_eq!(records[1].max_total_claim_sum, 100, "marinade not inflated");
+        assert_eq!(
+            records[2].max_total_claim_sum, 100,
+            "disabled vote not inflated"
+        );
+    }
+
+    #[test]
+    fn front_only_on_first_touch_of_enabled_bond() {
+        let on = Pubkey::new_unique();
+        let reserve = cfg(&[on], 1_000);
+        assert_eq!(
+            reserve_front_lamports(Some(&reserve), &on, true, 0),
+            1_000,
+            "enabled+bond+unfunded"
+        );
+        assert_eq!(
+            reserve_front_lamports(Some(&reserve), &on, true, 1),
+            0,
+            "already funded: no front"
+        );
+        assert_eq!(
+            reserve_front_lamports(Some(&reserve), &on, false, 0),
+            0,
+            "marinade: no front"
+        );
+        assert_eq!(
+            reserve_front_lamports(Some(&reserve), &Pubkey::new_unique(), true, 0),
+            0,
+            "disabled vote: no front"
+        );
+        assert_eq!(
+            reserve_front_lamports(None, &on, true, 0),
+            0,
+            "reserve off: no front"
+        );
     }
 }

--- a/settlement-pipelines/src/reserve.rs
+++ b/settlement-pipelines/src/reserve.rs
@@ -2,12 +2,13 @@ use crate::settlement_data::{SettlementFunderType, SettlementRecord};
 use clap::Args;
 
 /// CLI options for the global reserve that fronts mSOL bid payouts. A zero
-/// prefund turns the reserve off — inflation and front both compute to zero.
+/// prefund turns the reserve off.
 #[derive(Debug, Clone, Args)]
 pub struct ReserveOpts {
-    /// Lamports the reserve pre-funds per bond settlement (R). The on-chain
-    /// max_total_claim is inflated by exactly this amount so the bond's funding
-    /// reimburses the reserve and the leftover is reaped back at close.
+    /// Lamports the reserve pre-funds per bond settlement (R). On first touch
+    /// the fund pass creates an undelegated stake of R from marinade_wallet so
+    /// stakers can claim immediately; the bond funds the remaining C-R; at close
+    /// the undelegated leftover reaps back to marinade_wallet.
     #[arg(long, env, default_value_t = 0)]
     pub reserve_prefund_lamports: u64,
 }
@@ -19,23 +20,6 @@ pub fn is_reserve_target(record: &SettlementRecord) -> bool {
     matches!(record.funder, SettlementFunderType::ValidatorBond(_))
 }
 
-/// Inflate on-chain max_total_claim by the reserve prefund for every bond-funded
-/// settlement (a zero prefund is a no-op). The merkle root still commits to the
-/// real claims (their sum is unchanged); the extra headroom is funded by the
-/// validator bond, never claimed (no merkle node covers it), and reaped back to
-/// the reserve at close.
-///
-/// INVARIANT: this inflation MUST equal what the fund pass fronts from
-/// marinade_wallet on first touch — same `is_reserve_target` gate, same prefund —
-/// so the bond funds toward exactly the inflated max and the funding assert holds.
-pub fn apply_reserve_inflation(records: &mut [SettlementRecord], reserve_prefund_lamports: u64) {
-    for record in records.iter_mut() {
-        if is_reserve_target(record) {
-            record.max_total_claim_sum += reserve_prefund_lamports;
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -43,7 +27,7 @@ mod tests {
     use anchor_client::anchor_lang::prelude::Pubkey;
     use std::collections::HashMap;
 
-    fn record(funder: SettlementFunderType, claim_sum: u64) -> SettlementRecord {
+    fn record(funder: SettlementFunderType) -> SettlementRecord {
         SettlementRecord {
             epoch: 0,
             vote_account_address: Pubkey::new_unique(),
@@ -54,7 +38,7 @@ mod tests {
             settlement_staker_authority: Pubkey::default(),
             merkle_root: [0u8; 32],
             tree_nodes: vec![],
-            max_total_claim_sum: claim_sum,
+            max_total_claim_sum: 0,
             max_total_claim: 0,
             funder,
             reason: None,
@@ -66,33 +50,10 @@ mod tests {
     #[test]
     fn is_reserve_target_bond_only() {
         assert!(is_reserve_target(&record(
-            SettlementFunderType::ValidatorBond(vec![]),
-            0
+            SettlementFunderType::ValidatorBond(vec![])
         )));
-        assert!(!is_reserve_target(&record(
-            SettlementFunderType::Marinade(None),
-            0
-        )));
-    }
-
-    #[test]
-    fn inflation_targets_only_bond_settlements() {
-        let mut records = vec![
-            record(SettlementFunderType::ValidatorBond(vec![]), 100),
-            record(SettlementFunderType::Marinade(None), 100),
-        ];
-        apply_reserve_inflation(&mut records, 1_000);
-        assert_eq!(records[0].max_total_claim_sum, 1_100, "bond inflated by R");
-        assert_eq!(records[1].max_total_claim_sum, 100, "marinade not inflated");
-    }
-
-    #[test]
-    fn zero_prefund_is_inert() {
-        let mut records = vec![record(SettlementFunderType::ValidatorBond(vec![]), 100)];
-        apply_reserve_inflation(&mut records, 0);
-        assert_eq!(
-            records[0].max_total_claim_sum, 100,
-            "zero prefund: no inflation"
-        );
+        assert!(!is_reserve_target(&record(SettlementFunderType::Marinade(
+            None
+        ))));
     }
 }

--- a/settlement-pipelines/src/reserve.rs
+++ b/settlement-pipelines/src/reserve.rs
@@ -1,9 +1,8 @@
 use crate::settlement_data::{SettlementFunderType, SettlementRecord};
 use clap::Args;
-use log::info;
 
 /// CLI options for the global reserve that fronts mSOL bid payouts. A zero
-/// prefund turns the feature off and the pipeline behaves as it did before.
+/// prefund turns the reserve off — inflation and front both compute to zero.
 #[derive(Debug, Clone, Args)]
 pub struct ReserveOpts {
     /// Lamports the reserve pre-funds per bond settlement (R). The on-chain
@@ -13,69 +12,27 @@ pub struct ReserveOpts {
     pub reserve_prefund_lamports: u64,
 }
 
-/// Resolved reserve configuration; build via [`ReserveConfig::load`].
-#[derive(Debug, Clone)]
-pub struct ReserveConfig {
-    pub prefund_lamports: u64,
-}
-
-impl ReserveConfig {
-    /// Resolve [`ReserveOpts`]. Returns `None` when the prefund is zero, so
-    /// callers skip all reserve behavior.
-    pub fn load(opts: &ReserveOpts) -> Option<Self> {
-        if opts.reserve_prefund_lamports == 0 {
-            return None;
-        }
-        info!(
-            "Reserve enabled for all bond settlements, prefund {} lamports each",
-            opts.reserve_prefund_lamports,
-        );
-        Some(Self {
-            prefund_lamports: opts.reserve_prefund_lamports,
-        })
-    }
-}
-
 /// Whether the reserve fronts this settlement. Bond-funded only: Marinade-funded
-/// settlements (e.g. PSR) fund from `marinade_wallet` directly, are already
+/// settlements (e.g. PSR) fund from marinade_wallet directly, are already
 /// claimable on time, and have no bond to reimburse a front.
-fn is_reserve_target(record: &SettlementRecord) -> bool {
+pub fn is_reserve_target(record: &SettlementRecord) -> bool {
     matches!(record.funder, SettlementFunderType::ValidatorBond(_))
 }
 
-/// Inflate on-chain `max_total_claim` by the reserve prefund for every bond-funded
-/// settlement. The merkle root still commits to the real claims (their sum is
-/// unchanged); the extra `prefund_lamports` headroom is funded by the validator
-/// bond, never claimed (no merkle node covers it), and reaped back to the reserve
-/// at close.
+/// Inflate on-chain max_total_claim by the reserve prefund for every bond-funded
+/// settlement (a zero prefund is a no-op). The merkle root still commits to the
+/// real claims (their sum is unchanged); the extra headroom is funded by the
+/// validator bond, never claimed (no merkle node covers it), and reaped back to
+/// the reserve at close.
 ///
-/// INVARIANT: the inflation MUST equal what [`reserve_front_lamports`] fronts —
-/// same target, same `prefund_lamports` — so the bond funds toward exactly the
-/// inflated max and the funding assert holds.
-pub fn apply_reserve_inflation(records: &mut [SettlementRecord], reserve: &ReserveConfig) {
+/// INVARIANT: this inflation MUST equal what the fund pass fronts from
+/// marinade_wallet on first touch — same `is_reserve_target` gate, same prefund —
+/// so the bond funds toward exactly the inflated max and the funding assert holds.
+pub fn apply_reserve_inflation(records: &mut [SettlementRecord], reserve_prefund_lamports: u64) {
     for record in records.iter_mut() {
         if is_reserve_target(record) {
-            record.max_total_claim_sum += reserve.prefund_lamports;
+            record.max_total_claim_sum += reserve_prefund_lamports;
         }
-    }
-}
-
-/// Lamports to front from the reserve for this settlement on this funding run.
-/// Fronts the prefund R only for a bond-funded settlement with nothing funded yet
-/// (`settlement_amount_funded == 0`); otherwise 0. Fronting only on first touch
-/// keeps front-by-R == inflate-by-R: later runs see `settlement_amount_funded > 0`
-/// (the bond's FundSettlement CPI bumped `lamports_funded`), so the normal funding
-/// target already accounts for the front.
-pub fn reserve_front_lamports(
-    reserve: Option<&ReserveConfig>,
-    record: &SettlementRecord,
-    settlement_amount_funded: u64,
-) -> u64 {
-    match reserve {
-        Some(reserve) if settlement_amount_funded == 0 && is_reserve_target(record) => {
-            reserve.prefund_lamports
-        }
-        _ => 0,
     }
 }
 
@@ -102,64 +59,40 @@ mod tests {
             funder,
             reason: None,
             funding_sources: HashMap::new(),
-            reserve_front_lamports: 0,
-        }
-    }
-
-    fn cfg(prefund: u64) -> ReserveConfig {
-        ReserveConfig {
-            prefund_lamports: prefund,
+            reserve_front: 0,
         }
     }
 
     #[test]
-    fn load_off_when_zero_prefund() {
-        assert!(ReserveConfig::load(&ReserveOpts {
-            reserve_prefund_lamports: 0
-        })
-        .is_none());
-        assert!(ReserveConfig::load(&ReserveOpts {
-            reserve_prefund_lamports: 1
-        })
-        .is_some());
+    fn is_reserve_target_bond_only() {
+        assert!(is_reserve_target(&record(
+            SettlementFunderType::ValidatorBond(vec![]),
+            0
+        )));
+        assert!(!is_reserve_target(&record(
+            SettlementFunderType::Marinade(None),
+            0
+        )));
     }
 
     #[test]
     fn inflation_targets_only_bond_settlements() {
-        let reserve = cfg(1_000);
         let mut records = vec![
             record(SettlementFunderType::ValidatorBond(vec![]), 100),
             record(SettlementFunderType::Marinade(None), 100),
         ];
-        apply_reserve_inflation(&mut records, &reserve);
+        apply_reserve_inflation(&mut records, 1_000);
         assert_eq!(records[0].max_total_claim_sum, 1_100, "bond inflated by R");
         assert_eq!(records[1].max_total_claim_sum, 100, "marinade not inflated");
     }
 
     #[test]
-    fn front_only_on_first_touch_of_bond() {
-        let reserve = cfg(1_000);
-        let bond = record(SettlementFunderType::ValidatorBond(vec![]), 100);
-        let marinade = record(SettlementFunderType::Marinade(None), 100);
+    fn zero_prefund_is_inert() {
+        let mut records = vec![record(SettlementFunderType::ValidatorBond(vec![]), 100)];
+        apply_reserve_inflation(&mut records, 0);
         assert_eq!(
-            reserve_front_lamports(Some(&reserve), &bond, 0),
-            1_000,
-            "bond + unfunded"
-        );
-        assert_eq!(
-            reserve_front_lamports(Some(&reserve), &bond, 1),
-            0,
-            "already funded: no front"
-        );
-        assert_eq!(
-            reserve_front_lamports(Some(&reserve), &marinade, 0),
-            0,
-            "marinade: no front"
-        );
-        assert_eq!(
-            reserve_front_lamports(None, &bond, 0),
-            0,
-            "reserve off: no front"
+            records[0].max_total_claim_sum, 100,
+            "zero prefund: no inflation"
         );
     }
 }

--- a/settlement-pipelines/src/reserve.rs
+++ b/settlement-pipelines/src/reserve.rs
@@ -1,0 +1,98 @@
+use crate::arguments::load_pubkey;
+use crate::settlement_data::{SettlementFunderType, SettlementRecord};
+use anchor_client::anchor_lang::prelude::Pubkey;
+use anyhow::anyhow;
+use clap::Args;
+use log::info;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+
+/// CLI options for the global reserve that fronts mSOL bid payouts (Coord Goal 2).
+/// When the gate file is unset/empty or the prefund is zero, the feature is OFF
+/// and behavior is identical to today.
+#[derive(Debug, Clone, Args)]
+pub struct ReserveOpts {
+    /// File of vote accounts (one base58 pubkey per line; '#' comments allowed)
+    /// whose bond-funded settlements are fronted from the reserve. Absent/empty
+    /// => feature off.
+    #[arg(long, env)]
+    pub reserve_enabled_vote_accounts: Option<PathBuf>,
+
+    /// Lamports the reserve pre-funds per reserve-enabled settlement (R). The
+    /// on-chain max_total_claim is inflated by exactly this amount so the bond's
+    /// funding reimburses the reserve and the leftover is reaped back at close.
+    #[arg(long, env, default_value_t = 0)]
+    pub reserve_prefund_lamports: u64,
+}
+
+/// Resolved reserve configuration; build via [`ReserveConfig::load`].
+#[derive(Debug, Clone)]
+pub struct ReserveConfig {
+    enabled_vote_accounts: HashSet<Pubkey>,
+    pub prefund_lamports: u64,
+}
+
+impl ReserveConfig {
+    /// Resolve [`ReserveOpts`]. Returns `None` when the feature is off (no gate
+    /// file, empty gate, or zero prefund), so callers skip all reserve behavior.
+    pub fn load(opts: &ReserveOpts) -> anyhow::Result<Option<Self>> {
+        let path = match &opts.reserve_enabled_vote_accounts {
+            Some(path) => path,
+            None => return Ok(None),
+        };
+        let contents = fs::read_to_string(path)
+            .map_err(|e| anyhow!("Could not read reserve gate file '{}': {e}", path.display()))?;
+        let enabled_vote_accounts = contents
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .map(load_pubkey)
+            .collect::<anyhow::Result<HashSet<Pubkey>>>()?;
+        if enabled_vote_accounts.is_empty() || opts.reserve_prefund_lamports == 0 {
+            return Ok(None);
+        }
+        info!(
+            "Reserve enabled for {} vote accounts, prefund {} lamports each",
+            enabled_vote_accounts.len(),
+            opts.reserve_prefund_lamports,
+        );
+        Ok(Some(Self {
+            enabled_vote_accounts,
+            prefund_lamports: opts.reserve_prefund_lamports,
+        }))
+    }
+
+    pub fn is_enabled(&self, vote_account: &Pubkey) -> bool {
+        self.enabled_vote_accounts.contains(vote_account)
+    }
+}
+
+/// Option B: inflate on-chain `max_total_claim` by the reserve prefund for every
+/// reserve-enabled, bond-funded settlement. The merkle root still commits to the
+/// real claims (their sum is unchanged); the extra `prefund_lamports` headroom is
+/// funded by the validator bond, never claimed (no merkle node covers it), and
+/// reaped back to the reserve at close.
+///
+/// Gated to `ValidatorBond` funder so only the bond-funded staker payout is
+/// inflated, not Marinade-funded settlements (e.g. PSR).
+///
+/// INVARIANT: the inflation MUST equal the amount the reserve actually pre-funds
+/// (see the early pre-fund pass). If the reserve fronts less, the bond over-funds
+/// and the reserve over-recovers. Apply this in every binary that reads the
+/// on-chain `max_total_claim` (init sets it; fund targets it), so both sides stay
+/// consistent and the funding assert holds.
+pub fn apply_reserve_inflation(
+    records_by_epoch: &mut HashMap<u64, Vec<SettlementRecord>>,
+    reserve: &ReserveConfig,
+) {
+    for records in records_by_epoch.values_mut() {
+        for record in records.iter_mut() {
+            if reserve.is_enabled(&record.vote_account_address)
+                && matches!(record.funder, SettlementFunderType::ValidatorBond(_))
+            {
+                record.max_total_claim_sum += reserve.prefund_lamports;
+            }
+        }
+    }
+}

--- a/settlement-pipelines/src/reserve.rs
+++ b/settlement-pipelines/src/reserve.rs
@@ -4,7 +4,7 @@ use anchor_client::anchor_lang::prelude::Pubkey;
 use anyhow::anyhow;
 use clap::Args;
 use log::info;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
@@ -77,22 +77,17 @@ impl ReserveConfig {
 /// Gated to `ValidatorBond` funder so only the bond-funded staker payout is
 /// inflated, not Marinade-funded settlements (e.g. PSR).
 ///
-/// INVARIANT: the inflation MUST equal the amount the reserve actually pre-funds
-/// (see the early pre-fund pass). If the reserve fronts less, the bond over-funds
-/// and the reserve over-recovers. Apply this in every binary that reads the
-/// on-chain `max_total_claim` (init sets it; fund targets it), so both sides stay
-/// consistent and the funding assert holds.
-pub fn apply_reserve_inflation(
-    records_by_epoch: &mut HashMap<u64, Vec<SettlementRecord>>,
-    reserve: &ReserveConfig,
-) {
-    for records in records_by_epoch.values_mut() {
-        for record in records.iter_mut() {
-            if reserve.is_enabled(&record.vote_account_address)
-                && matches!(record.funder, SettlementFunderType::ValidatorBond(_))
-            {
-                record.max_total_claim_sum += reserve.prefund_lamports;
-            }
+/// INVARIANT: the inflation MUST equal the amount the reserve actually fronts from
+/// `marinade_wallet` during normal funding. If the reserve fronts less, the bond
+/// over-funds and the reserve over-recovers. Apply this in every binary that reads
+/// the on-chain `max_total_claim` (init sets it; fund targets it), so both sides
+/// stay consistent and the funding assert holds.
+pub fn apply_reserve_inflation(records: &mut [SettlementRecord], reserve: &ReserveConfig) {
+    for record in records.iter_mut() {
+        if reserve.is_enabled(&record.vote_account_address)
+            && matches!(record.funder, SettlementFunderType::ValidatorBond(_))
+        {
+            record.max_total_claim_sum += reserve.prefund_lamports;
         }
     }
 }

--- a/settlement-pipelines/src/settlement_data.rs
+++ b/settlement-pipelines/src/settlement_data.rs
@@ -41,7 +41,7 @@ pub struct SettlementRecord {
     pub reason: Option<SettlementReason>,
     // Per-funder funding amounts from the merkle tree
     pub funding_sources: HashMap<SettlementFunder, u64>,
-    // Lamports the reserve fronts for this settlement on this run (0 = no reserve front).
+    // Lamports the reserve fronts for this settlement on this run.
     // Set by prepare_funding; consumed by fund_settlements to emit the Marinade-route front.
     pub reserve_front_lamports: u64,
 }

--- a/settlement-pipelines/src/settlement_data.rs
+++ b/settlement-pipelines/src/settlement_data.rs
@@ -43,7 +43,7 @@ pub struct SettlementRecord {
     pub funding_sources: HashMap<SettlementFunder, u64>,
     // Lamports the reserve fronts for this settlement on this run.
     // Set by prepare_funding; consumed by fund_settlements to emit the Marinade-route front.
-    pub reserve_front_lamports: u64,
+    pub reserve_front: u64,
 }
 
 /// Two SettlementRecords are equal if they are of the same bond and have the same epoch and merkle root.
@@ -214,7 +214,7 @@ pub fn parse_from_merkle_tree_collections(
                 funding_sources: merkle_tree.funding_sources.clone(),
                 bond_account: None,
                 settlement_account: None,
-                reserve_front_lamports: 0,
+                reserve_front: 0,
             };
 
             settlement_records_by_epoch
@@ -291,7 +291,7 @@ pub fn parse_settlements_from_json(
                     funding_sources: merkle_tree.funding_sources.clone(),
                     bond_account: None,
                     settlement_account: None,
-                    reserve_front_lamports: 0,
+                    reserve_front: 0,
                 } ;
                 Ok(settlement_record)
             } else {

--- a/settlement-pipelines/src/settlement_data.rs
+++ b/settlement-pipelines/src/settlement_data.rs
@@ -41,6 +41,9 @@ pub struct SettlementRecord {
     pub reason: Option<SettlementReason>,
     // Per-funder funding amounts from the merkle tree
     pub funding_sources: HashMap<SettlementFunder, u64>,
+    // Lamports the reserve fronts for this settlement on this run (0 = no reserve front).
+    // Set by prepare_funding; consumed by fund_settlements to emit the Marinade-route front.
+    pub reserve_front_lamports: u64,
 }
 
 /// Two SettlementRecords are equal if they are of the same bond and have the same epoch and merkle root.
@@ -211,6 +214,7 @@ pub fn parse_from_merkle_tree_collections(
                 funding_sources: merkle_tree.funding_sources.clone(),
                 bond_account: None,
                 settlement_account: None,
+                reserve_front_lamports: 0,
             };
 
             settlement_records_by_epoch
@@ -287,6 +291,7 @@ pub fn parse_settlements_from_json(
                     funding_sources: merkle_tree.funding_sources.clone(),
                     bond_account: None,
                     settlement_account: None,
+                    reserve_front_lamports: 0,
                 } ;
                 Ok(settlement_record)
             } else {


### PR DESCRIPTION
## Reserve front

Makes mSOL bid-settlement APY realize on time. Without a reserve, stakers wait
2–6 epochs for validators to fund their bond stake. The reserve eliminates that
lag by pre-funding each bond settlement from \`marinade_wallet\`.

### Design

**No on-chain inflation.** \`max_total_claim\` stays at the real merkle claim sum C.
The reserve R sits as an extra undelegated stake on the settlement — outside the
tracked \`lamports_funded\` counter — and is therefore not required for the bond to
be considered fully funded.

### Epoch-by-epoch flow

| Epoch | Event |
|-------|-------|
| N | \`init-settlement\`: on-chain \`max_total_claim = C\`, \`lamports_funded = 0\` |
| N | \`fund-settlement\` run 1 (\`lamports_funded == 0\`): marinade\_wallet → undelegated stake R — immediately claimable; bond → \`FundSettlement\` C−R (deactivates bond stake) |
| N+1 | Bond stake finishes deactivating. Both pools undelegated: reserve R + bond C−R = C total available |
| N+1 | Stakers claim up to C via \`ClaimSettlementV2\` (bounded by \`max_total_claim\`, not \`lamports_funded\`) — reserve claimable from epoch N |
| N+1 | \`fund-settlement\` run 2 (\`lamports_funded = C−R ≠ 0\`, no re-front): bond funds R more → \`lamports_funded = C\` |
| N+k | \`close-settlement\`: remaining undelegated stakes → \`WithdrawStake\` → \`marinade_wallet\`. Exactly R reaps back (bond's run-2 contribution); marinade made whole. |

### Invariants

1. \`max_total_claim = C\` — no inflation, claim pipeline unaffected
2. Reserve fires at most once — guard: \`on_chain lamports_funded == 0\`
3. Total claims bounded to C — program enforces \`lamports_claimed + claim ≤ max_total_claim\`
4. Bond reaches \`lamports_funded = C\` — fund pipeline retries until max reached
5. R reaps to marinade — close pipeline: undelegated → \`WithdrawStake\` → \`marinade_wallet\`

### Activation

```
--reserve-prefund-lamports <LAMPORTS>   # env: RESERVE_PREFUND_LAMPORTS, default: 0
```

Zero (default) is a no-op; the pipeline behaves exactly as before.

### Known POC limitation

\`ClaimSettlementV2\` accepts any stake with \`staker == settlement_staker_authority\`
as the source, including the reserve front. The Marinade-operated claim pipeline
uses bond stakes, leaving the reserve front for the close reap. A complete fix
requires a \`reserve: u64\` field on \`Settlement\` (future program change).

### Changes

- \`settlement-pipelines/src/reserve.rs\` — \`ReserveOpts\`, \`is_reserve_target\`; inflation removed
- \`settlement-pipelines/src/bin/init_settlement.rs\` — passes \`--reserve-prefund-lamports\`
- \`settlement-pipelines/src/bin/fund_settlement.rs\` — first-touch front; guard on \`lamports_funded == 0\`
- \`settlement-pipelines/src/settlement_data.rs\` — \`reserve_front\` field on \`SettlementRecord\`
- \`packages/validator-bonds-sdk/__tests__/bankrun/reserveReap.spec.ts\` — end-to-end: init → fund reserve stake → close → WithdrawStake reaps R to marinade\_wallet