### PR TITLE
[report] fix discord report [GEN-7676] 

### DIFF
--- a/scripts/generate-discord-public-report.bash
+++ b/scripts/generate-discord-public-report.bash
@@ -10,30 +10,6 @@ then
     exit 1
 fi
 
-# Fee authority addresses: env vars override, otherwise read from settlement-config.yaml
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SETTLEMENT_CONFIG="${SCRIPT_DIR}/../settlement-config.yaml"
-if [[ -z "${MARINADE_FEE_STAKE_AUTHORITY:-}${MARINADE_FEE_WITHDRAW_AUTHORITY:-}${DAO_FEE_STAKE_AUTHORITY:-}${DAO_FEE_WITHDRAW_AUTHORITY:-}" ]] \
-   && [[ -f "$SETTLEMENT_CONFIG" ]]; then
-  MARINADE_FEE_STAKE_AUTHORITY=$(yq -r '.fee_config.marinade.stake_authority' "$SETTLEMENT_CONFIG")
-  MARINADE_FEE_WITHDRAW_AUTHORITY=$(yq -r '.fee_config.marinade.withdraw_authority' "$SETTLEMENT_CONFIG")
-  DAO_FEE_STAKE_AUTHORITY=$(yq -r '.fee_config.dao.stake_authority' "$SETTLEMENT_CONFIG")
-  DAO_FEE_WITHDRAW_AUTHORITY=$(yq -r '.fee_config.dao.withdraw_authority' "$SETTLEMENT_CONFIG")
-fi
-marinade_fee_stake_authority="${MARINADE_FEE_STAKE_AUTHORITY:-}"
-marinade_fee_withdraw_authority="${MARINADE_FEE_WITHDRAW_AUTHORITY:-}"
-dao_fee_stake_authority="${DAO_FEE_STAKE_AUTHORITY:-}"
-dao_fee_withdraw_authority="${DAO_FEE_WITHDRAW_AUTHORITY:-}"
-
-# Fail fast if no fee authority addresses could be resolved from env or config
-if [[ -z "$marinade_fee_stake_authority" ]] \
-   && [[ -z "$marinade_fee_withdraw_authority" ]] \
-   && [[ -z "$dao_fee_stake_authority" ]] \
-   && [[ -z "$dao_fee_withdraw_authority" ]]; then
-  echo "Error: fee authority addresses are not configured. Set MARINADE_FEE_STAKE_AUTHORITY, MARINADE_FEE_WITHDRAW_AUTHORITY, DAO_FEE_STAKE_AUTHORITY and/or DAO_FEE_WITHDRAW_AUTHORITY, or provide settlement-config.yaml with fee_config.marinade/dao authorities." >&2
-  exit 1
-fi
-
 epoch="$(<"$settlement_collection_file" jq '.epoch' -r)"
 settlements_count=$(<"$settlement_collection_file" jq '.settlements | length' -r)
 if (( settlements_count == 0 ))
@@ -87,22 +63,17 @@ do
     vote_account=$(<<<"$settlement" jq '.vote_account' -r)
     claims_amount=$(<<<"$settlement" jq '.claims_amount / 1e9' -r | xargs printf $decimal_format)
 
-    # the pipeline processing places the whole stake amount into the amount acclaimed to fee accounts
-    # when there is some user stake accounts to distribute to the stake sum is doubled
-    protected_stake_filtered=$(<<<"$settlement" jq "[.claims[] | select(.withdraw_authority != \"$marinade_fee_withdraw_authority\" and .withdraw_authority != \"$dao_fee_withdraw_authority\" and .stake_authority != \"$marinade_fee_stake_authority\" and .stake_authority != \"$dao_fee_stake_authority\") | .active_stake] | add // 0 | . / 1e9" -r | xargs -I{} bash -c 'fmt_human_number "$@"' _ {})
-    protected_stake_raw=$(<<<"$settlement" jq '[.claims[].active_stake] | add / 1e9' -r | xargs -I{} bash -c 'fmt_human_number "$@"' _ {})
-    activating_stake_raw=$(<<<"$settlement" jq '[.claims[].activating_stake // 0] | add / 1e9' -r | xargs -I{} bash -c 'fmt_human_number "$@"' _ {})
-    if [ "$activating_stake_raw" != "0" ]; then
+    # Marinade stake the settlement charges the validator for, read from settlement details.
+    # Claim-level active_stake is 0 when the whole bid is captured as fee; ProtectedEvent has no details, so fall back to the claim sum.
+    active_basis=$(<<<"$settlement" jq -r '(.details // {}) as $d | ($d.total_marinade_active_stake // 0) as $a | (if $a > 0 then $a else ([.claims[].active_stake] | add // 0) end) / 1e9' | xargs -I{} bash -c 'fmt_human_number "$@"' _ {})
+    activating_basis=$(<<<"$settlement" jq -r '(.details // {}) as $d | ($d.total_marinade_activating_stake // 0) as $g | (if $g > 0 then $g else ([.claims[].activating_stake // 0] | add // 0) end) / 1e9' | xargs -I{} bash -c 'fmt_human_number "$@"' _ {})
+    if [ "$activating_basis" != "0" ]; then
         # Activating-stake settlement (PriorityFee): "+" sign before ☉ marks activating
         stake_sign="+"
-        stake_value="$activating_stake_raw"
+        stake_value="$activating_basis"
     else
         stake_sign=" "
-        if [ "$protected_stake_filtered" != "0" ] && [ "$protected_stake_filtered" != "$protected_stake_raw" ]; then
-            stake_value="$protected_stake_filtered"
-        else
-            stake_value="$protected_stake_raw"
-        fi
+        stake_value="$active_basis"
     fi
     # Right-align integer part of value, left-align trailing (decimal/unit) so
     # units digits line up under each other regardless of suffix or fraction.


### PR DESCRIPTION
A follow-up for the SOL targeting task. The Discord report is broken (see zero target stake for most of the validators)

```
========================================================
Settlements Bidding in epoch 991: 128 total, ☉196.939072568
  Bidding: 79 settlements, ☉190.051368816
  BondRiskFee: 1 settlements, ☉0.953173261
  PriorityFee: 46 settlements, ☉5.030089042
  ProtectedEvent/CommissionSamIncrease: 1 settlements, ☉0.067925791
  ProtectedEvent/DowntimeRevenueImpact: 1 settlements, ☉0.836515658
                                vote account    settlement                        reason  stake       funded by
--------------------------------------------+-------------+-----------------------------+--------+-------------
 1oH9rfyrbKoP7ucJ1Zr2HLHmDU8N6G1G6dEuruFsSqy  ☉0.022140452                      Bidding  ☉  0        Validator
 1oH9rfyrbKoP7ucJ1Zr2HLHmDU8N6G1G6dEuruFsSqy  ☉0.000003270                  PriorityFee  ☉  0        Validator
2DNGsVZ9rg6RvT8bY4SGmGvyiVJ4xt9RL3NDd6uhfN46  ☉2.544341746                      Bidding  ☉  0        Validator
2DNGsVZ9rg6RvT8bY4SGmGvyiVJ4xt9RL3NDd6uhfN46  ☉0.000006495                  PriorityFee  ☉  0        Validator
2ve7kgjvaDZhMPq2nXhvGLno8sPJ8BAEdCvza384PyC8  ☉0.021862265                      Bidding  ☉  0        Validator
2wUhcnViyzstvWmk7NAboKtjbFbqJPo4BvFBV37dacLc  ☉1.504872675                      Bidding  ☉ 34k       Validator
2wUhcnViyzstvWmk7NAboKtjbFbqJPo4BvFBV37dacLc  ☉0.416888804                  PriorityFee +☉  1.7k     Validator
3vwstewNgWAwN2uyuJduoZVVhmiwvAbwCxrjeJG6bASy  ☉2.088327215                      Bidding  ☉  0        Validator
4BVYjw1ztUzUPsxsaCheWWwThT2X4rjogZytGnuWPUGg  ☉0.002583608                      Bidding  ☉  0        Validator
4ibf8qJirtoBGg7gSD7V7CeCKoFB96PBYQ3J5QjSmAob  ☉2.494330278                      Bidding  ☉  0        Validator
...
```
