### PR TITLE
[pipeline] ignore minimal dangling stake for close [GEN-8174]

### DIFF
--- a/settlement-distributions/bid-distribution/src/settlement_config.rs
+++ b/settlement-distributions/bid-distribution/src/settlement_config.rs
@@ -87,8 +87,7 @@ impl FeeConfig {
         if let Some(value) = self.min_yield_premium_over_ssr_pmpe {
             ensure!(
                 value.abs() <= dec!(0.1),
-                "min_yield_premium_over_ssr_pmpe {} exceeds ±0.1 PMPE (~2% APY)",
-                value
+                "min_yield_premium_over_ssr_pmpe {value} exceeds ±0.1 PMPE (~2% APY)"
             );
         }
         ensure!(

--- a/settlement-pipelines/src/bin/close_settlement.rs
+++ b/settlement-pipelines/src/bin/close_settlement.rs
@@ -320,6 +320,15 @@ async fn reset_stake_accounts(
                     debug!(
                         "Stake account {stake_pubkey} is dangling but it is in the list of known problematic stake accounts, skipping it."
                     );
+                } else if lamports < minimal_stake_lamports {
+                    // sub-minimal dangling dust can neither be re-delegated (DelegateStake rejects
+                    // below the network minimum) nor withdrawn by the current program, so it is
+                    // unrecoverable here; log instead of failing the pipeline
+                    info!(
+                        "Stake account {stake_pubkey} is dangling and below the minimum stake size {} (balance {}); cannot be cleaned up by the pipeline, skipping.",
+                        build_balance_message(minimal_stake_lamports, false, false),
+                        build_balance_message(lamports, false, false),
+                    );
                 } else {
                     reporting.error().with_msg(format!(
                         "Stake account {stake_pubkey} is dangling, not belonging to any Settlement. Manual intervention needed."


### PR DESCRIPTION
Small stake accounts that cannot be closed now should be ignored

This can be fully fixed when https://github.com/marinade-finance/validator-bonds/pull/463 lands on-chain