### PR TITLE
[contract] update withdraw stake to make possible to withdraw small stake accounts [GEN-8174] 

### DIFF
--- a/packages/validator-bonds-codama/src/errors/validatorBonds.ts
+++ b/packages/validator-bonds-codama/src/errors/validatorBonds.ts
@@ -172,6 +172,12 @@ export const VALIDATOR_BONDS_ERROR__BOND_PRODUCT_SETUP_NOT_PERMITTED = 0x17bc //
 export const VALIDATOR_BONDS_ERROR__INVALID_BOND_PRODUCT_ADDRESS = 0x17bd // 6077
 /** ProductTypeConfigValidationFailure: Fail to validate ProductConfig value */
 export const VALIDATOR_BONDS_ERROR__PRODUCT_TYPE_CONFIG_VALIDATION_FAILURE = 0x17be // 6078
+/** StakeNotFullyDeactivated: Stake account is not fully deactivated, cannot be withdrawn */
+export const VALIDATOR_BONDS_ERROR__STAKE_NOT_FULLY_DEACTIVATED = 0x17bf // 6079
+/** StakeAccountIsBigEnoughToReset: Stake account is big enough to be reset, withdraw is not permitted */
+export const VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_IS_BIG_ENOUGH_TO_RESET = 0x17c0 // 6080
+/** StakeAccountNotBigEnoughToFund: Stake account is not big enough to be funded to settlement */
+export const VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_NOT_BIG_ENOUGH_TO_FUND = 0x17c1 // 6081
 
 export type ValidatorBondsError =
   | typeof VALIDATOR_BONDS_ERROR__ALREADY_PAUSED
@@ -234,12 +240,15 @@ export type ValidatorBondsError =
   | typeof VALIDATOR_BONDS_ERROR__SETTLEMENT_NOT_CLOSED
   | typeof VALIDATOR_BONDS_ERROR__SETTLEMENT_NOT_EXPIRED
   | typeof VALIDATOR_BONDS_ERROR__SETTLEMENT_NOT_READY_FOR_CLAIMING
+  | typeof VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_IS_BIG_ENOUGH_TO_RESET
   | typeof VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_IS_FUNDED_TO_SETTLEMENT
+  | typeof VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_NOT_BIG_ENOUGH_TO_FUND
   | typeof VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_NOT_BIG_ENOUGH_TO_SPLIT
   | typeof VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_NOT_FUNDED_TO_SETTLEMENT
   | typeof VALIDATOR_BONDS_ERROR__STAKE_DELEGATION_MISMATCH
   | typeof VALIDATOR_BONDS_ERROR__STAKE_LOCKED_UP
   | typeof VALIDATOR_BONDS_ERROR__STAKE_NOT_DELEGATED
+  | typeof VALIDATOR_BONDS_ERROR__STAKE_NOT_FULLY_DEACTIVATED
   | typeof VALIDATOR_BONDS_ERROR__STAKER_AUTHORITY_MISMATCH
   | typeof VALIDATOR_BONDS_ERROR__UNEXPECTED_REMAINING_ACCOUNTS
   | typeof VALIDATOR_BONDS_ERROR__UNINITIALIZED_STAKE
@@ -317,12 +326,15 @@ if (process.env.NODE_ENV !== 'production') {
     [VALIDATOR_BONDS_ERROR__SETTLEMENT_NOT_CLOSED]: `Settlement has to be closed`,
     [VALIDATOR_BONDS_ERROR__SETTLEMENT_NOT_EXPIRED]: `Settlement has not expired yet`,
     [VALIDATOR_BONDS_ERROR__SETTLEMENT_NOT_READY_FOR_CLAIMING]: `Settlement slots to start claiming not expired yet`,
+    [VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_IS_BIG_ENOUGH_TO_RESET]: `Stake account is big enough to be reset, withdraw is not permitted`,
     [VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_IS_FUNDED_TO_SETTLEMENT]: `Provided stake account has been already funded to a settlement`,
+    [VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_NOT_BIG_ENOUGH_TO_FUND]: `Stake account is not big enough to be funded to settlement`,
     [VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_NOT_BIG_ENOUGH_TO_SPLIT]: `Stake account is not big enough to be split`,
     [VALIDATOR_BONDS_ERROR__STAKE_ACCOUNT_NOT_FUNDED_TO_SETTLEMENT]: `Provided stake account is not funded under the settlement`,
     [VALIDATOR_BONDS_ERROR__STAKE_DELEGATION_MISMATCH]: `Delegation of provided stake account mismatches`,
     [VALIDATOR_BONDS_ERROR__STAKE_LOCKED_UP]: `Provided stake account is locked-up`,
     [VALIDATOR_BONDS_ERROR__STAKE_NOT_DELEGATED]: `Provided stake cannot be used for bonds, it's not delegated`,
+    [VALIDATOR_BONDS_ERROR__STAKE_NOT_FULLY_DEACTIVATED]: `Stake account is not fully deactivated, cannot be withdrawn`,
     [VALIDATOR_BONDS_ERROR__STAKER_AUTHORITY_MISMATCH]: `Stake account's staker does not match with the provided authority`,
     [VALIDATOR_BONDS_ERROR__UNEXPECTED_REMAINING_ACCOUNTS]: `Instruction context was provided with unexpected set of remaining accounts`,
     [VALIDATOR_BONDS_ERROR__UNINITIALIZED_STAKE]: `Stake is not initialized`,

--- a/packages/validator-bonds-sdk/__tests__/bankrun/fundSettlement.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/fundSettlement.spec.ts
@@ -874,6 +874,45 @@ describe('Validator Bonds fund settlement', () => {
     },
   )
 
+  it('cannot fund settlement with a stake account at the minimal size', async () => {
+    // a stake account holding exactly the minimal stake size has nothing fundable above
+    // the min size; the on-chain guard must reject it instead of underflowing
+    const maxTotalClaim = LAMPORTS_PER_SOL * 10
+    const { settlementAccount } = await executeInitSettlement({
+      configAccount,
+      program,
+      provider,
+      voteAccount,
+      operatorAuthority,
+      currentEpoch: settlementEpoch,
+      maxTotalClaim,
+    })
+
+    const stakeAccount = await createBondsFundedStakeAccountActivated(
+      stakeAccountMinimalAmount,
+    )
+    expect(
+      (await provider.connection.getAccountInfo(stakeAccount))?.lamports,
+    ).toEqual(stakeAccountMinimalAmount)
+
+    const { instruction, splitStakeAccount } = await fundSettlementInstruction({
+      program,
+      settlementAccount,
+      stakeAccount,
+    })
+    try {
+      await provider.sendIx(
+        [signer(splitStakeAccount), operatorAuthority],
+        instruction,
+      )
+      throw new Error('Expected error; stake account is only the minimal size')
+    } catch (e) {
+      verifyError(e, Errors, 6081, 'not big enough to be funded')
+    }
+    const settlementData = await getSettlement(program, settlementAccount)
+    expect(settlementData.lamportsFunded).toEqual(0)
+  })
+
   it('double fund settlement minimum delegated amount', async () => {
     const maxTotalClaim = 50 * LAMPORTS_PER_SOL
     const { settlementAccount } = await executeInitSettlement({

--- a/packages/validator-bonds-sdk/__tests__/bankrun/withdrawStake.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/bankrun/withdrawStake.spec.ts
@@ -1,19 +1,28 @@
 import { verifyError } from '@marinade.finance/anchor-common'
-import { assertNotExist, currentEpoch } from '@marinade.finance/bankrun-utils'
+import {
+  assertNotExist,
+  currentEpoch,
+  warpToNextEpoch,
+} from '@marinade.finance/bankrun-utils'
 import { createUserAndFund, signer } from '@marinade.finance/web3js-1x'
-import { Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js'
+import { Keypair, LAMPORTS_PER_SOL, StakeProgram } from '@solana/web3.js'
 
 import { initBankrunTest } from './bankrun'
 import {
   Errors,
+  bondsWithdrawerAuthority,
+  getRentExemptStake,
   resetStakeInstruction,
+  settlementStakerAuthority,
   withdrawStakeInstruction,
 } from '../../src'
 import {
+  authorizeStakeAccount,
   createBondsFundedStakeAccount,
   createSettlementFundedDelegatedStake,
   createSettlementFundedInitializedStake,
   createVoteAccount,
+  delegatedStakeAccount,
 } from '../utils/staking'
 import {
   executeInitBondInstruction,
@@ -61,6 +70,61 @@ describe('Validator Bonds withdraw stake', () => {
     )
   })
 
+  // Creates a settlement-funded DELEGATED stake that is fully deactivated (inactive).
+  // A sub-minimal delegated stake cannot be made with a real DelegateStake (that rejection
+  // is the bug itself), so we delegate >= 1 SOL, activate, deactivate, cool down, optionally
+  // withdraw down to dust, then re-authorize to the bonds/settlement PDAs.
+  // Side effect: advances ~2 epochs on the shared provider clock.
+  async function fundedDeactivatedDelegatedStake(
+    settlement: PublicKey,
+    initialLamports: number,
+    withdrawDownTo?: number,
+  ): Promise<PublicKey> {
+    const [bondsAuth] = bondsWithdrawerAuthority(
+      configAccount,
+      program.programId,
+    )
+    const [settlementAuth] = settlementStakerAuthority(
+      settlement,
+      program.programId,
+    )
+    const { stakeAccount, staker, withdrawer } = await delegatedStakeAccount({
+      provider,
+      lamports: initialLamports,
+      voteAccountToDelegate: voteAccount,
+    })
+    await warpToNextEpoch(provider) // activate
+    await provider.sendIx(
+      [staker],
+      StakeProgram.deactivate({
+        stakePubkey: stakeAccount,
+        authorizedPubkey: staker.publicKey,
+      }),
+    )
+    await warpToNextEpoch(provider) // deactivation completes -> fully inactive
+    if (withdrawDownTo !== undefined) {
+      const cur = (await provider.connection.getAccountInfo(stakeAccount))!
+        .lamports
+      await provider.sendIx(
+        [withdrawer],
+        StakeProgram.withdraw({
+          stakePubkey: stakeAccount,
+          authorizedPubkey: withdrawer.publicKey,
+          toPubkey: provider.walletPubkey,
+          lamports: cur - withdrawDownTo,
+        }),
+      )
+    }
+    await authorizeStakeAccount({
+      provider,
+      authority: withdrawer,
+      stakeAccount,
+      withdrawer: bondsAuth,
+      staker: settlementAuth,
+    })
+    return stakeAccount
+  }
+
   it('withdraw settlement operator stake account', async () => {
     const fakeSettlement = Keypair.generate().publicKey
     const stakeAccount = await createSettlementFundedInitializedStake({
@@ -85,7 +149,8 @@ describe('Validator Bonds withdraw stake', () => {
     ).toEqual(2 * LAMPORTS_PER_SOL)
   })
 
-  it('cannot withdraw settlement operator stake when delegated', async () => {
+  it('cannot withdraw settlement operator stake when delegated and active', async () => {
+    // active delegated stake is live validator collateral -> must NOT be withdrawable
     const fakeSettlement = Keypair.generate().publicKey
     const stakeAccount = await createSettlementFundedDelegatedStake({
       program,
@@ -105,9 +170,9 @@ describe('Validator Bonds withdraw stake', () => {
     })
     try {
       await provider.sendIx([operatorAuthority], instruction)
-      throw new Error('Expected error; stake is delegated')
+      throw new Error('Expected error; stake is delegated and not deactivated')
     } catch (e) {
-      verifyError(e, Errors, 6057, 'Wrong state')
+      verifyError(e, Errors, 6079, 'not fully deactivated')
     }
     expect(
       await provider.connection.getAccountInfo(stakeAccount),
@@ -174,6 +239,86 @@ describe('Validator Bonds withdraw stake', () => {
       throw new Error('Expected error; settlement account exists')
     } catch (e) {
       verifyError(e, Errors, 6027, 'Settlement has to be closed')
+    }
+  })
+
+  it('withdraws delegated, fully-deactivated, sub-minimal stake to operator', async () => {
+    const fakeSettlement = Keypair.generate().publicKey
+    const rentExempt = await getRentExemptStake(provider)
+    const stakeAccount = await fundedDeactivatedDelegatedStake(
+      fakeSettlement,
+      2 * LAMPORTS_PER_SOL + rentExempt, // delegatable so DelegateStake succeeds
+      rentExempt + 0.01 * LAMPORTS_PER_SOL, // end below minimal_size_stake_account (rent + 1 SOL)
+    )
+    const userBefore = (
+      await provider.connection.getAccountInfo(user.publicKey)
+    )?.lamports
+    const finalLamports = (
+      await provider.connection.getAccountInfo(stakeAccount)
+    )?.lamports
+    const { instruction } = await withdrawStakeInstruction({
+      program,
+      configAccount,
+      stakeAccount,
+      operatorAuthority: operatorAuthority.publicKey,
+      settlementAccount: fakeSettlement,
+      withdrawTo: user.publicKey,
+    })
+    await provider.sendIx([operatorAuthority], instruction)
+    await assertNotExist(provider, stakeAccount) // drained + closed
+    expect(
+      (await provider.connection.getAccountInfo(user.publicKey))?.lamports,
+    ).toEqual((userBefore ?? 0) + (finalLamports ?? 0))
+  })
+
+  it('cannot withdraw deactivated stake that is big enough to be reset', async () => {
+    const fakeSettlement = Keypair.generate().publicKey
+    const rentExempt = await getRentExemptStake(provider)
+    const stakeAccount = await fundedDeactivatedDelegatedStake(
+      fakeSettlement,
+      2 * LAMPORTS_PER_SOL + rentExempt, // stays >= minimal_size_stake_account
+    )
+    const { instruction } = await withdrawStakeInstruction({
+      program,
+      configAccount,
+      stakeAccount,
+      operatorAuthority: operatorAuthority.publicKey,
+      settlementAccount: fakeSettlement,
+      withdrawTo: user.publicKey,
+    })
+    try {
+      await provider.sendIx([operatorAuthority], instruction)
+      throw new Error('Expected error; stake is big enough to be reset')
+    } catch (e) {
+      verifyError(e, Errors, 6080, 'big enough to be reset')
+    }
+    expect(
+      await provider.connection.getAccountInfo(stakeAccount),
+    ).not.toBeNull()
+  })
+
+  it('cannot withdraw deactivated sub-minimal stake without operator authority', async () => {
+    const fakeSettlement = Keypair.generate().publicKey
+    const rentExempt = await getRentExemptStake(provider)
+    const stakeAccount = await fundedDeactivatedDelegatedStake(
+      fakeSettlement,
+      2 * LAMPORTS_PER_SOL + rentExempt,
+      rentExempt + 0.01 * LAMPORTS_PER_SOL,
+    )
+    const notOperator = Keypair.generate()
+    const { instruction } = await withdrawStakeInstruction({
+      program,
+      configAccount,
+      stakeAccount,
+      operatorAuthority: notOperator.publicKey,
+      settlementAccount: fakeSettlement,
+      withdrawTo: user.publicKey,
+    })
+    try {
+      await provider.sendIx([notOperator], instruction)
+      throw new Error('Expected error; signer is not the operator authority')
+    } catch (e) {
+      verifyError(e, Errors, 6003, 'operator authority')
     }
   })
 })

--- a/packages/validator-bonds-sdk/idl/json/validator_bonds.json
+++ b/packages/validator-bonds-sdk/idl/json/validator_bonds.json
@@ -4299,6 +4299,21 @@
       "code": 6078,
       "name": "ProductTypeConfigValidationFailure",
       "msg": "Fail to validate ProductConfig value"
+    },
+    {
+      "code": 6079,
+      "name": "StakeNotFullyDeactivated",
+      "msg": "Stake account is not fully deactivated, cannot be withdrawn"
+    },
+    {
+      "code": 6080,
+      "name": "StakeAccountIsBigEnoughToReset",
+      "msg": "Stake account is big enough to be reset, withdraw is not permitted"
+    },
+    {
+      "code": 6081,
+      "name": "StakeAccountNotBigEnoughToFund",
+      "msg": "Stake account is not big enough to be funded to settlement"
     }
   ],
   "types": [

--- a/packages/validator-bonds-sdk/idl/types/validator_bonds.ts
+++ b/packages/validator-bonds-sdk/idl/types/validator_bonds.ts
@@ -4305,6 +4305,21 @@ export type ValidatorBonds = {
       "code": 6078,
       "name": "productTypeConfigValidationFailure",
       "msg": "Fail to validate ProductConfig value"
+    },
+    {
+      "code": 6079,
+      "name": "stakeNotFullyDeactivated",
+      "msg": "Stake account is not fully deactivated, cannot be withdrawn"
+    },
+    {
+      "code": 6080,
+      "name": "stakeAccountIsBigEnoughToReset",
+      "msg": "Stake account is big enough to be reset, withdraw is not permitted"
+    },
+    {
+      "code": 6081,
+      "name": "stakeAccountNotBigEnoughToFund",
+      "msg": "Stake account is not big enough to be funded to settlement"
     }
   ],
   "types": [

--- a/packages/validator-bonds-sdk/src/instructions/withdrawStake.ts
+++ b/packages/validator-bonds-sdk/src/instructions/withdrawStake.ts
@@ -12,9 +12,12 @@ import type { Wallet as WalletInterface } from '@coral-xyz/anchor/dist/cjs/provi
 import type { TransactionInstruction, Keypair, Signer } from '@solana/web3.js'
 
 /**
- * Generate instruction to withdraw lamports from stake accounts
- * in `Initialized` state. Non-delegated initialized stake accounts
- * are considered as operator owned.
+ * Generate instruction to withdraw lamports from a closed settlement's leftover
+ * stake account that is NOT live validator collateral: either `Initialized`
+ * (non-delegated), or delegated but fully deactivated and below the minimal
+ * delegatable size (cannot be re-delegated/reset). Such accounts are considered
+ * operator owned. Active stake, or an inactive stake big enough to be reset,
+ * returns to the validator via ResetStake instead.
  * Only operator may call this operation.
  */
 export async function withdrawStakeInstruction({

--- a/programs/validator-bonds/src/checks.rs
+++ b/programs/validator-bonds/src/checks.rs
@@ -222,6 +222,39 @@ pub fn check_stake_exist_and_activating_or_activated(
     }
 }
 
+/// Verifies the stake account is fully inactive — no effective, activating, or
+/// deactivating stake — so the entire balance is safe to withdraw.
+/// A non-delegated (Initialized) account returns Ok (nothing is staked).
+pub fn check_stake_is_fully_deactivated(
+    stake_account: &StakeAccount,
+    epoch: Epoch,
+    stake_history: &StakeHistory,
+    stake_account_attribute_name: &str,
+) -> Result<()> {
+    if let Some(stake) = stake_account.stake() {
+        let StakeHistoryEntry {
+            effective,
+            activating,
+            deactivating,
+        } = stake
+            .delegation
+            .stake_activating_and_deactivating(epoch, stake_history, None);
+        if effective != 0 || activating != 0 || deactivating != 0 {
+            msg!(
+                "Stake account is not fully deactivated: {:?}",
+                stake_account.deref()
+            );
+            return Err(error!(ErrorCode::StakeNotFullyDeactivated)
+                .with_account_name(stake_account_attribute_name)
+                .with_values((
+                    "effective/activating/deactivating",
+                    format!("{effective}/{activating}/{deactivating}"),
+                )));
+        }
+    }
+    Ok(())
+}
+
 pub fn deserialize_stake_account(account: &UncheckedAccount) -> Result<StakeAccount> {
     require_keys_eq!(
         *account.owner,
@@ -734,6 +767,99 @@ mod tests {
                 &stake_history
             ),
             Ok(stake_activated)
+        );
+    }
+
+    #[test]
+    pub fn stake_is_fully_deactivated_check() {
+        let clock = get_clock();
+        let stake_history = StakeHistory::default();
+        assert!(clock.epoch > 0);
+
+        // not delegated -> Ok (nothing is staked)
+        for state in [
+            StakeStateV2::Uninitialized,
+            StakeStateV2::Initialized(Meta::default()),
+        ] {
+            assert_eq!(
+                check_stake_is_fully_deactivated(
+                    &get_stake_account(state),
+                    clock.epoch,
+                    &stake_history,
+                    "stake_account"
+                ),
+                Ok(())
+            );
+        }
+
+        // delegated, fully deactivated (deactivated before current epoch) -> Ok
+        let deactivated = get_stake_account(StakeStateV2::Stake(
+            Meta::default(),
+            Stake {
+                delegation: Delegation {
+                    stake: 100,
+                    activation_epoch: u64::MAX,
+                    deactivation_epoch: clock.epoch - 1,
+                    ..Delegation::default()
+                },
+                ..Stake::default()
+            },
+            StakeFlags::empty(),
+        ));
+        assert_eq!(
+            check_stake_is_fully_deactivated(
+                &deactivated,
+                clock.epoch,
+                &stake_history,
+                "stake_account"
+            ),
+            Ok(())
+        );
+
+        // delegated, currently activating -> Err
+        let activating = get_stake_account(StakeStateV2::Stake(
+            Meta::default(),
+            Stake {
+                delegation: Delegation {
+                    stake: 100,
+                    activation_epoch: clock.epoch,
+                    ..Delegation::default()
+                },
+                ..Stake::default()
+            },
+            StakeFlags::empty(),
+        ));
+        assert_eq!(
+            check_stake_is_fully_deactivated(
+                &activating,
+                clock.epoch,
+                &stake_history,
+                "stake_account"
+            ),
+            Err(ErrorCode::StakeNotFullyDeactivated.into())
+        );
+
+        // delegated, activated/effective -> Err
+        let activated = get_stake_account(StakeStateV2::Stake(
+            Meta::default(),
+            Stake {
+                delegation: Delegation {
+                    stake: 100,
+                    activation_epoch: clock.epoch - 1,
+                    ..Delegation::default()
+                },
+                ..Stake::default()
+            },
+            StakeFlags::empty(),
+        ));
+        assert_eq!(
+            check_stake_is_fully_deactivated(
+                &activated,
+                clock.epoch,
+                &stake_history,
+                "stake_account"
+            ),
+            Err(ErrorCode::StakeNotFullyDeactivated.into())
         );
     }
 

--- a/programs/validator-bonds/src/error.rs
+++ b/programs/validator-bonds/src/error.rs
@@ -242,4 +242,13 @@ pub enum ErrorCode {
 
     #[msg("Fail to validate ProductConfig value")]
     ProductTypeConfigValidationFailure, // 6078 0x17be
+
+    #[msg("Stake account is not fully deactivated, cannot be withdrawn")]
+    StakeNotFullyDeactivated, // 6079 0x17bf
+
+    #[msg("Stake account is big enough to be reset, withdraw is not permitted")]
+    StakeAccountIsBigEnoughToReset, // 6080 0x17c0
+
+    #[msg("Stake account is not big enough to be funded to settlement")]
+    StakeAccountNotBigEnoughToFund, // 6081 0x17c1
 }

--- a/programs/validator-bonds/src/instructions/settlement/fund_settlement.rs
+++ b/programs/validator-bonds/src/instructions/settlement/fund_settlement.rs
@@ -192,11 +192,18 @@ impl FundSettlement<'_> {
         let left_over_splittable = amount_available > amount_needed
             && amount_available - amount_needed >= stake_account_min_size + split_stake_rent_exempt;
 
+        // the stake account has to hold strictly more than the minimal stake size, otherwise there is
+        // nothing to fund and the `amount_available - stake_account_min_size` below would underflow
+        require_gt!(
+            amount_available,
+            stake_account_min_size,
+            ErrorCode::StakeAccountNotBigEnoughToFund
+        );
+
         let (funding_amount, is_split) =
             // -> no split needed or possible, whole stake account funded, still amount funded is subtracted off the min size
             // as after claiming the stake will be capable to exist
             if amount_available <= amount_needed || !left_over_splittable  {
-                // caller must provide a stake account above stake_account_min_size, otherwise this underflows
                 let lamports_to_fund = ctx.accounts.stake_account.get_lamports() - stake_account_min_size;
 
                 // whole amount used, no splitting - closing and returning rent

--- a/programs/validator-bonds/src/instructions/stake/withdraw_stake.rs
+++ b/programs/validator-bonds/src/instructions/stake/withdraw_stake.rs
@@ -1,19 +1,26 @@
 #![allow(deprecated)]
 // allowing deprecation as anchor 0.29.0 works with old version of StakeState struct
 
-use crate::checks::{check_stake_is_initialized_with_withdrawer_authority, is_closed};
+use crate::checks::{
+    check_stake_is_fully_deactivated, check_stake_is_initialized_with_withdrawer_authority,
+    is_closed,
+};
 use crate::constants::BONDS_WITHDRAWER_AUTHORITY_SEED;
 use crate::error::ErrorCode;
 use crate::events::stake::WithdrawStakeEvent;
 use crate::state::config::Config;
 use crate::state::settlement::find_settlement_staker_authority;
+use crate::utils::minimal_size_stake_account;
 use anchor_lang::prelude::*;
-use anchor_lang::solana_program::{stake::state::StakeState, sysvar::stake_history};
+use anchor_lang::solana_program::stake::state::StakeState;
 use anchor_spl::stake::{withdraw, Stake, StakeAccount, Withdraw};
 use std::ops::Deref;
 
-/// Withdrawing funded stake account belonging to removed settlement that has not been delegated (it's in Initialized state).
-/// Such a stake account is considered belonging to the operator of the config account.
+/// Withdrawing a funded stake account belonging to a removed (closed) settlement that is NOT live
+/// validator collateral: either non-delegated (Initialized), or delegated but fully deactivated and
+/// below the minimal delegatable size (cannot be re-delegated/reset). Such a stake account is
+/// considered belonging to the operator of the config account. Active stake, or an inactive stake
+/// big enough to be reset, is never withdrawn here — it returns to the validator via ResetStake.
 #[event_cpi]
 #[derive(Accounts)]
 pub struct WithdrawStake<'info> {
@@ -49,9 +56,7 @@ pub struct WithdrawStake<'info> {
     #[account(mut)]
     pub withdraw_to: UncheckedAccount<'info>,
 
-    /// CHECK: have no CPU budget to parse
-    #[account(address = stake_history::ID)]
-    pub stake_history: UncheckedAccount<'info>,
+    pub stake_history: Sysvar<'info, StakeHistory>,
 
     pub clock: Sysvar<'info, Clock>,
 
@@ -62,36 +67,20 @@ impl WithdrawStake<'_> {
     pub fn process(ctx: Context<WithdrawStake>) -> Result<()> {
         require!(!ctx.accounts.config.paused, ErrorCode::ProgramIsPaused);
 
-        // The rule stipulates to withdraw only when the settlement does exist.
+        // withdraw is permitted only for a leftover stake account of an already closed settlement
         require!(
             is_closed(&ctx.accounts.settlement),
             ErrorCode::SettlementNotClosed
         );
 
-        // stake account is managed by bonds program and belongs under bond validator
-        check_stake_is_initialized_with_withdrawer_authority(
+        // stake account is managed by the bonds program (withdrawer == bonds withdrawer authority)
+        let stake_meta = check_stake_is_initialized_with_withdrawer_authority(
             &ctx.accounts.stake_account,
             &ctx.accounts.bonds_withdrawer_authority.key(),
             "stake_account",
         )?;
-        let stake_state: &StakeState = ctx.accounts.stake_account.deref();
-        // operator is permitted to work only with Initialized non-delegated stake accounts
-        let stake_meta = match stake_state {
-            StakeState::Initialized(meta) => meta,
-            _ => {
-                return Err(
-                    error!(ErrorCode::WrongStakeAccountState).with_account_name("stake_account")
-                )
-            }
-        };
-        // stake account belongs under the bond config account
-        require_eq!(
-            stake_meta.authorized.withdrawer,
-            ctx.accounts.bonds_withdrawer_authority.key(),
-            ErrorCode::WrongStakeAccountWithdrawer
-        );
 
-        // check the stake account is funded to removed settlement
+        // the stake account must belong to the (closed) settlement by its staker authority
         let settlement_staker_authority =
             find_settlement_staker_authority(&ctx.accounts.settlement.key()).0;
         require_eq!(
@@ -99,6 +88,35 @@ impl WithdrawStake<'_> {
             settlement_staker_authority,
             ErrorCode::SettlementAuthorityMismatch
         );
+
+        // The operator may withdraw a leftover that is NOT live validator collateral:
+        //   * non-delegated (Initialized) — historical behaviour, considered operator owned; OR
+        //   * delegated but FULLY DEACTIVATED and BELOW the minimal delegatable size, i.e. it can
+        //     never be re-delegated/reset. Any active stake, or an inactive stake big enough to be
+        //     reset, must be returned to the validator via ResetStake instead of being withdrawn.
+        let stake_state: &StakeState = ctx.accounts.stake_account.deref();
+        match stake_state {
+            StakeState::Initialized(_) => { /* allowed, as before */ }
+            StakeState::Stake(_, _) => {
+                check_stake_is_fully_deactivated(
+                    &ctx.accounts.stake_account,
+                    ctx.accounts.clock.epoch,
+                    &ctx.accounts.stake_history,
+                    "stake_account",
+                )?;
+                let minimal_size = minimal_size_stake_account(&stake_meta, &ctx.accounts.config);
+                require_gt!(
+                    minimal_size,
+                    ctx.accounts.stake_account.get_lamports(),
+                    ErrorCode::StakeAccountIsBigEnoughToReset
+                );
+            }
+            _ => {
+                return Err(
+                    error!(ErrorCode::WrongStakeAccountState).with_account_name("stake_account")
+                )
+            }
+        }
 
         let withdrawn_amount = ctx.accounts.stake_account.get_lamports();
         withdraw(

--- a/resources/idl/validator_bonds.json
+++ b/resources/idl/validator_bonds.json
@@ -4299,6 +4299,21 @@
       "code": 6078,
       "name": "ProductTypeConfigValidationFailure",
       "msg": "Fail to validate ProductConfig value"
+    },
+    {
+      "code": 6079,
+      "name": "StakeNotFullyDeactivated",
+      "msg": "Stake account is not fully deactivated, cannot be withdrawn"
+    },
+    {
+      "code": 6080,
+      "name": "StakeAccountIsBigEnoughToReset",
+      "msg": "Stake account is big enough to be reset, withdraw is not permitted"
+    },
+    {
+      "code": 6081,
+      "name": "StakeAccountNotBigEnoughToFund",
+      "msg": "Stake account is not big enough to be funded to settlement"
     }
   ],
   "types": [

--- a/settlement-distributions/bid-distribution/src/settlement_config.rs
+++ b/settlement-distributions/bid-distribution/src/settlement_config.rs
@@ -87,8 +87,7 @@ impl FeeConfig {
         if let Some(value) = self.min_yield_premium_over_ssr_pmpe {
             ensure!(
                 value.abs() <= dec!(0.1),
-                "min_yield_premium_over_ssr_pmpe {} exceeds ±0.1 PMPE (~2% APY)",
-                value
+                "min_yield_premium_over_ssr_pmpe {value} exceeds ±0.1 PMPE (~2% APY)"
             );
         }
         ensure!(

--- a/settlement-pipelines/src/bin/close_settlement.rs
+++ b/settlement-pipelines/src/bin/close_settlement.rs
@@ -20,8 +20,8 @@ use settlement_pipelines::settlements::{
     load_expired_settlements, obtain_settlement_closing_refunds, SettlementRefundPubkeys,
 };
 use settlement_pipelines::stake_accounts::{
-    filter_settlement_funded, IGNORE_DANGLING_NOT_CLOSABLE_STAKE_ACCOUNTS_LIST,
-    STAKE_ACCOUNT_RENT_EXEMPTION,
+    filter_settlement_funded, get_stake_state_type, StakeAccountStateType,
+    IGNORE_DANGLING_NOT_CLOSABLE_STAKE_ACCOUNTS_LIST, STAKE_ACCOUNT_RENT_EXEMPTION,
 };
 use solana_cli_output::display::build_balance_message;
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -51,7 +51,9 @@ use validator_bonds_common::cli_result::{CliError, CliResult};
 use validator_bonds_common::config::get_config;
 use validator_bonds_common::constants::find_event_authority;
 use validator_bonds_common::settlements::get_settlements;
-use validator_bonds_common::stake_accounts::{collect_stake_accounts, get_clock};
+use validator_bonds_common::stake_accounts::{
+    collect_stake_accounts, get_clock, get_stake_history,
+};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -288,6 +290,9 @@ async fn reset_stake_accounts(
     let clock = get_clock(rpc_client.clone())
         .await
         .map_err(CliError::retry_able)?;
+    let stake_history = get_stake_history(rpc_client.clone())
+        .await
+        .map_err(CliError::retry_able)?;
     let all_bonds_stake_accounts =
         collect_stake_accounts(rpc_client.clone(), Some(&bonds_withdrawer_authority), None)
             .await
@@ -367,12 +372,55 @@ async fn reset_stake_accounts(
             // ResetStake re-delegates the stake; the on-chain DelegateStake CPI rejects a stake
             // whose delegatable amount is below the network minimum delegation (custom error 0xc).
             if lamports < minimal_stake_lamports {
-                reporting.warning().with_msg(format!(
-                    "Skipping reset of stake account {stake_pubkey} (settlement {}, vote account {settlement_vote_account}): its stake balance {} is below the minimum stake size {} required to re-delegate. Manual intervention needed.",
-                    reset_data.settlement,
-                    build_balance_message(lamports, false, false),
-                    build_balance_message(minimal_stake_lamports, false, false),
-                )).add();
+                // Too small to re-delegate (DelegateStake rejects below the 1 SOL network minimum).
+                // If the stake is already fully deactivated it is non-live collateral and can be
+                // swept to the operator wallet via WithdrawStake (the on-chain instruction accepts
+                // delegated + fully-deactivated + sub-minimal stakes). If it is not yet fully
+                // deactivated it cannot be withdrawn yet -> warn and skip.
+                // NOTE: this must match the on-chain `check_stake_is_fully_deactivated` (which uses
+                // stake history), otherwise we would schedule a WithdrawStake the program rejects.
+                let fully_deactivated = get_stake_state_type(&stake_state, &clock, &stake_history)
+                    == StakeAccountStateType::DelegatedAndDeactivated;
+                if fully_deactivated {
+                    transaction_builder.add_signer_checked(operator_authority_keypair);
+                    let req = program
+                        .request()
+                        .accounts(validator_bonds::accounts::WithdrawStake {
+                            config: *config_address,
+                            operator_authority: operator_authority_keypair.pubkey(),
+                            settlement: reset_data.settlement,
+                            stake_account: stake_pubkey,
+                            bonds_withdrawer_authority,
+                            withdraw_to: *marinade_wallet,
+                            stake_history: stake_history_sysvar_id,
+                            clock: clock_sysvar_id,
+                            stake_program: stake_program_id,
+                            program: validator_bonds_id,
+                            event_authority: find_event_authority().0,
+                        })
+                        .args(validator_bonds::instruction::WithdrawStake {});
+                    add_instruction_to_builder(
+                        transaction_builder,
+                        &req,
+                        format!(
+                            "Withdraw undelegatable (sub-min, deactivated) stake account {stake_pubkey} for settlement {} to operator wallet",
+                            reset_data.settlement
+                        ),
+                    )?;
+                    reporting.reportable.add_withdraw_stake(
+                        reset_data.settlement,
+                        *marinade_wallet,
+                        reset_data.epoch,
+                        lamports,
+                    );
+                } else {
+                    reporting.warning().with_msg(format!(
+                        "Skipping stake account {stake_pubkey} (settlement {}, vote account {settlement_vote_account}): its stake balance {} is below the minimum stake size {} required to re-delegate and it is not yet fully deactivated. Deactivate then re-run; manual intervention may be needed.",
+                        reset_data.settlement,
+                        build_balance_message(lamports, false, false),
+                        build_balance_message(minimal_stake_lamports, false, false),
+                    )).add();
+                }
                 continue;
             }
             let req = program


### PR DESCRIPTION
A proposal for a contract change that permits the withdrawal of small stake accounts has emerged because of Solana changes.

`TODO:` plan to deploy on-chain