### PR TITLE
Fix Marinade settlement funding detection in verify_settlement

### DIFF
--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -25,8 +25,8 @@ use settlement_pipelines::settlement_data::{
     SettlementRecord,
 };
 use settlement_pipelines::stake_accounts::{
-    get_delegated_amount, get_stake_state_type, prepare_merge_instructions, StakeAccountStateType,
-    STAKE_ACCOUNT_RENT_EXEMPTION,
+    get_delegated_amount, get_stake_state_type, prepare_merge_instructions,
+    settlement_funded_claimable_lamports, StakeAccountStateType, STAKE_ACCOUNT_RENT_EXEMPTION,
 };
 use solana_cli_output::display::build_balance_message;
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -271,22 +271,40 @@ async fn prepare_funding(
             continue;
         }
 
-        let settlement_amount_funded = settlement_record
-            .settlement_account
-            .as_ref()
-            .map_or(0, |s| s.lamports_funded.saturating_sub(s.lamports_claimed));
-        let amount_to_fund = settlement_record.settlement_account.as_ref().map_or(
-            settlement_record.max_total_claim_sum,
-            |settlement| {
-                assert_eq!(
-                    settlement.max_total_claim,
-                    settlement_record.max_total_claim_sum,
-                );
-                settlement
-                    .max_total_claim
-                    .saturating_sub(settlement.lamports_funded)
-            },
-        );
+        // `Settlement.lamports_funded` is increased only by the on-chain `fund_settlement`
+        // instruction, which is the ValidatorBond funding path. Marinade-funded settlements are
+        // funded by creating a stake account assigned to the settlement staker authority directly
+        // (no `fund_settlement` call), so their `lamports_funded` stays 0 forever. Deriving
+        // `amount_to_fund` from `lamports_funded` would therefore make Marinade funding
+        // non-idempotent: every run recomputes the full amount and creates yet another duplicate
+        // stake account. For the Marinade funder we reconstruct how much is already funded from
+        // on-chain reality instead — lamports already claimed plus claimable lamports still held by
+        // the settlement's stake accounts.
+        let already_funded = match &settlement_record.funder {
+            SettlementFunderType::Marinade(_) => {
+                let lamports_claimed = settlement_record
+                    .settlement_account
+                    .as_ref()
+                    .map_or(0, |s| s.lamports_claimed);
+                lamports_claimed
+                    + settlement_funded_claimable_lamports(
+                        &settlement_record.settlement_staker_authority,
+                        &all_stake_accounts,
+                        minimal_stake_lamports,
+                    )
+            }
+            SettlementFunderType::ValidatorBond(_) => settlement_record
+                .settlement_account
+                .as_ref()
+                .map_or(0, |s| {
+                    assert_eq!(s.max_total_claim, settlement_record.max_total_claim_sum);
+                    s.lamports_funded
+                }),
+        };
+        let settlement_amount_funded = already_funded;
+        let amount_to_fund = settlement_record
+            .max_total_claim_sum
+            .saturating_sub(already_funded);
 
         if amount_to_fund == 0 {
             info!(

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -271,21 +271,20 @@ async fn prepare_funding(
             continue;
         }
 
-        // `Settlement.lamports_funded` is increased only by the on-chain `fund_settlement`
-        // instruction, which is the ValidatorBond funding path. Marinade-funded settlements are
-        // funded by creating a stake account assigned to the settlement staker authority directly
-        // (no `fund_settlement` call), so their `lamports_funded` stays 0 forever. Deriving
-        // `amount_to_fund` from `lamports_funded` would therefore make Marinade funding
-        // non-idempotent: every run recomputes the full amount and creates yet another duplicate
-        // stake account. For the Marinade funder we reconstruct how much is already funded from
-        // on-chain reality instead — lamports already claimed plus claimable lamports still held by
-        // the settlement's stake accounts.
+        // Marinade funds a settlement by creating a stake account directly (no `fund_settlement`
+        // call), so `lamports_funded` stays 0 — deriving `amount_to_fund` from it would re-fund
+        // and duplicate the stake account every run. Reconstruct: claimed + claimable held in
+        // stake accounts.
         let already_funded = match &settlement_record.funder {
             SettlementFunderType::Marinade(_) => {
-                let lamports_claimed = settlement_record
-                    .settlement_account
-                    .as_ref()
-                    .map_or(0, |s| s.lamports_claimed);
+                let lamports_claimed =
+                    settlement_record
+                        .settlement_account
+                        .as_ref()
+                        .map_or(0, |s| {
+                            assert_eq!(s.max_total_claim, settlement_record.max_total_claim_sum);
+                            s.lamports_claimed
+                        });
                 lamports_claimed
                     + settlement_funded_claimable_lamports(
                         &settlement_record.settlement_staker_authority,

--- a/settlement-pipelines/src/bin/verify_settlement.rs
+++ b/settlement-pipelines/src/bin/verify_settlement.rs
@@ -10,16 +10,21 @@ use settlement_pipelines::json_data::BondSettlement;
 use settlement_pipelines::reporting::{
     with_reporting_ext, PrintReportable, ReportHandler, ReportSerializable,
 };
+use settlement_pipelines::stake_accounts::{
+    settlement_funded_claimable_lamports, STAKE_ACCOUNT_RENT_EXEMPTION,
+};
 use solana_sdk::pubkey::Pubkey;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::ops::Range;
 use std::path::PathBuf;
 use std::pin::Pin;
-use validator_bonds::state::settlement::Settlement;
+use validator_bonds::state::config::find_bonds_withdrawer_authority;
+use validator_bonds::state::settlement::{find_settlement_staker_authority, Settlement};
 use validator_bonds_common::cli_result::{CliError, CliResult};
 use validator_bonds_common::config::get_config;
 use validator_bonds_common::settlements::get_settlements_for_config;
+use validator_bonds_common::stake_accounts::{collect_stake_accounts, CollectedStakeAccounts};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -134,6 +139,8 @@ fn verify_epoch_settlements(
     claiming_epoch_range: Range<u64>,
     listed_settlements_per_epoch: &HashMap<u64, Vec<&BondSettlement>>,
     onchain_settlements: &HashMap<Pubkey, Settlement>,
+    stake_accounts: &CollectedStakeAccounts,
+    minimal_stake_lamports: u64,
 ) -> (Vec<u64>, Vec<SettlementEpoch>, Vec<SettlementEpoch>) {
     let mut non_verified_epochs = Vec::new();
     let mut non_existing_settlements = Vec::new();
@@ -155,7 +162,25 @@ fn verify_epoch_settlements(
             if let Some(onchain_settlement) =
                 onchain_settlements.get(&listed_settlement.settlement_address)
             {
-                if onchain_settlement.lamports_funded == 0 {
+                // A settlement is funded if the on-chain `fund_settlement` instruction has run
+                // (ValidatorBond path bumps `lamports_funded`), OR it has already been (partially)
+                // claimed (claims are impossible without funding), OR it is funded by stake
+                // accounts assigned to its staker authority (the Marinade path, which never bumps
+                // `lamports_funded`). Without the latter two conditions every Marinade-funded
+                // settlement — even fully funded and fully claimed ones — is falsely reported as
+                // non-funded.
+                let settlement_staker_authority =
+                    find_settlement_staker_authority(&listed_settlement.settlement_address).0;
+                let funded_by_stake_accounts = settlement_funded_claimable_lamports(
+                    &settlement_staker_authority,
+                    stake_accounts,
+                    minimal_stake_lamports,
+                );
+                let is_funded = onchain_settlement.lamports_funded > 0
+                    || onchain_settlement.lamports_claimed > 0
+                    || onchain_settlement.lamports_claimed + funded_by_stake_accounts
+                        >= onchain_settlement.max_total_claim;
+                if !is_funded {
                     error!(
                         "Existing JSON settlement {} emitted on-chain but not funded (epoch: {})",
                         listed_settlement.settlement_address, epoch_to_verify
@@ -244,6 +269,16 @@ async fn real_main(
             .into_iter()
             .collect();
 
+    // Marinade-funded settlements never bump `Settlement.lamports_funded`, so funding for them can
+    // only be detected from the bonds-owned stake accounts assigned to each settlement's staker
+    // authority (mirrors how fund-settlement and close-settlement load stake accounts).
+    let (bonds_withdrawer_authority, _) = find_bonds_withdrawer_authority(&config_address);
+    let stake_accounts =
+        collect_stake_accounts(rpc_client.clone(), Some(&bonds_withdrawer_authority), None)
+            .await
+            .map_err(CliError::retry_able)?;
+    let minimal_stake_lamports = config_data.minimum_stake_lamports + STAKE_ACCOUNT_RENT_EXEMPTION;
+
     let epochs: Vec<_> = claiming_epoch_range.clone().collect();
     info!(
         "Found {} on-chain settlements for config {} (verifying epochs {:?})",
@@ -265,6 +300,8 @@ async fn real_main(
                 claiming_epoch_range,
                 &listed_settlements_per_epoch,
                 &onchain_settlements,
+                &stake_accounts,
+                minimal_stake_lamports,
             );
         alerts.non_verified_epochs = non_verified_epochs;
         alerts.non_existing_settlements = non_existing_settlements;
@@ -337,5 +374,160 @@ impl ReportSerializable for VerifySettlementReport {
                 None => serde_json::json!({"error": "not initialized"}),
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::stake::state::{Authorized, Lockup, Meta, StakeStateV2};
+
+    const SOL: u64 = 1_000_000_000;
+    const MIN: u64 = SOL + STAKE_ACCOUNT_RENT_EXEMPTION;
+
+    fn make_settlement(
+        max_total_claim: u64,
+        lamports_funded: u64,
+        lamports_claimed: u64,
+    ) -> Settlement {
+        Settlement {
+            bond: Pubkey::default(),
+            staker_authority: Pubkey::default(),
+            merkle_root: [0u8; 32],
+            max_total_claim,
+            max_merkle_nodes: 1,
+            lamports_funded,
+            lamports_claimed,
+            merkle_nodes_claimed: 0,
+            epoch_created_for: 0,
+            slot_created_at: 0,
+            rent_collector: Pubkey::default(),
+            split_rent_collector: None,
+            split_rent_amount: 0,
+            bumps: Default::default(),
+            reserved: [0u8; 90],
+        }
+    }
+
+    fn bond_settlement(
+        settlement_address: Pubkey,
+        epoch: u64,
+        claims_lamports: u64,
+    ) -> BondSettlement {
+        BondSettlement {
+            config_address: Pubkey::default(),
+            bond_address: Pubkey::new_unique(),
+            vote_account_address: Pubkey::new_unique(),
+            settlement_address,
+            epoch,
+            merkle_root: [0u8; 32],
+            claims_count: 1,
+            claims_lamports,
+        }
+    }
+
+    fn stake_funded_to(staker: Pubkey, lamports: u64) -> (Pubkey, u64, StakeStateV2) {
+        (
+            Pubkey::new_unique(),
+            lamports,
+            StakeStateV2::Initialized(Meta {
+                rent_exempt_reserve: STAKE_ACCOUNT_RENT_EXEMPTION,
+                authorized: Authorized {
+                    staker,
+                    withdrawer: Pubkey::new_unique(),
+                },
+                lockup: Lockup::default(),
+            }),
+        )
+    }
+
+    // Regression for the ep992/ep993 incident: Marinade-funded settlements have
+    // `lamports_funded == 0` even when funded, so they must not be flagged as non-funded when they
+    // are either already claimed or backed by a funding stake account.
+    #[test]
+    fn marinade_funded_settlements_are_not_flagged() {
+        let epoch = 992u64;
+        // A: claimed Marinade settlement (funded=0 but claimed>0) — like EkdR5SQ..
+        let a_addr = Pubkey::new_unique();
+        // B: funded-but-unclaimed Marinade settlement (funded=0, claimed=0, stake account holds it)
+        //    — like ep993 BUJVBJD..
+        let b_addr = Pubkey::new_unique();
+        // C: genuinely unfunded dust settlement (no funding, no claims, no stake account)
+        let c_addr = Pubkey::new_unique();
+
+        let onchain: HashMap<Pubkey, Settlement> = HashMap::from([
+            (a_addr, make_settlement(15 * SOL, 0, 15 * SOL)),
+            (b_addr, make_settlement(11 * SOL, 0, 0)),
+            (c_addr, make_settlement(SOL / 4, 0, 0)),
+        ]);
+
+        // Only B is backed by a stake account assigned to its settlement staker authority.
+        let b_staker = find_settlement_staker_authority(&b_addr).0;
+        let stake_accounts: CollectedStakeAccounts =
+            vec![stake_funded_to(b_staker, 11 * SOL + MIN)];
+
+        let listed = vec![
+            bond_settlement(a_addr, epoch, 15 * SOL),
+            bond_settlement(b_addr, epoch, 11 * SOL),
+            bond_settlement(c_addr, epoch, SOL / 4),
+        ];
+        let mut per_epoch: HashMap<u64, Vec<&BondSettlement>> = HashMap::new();
+        per_epoch.insert(epoch, listed.iter().collect());
+
+        let (non_verified, non_existing, non_funded) = verify_epoch_settlements(
+            epoch..(epoch + 1),
+            &per_epoch,
+            &onchain,
+            &stake_accounts,
+            MIN,
+        );
+
+        assert!(non_verified.is_empty());
+        assert!(non_existing.is_empty());
+        let flagged: Vec<Pubkey> = non_funded.iter().map(|s| s.address).collect();
+        assert_eq!(
+            flagged,
+            vec![c_addr],
+            "only the genuinely-unfunded dust settlement should be flagged as non-funded"
+        );
+    }
+
+    #[test]
+    fn validator_bond_funded_settlement_is_not_flagged() {
+        let epoch = 992u64;
+        let addr = Pubkey::new_unique();
+        // ValidatorBond funding bumps lamports_funded on-chain.
+        let onchain = HashMap::from([(addr, make_settlement(5 * SOL, 5 * SOL, 0))]);
+        let listed = vec![bond_settlement(addr, epoch, 5 * SOL)];
+        let mut per_epoch: HashMap<u64, Vec<&BondSettlement>> = HashMap::new();
+        per_epoch.insert(epoch, listed.iter().collect());
+        let empty: CollectedStakeAccounts = vec![];
+
+        let (_, _, non_funded) =
+            verify_epoch_settlements(epoch..(epoch + 1), &per_epoch, &onchain, &empty, MIN);
+        assert!(non_funded.is_empty());
+    }
+
+    #[test]
+    fn underfunded_settlement_is_still_flagged() {
+        let epoch = 992u64;
+        let addr = Pubkey::new_unique();
+        // funded=0, claimed=0, and the stake account holds less than max_total_claim -> not funded
+        let onchain = HashMap::from([(addr, make_settlement(11 * SOL, 0, 0))]);
+        let staker = find_settlement_staker_authority(&addr).0;
+        let stake_accounts: CollectedStakeAccounts = vec![stake_funded_to(staker, 4 * SOL + MIN)];
+        let listed = vec![bond_settlement(addr, epoch, 11 * SOL)];
+        let mut per_epoch: HashMap<u64, Vec<&BondSettlement>> = HashMap::new();
+        per_epoch.insert(epoch, listed.iter().collect());
+
+        let (_, _, non_funded) = verify_epoch_settlements(
+            epoch..(epoch + 1),
+            &per_epoch,
+            &onchain,
+            &stake_accounts,
+            MIN,
+        );
+        let flagged: Vec<Pubkey> = non_funded.iter().map(|s| s.address).collect();
+        assert_eq!(flagged, vec![addr]);
     }
 }

--- a/settlement-pipelines/src/bin/verify_settlement.rs
+++ b/settlement-pipelines/src/bin/verify_settlement.rs
@@ -162,13 +162,10 @@ fn verify_epoch_settlements(
             if let Some(onchain_settlement) =
                 onchain_settlements.get(&listed_settlement.settlement_address)
             {
-                // A settlement is funded if the on-chain `fund_settlement` instruction has run
-                // (ValidatorBond path bumps `lamports_funded`), OR it has already been (partially)
-                // claimed (claims are impossible without funding), OR it is funded by stake
-                // accounts assigned to its staker authority (the Marinade path, which never bumps
-                // `lamports_funded`). Without the latter two conditions every Marinade-funded
-                // settlement — even fully funded and fully claimed ones — is falsely reported as
-                // non-funded.
+                // Marinade funding never bumps `lamports_funded`; detect it via stake accounts
+                // assigned to the settlement staker authority. Funded if `lamports_funded > 0`, or
+                // any claim exists (claims are impossible without funding), or claimed + claimable
+                // covers `max_total_claim` (funds are conserved, so this holds at any claim stage).
                 let settlement_staker_authority =
                     find_settlement_staker_authority(&listed_settlement.settlement_address).0;
                 let funded_by_stake_accounts = settlement_funded_claimable_lamports(

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -232,6 +232,33 @@ pub fn filter_settlement_funded(
         .collect()
 }
 
+/// Claimable lamports already funded to a Settlement via on-chain stake accounts whose staker
+/// authority equals the settlement's `settlement_staker_authority`.
+///
+/// The on-chain `Settlement.lamports_funded` field is increased only by the `fund_settlement`
+/// instruction (the ValidatorBond funding path). Marinade-funded settlements are funded by
+/// creating a stake account assigned to the settlement staker authority directly, without calling
+/// `fund_settlement`, so their `lamports_funded` stays `0` forever. For those settlements the
+/// lamports held by the stake accounts under the settlement staker authority are the only on-chain
+/// source of truth for how much has been funded.
+///
+/// Each funding stake account must keep `minimal_stake_lamports` (minimum delegation + rent
+/// exemption) to remain a valid stake account once claims have drained it, so that buffer is
+/// excluded per account — the remainder is what is actually claimable.
+pub fn settlement_funded_claimable_lamports(
+    settlement_staker_authority: &Pubkey,
+    stake_accounts: &CollectedStakeAccounts,
+    minimal_stake_lamports: u64,
+) -> u64 {
+    stake_accounts
+        .iter()
+        .filter(|(_, _, state)| {
+            matches!(state.authorized(), Some(authorized) if authorized.staker == *settlement_staker_authority)
+        })
+        .map(|(_, lamports, _)| lamports.saturating_sub(minimal_stake_lamports))
+        .sum()
+}
+
 /// Preparing instructions to merge stake accounts from stake_accounts_to_merge into destination_stake
 /// Returning list of stake accounts addresses that cannot be merged.
 /// Prepared transactions are passed from the function through mutable referecne of `transaction_builder`.
@@ -292,4 +319,88 @@ pub async fn prepare_merge_instructions(
         }
     }
     Ok(non_mergeable_stake_accounts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::stake::state::{Authorized, Lockup, Meta};
+
+    const SOL: u64 = 1_000_000_000;
+    // minimum delegation (1 SOL) + rent exemption, matching `minimal_stake_lamports` used by the
+    // funding pipeline.
+    const MIN: u64 = SOL + STAKE_ACCOUNT_RENT_EXEMPTION;
+
+    fn initialized_stake(staker: Pubkey, withdrawer: Pubkey) -> StakeStateV2 {
+        StakeStateV2::Initialized(Meta {
+            rent_exempt_reserve: STAKE_ACCOUNT_RENT_EXEMPTION,
+            authorized: Authorized { staker, withdrawer },
+            lockup: Lockup::default(),
+        })
+    }
+
+    #[test]
+    fn funded_claimable_sums_only_accounts_for_the_staker_authority() {
+        let staker = Pubkey::new_unique();
+        let other_staker = Pubkey::new_unique();
+        let withdrawer = Pubkey::new_unique();
+        let accounts: CollectedStakeAccounts = vec![
+            // two accounts funded to `staker`: claimable is balance minus the min buffer each
+            (
+                Pubkey::new_unique(),
+                5 * SOL + MIN,
+                initialized_stake(staker, withdrawer),
+            ),
+            (
+                Pubkey::new_unique(),
+                3 * SOL + MIN,
+                initialized_stake(staker, withdrawer),
+            ),
+            // belongs to a different settlement -> must be ignored
+            (
+                Pubkey::new_unique(),
+                9 * SOL + MIN,
+                initialized_stake(other_staker, withdrawer),
+            ),
+        ];
+        assert_eq!(
+            settlement_funded_claimable_lamports(&staker, &accounts, MIN),
+            8 * SOL
+        );
+    }
+
+    #[test]
+    fn funded_claimable_is_zero_when_no_matching_stake_accounts() {
+        let staker = Pubkey::new_unique();
+        let withdrawer = Pubkey::new_unique();
+        let accounts: CollectedStakeAccounts = vec![(
+            Pubkey::new_unique(),
+            10 * SOL,
+            initialized_stake(Pubkey::new_unique(), withdrawer),
+        )];
+        assert_eq!(
+            settlement_funded_claimable_lamports(&staker, &accounts, MIN),
+            0
+        );
+        assert_eq!(
+            settlement_funded_claimable_lamports(&staker, &vec![], MIN),
+            0
+        );
+    }
+
+    #[test]
+    fn funded_claimable_saturates_for_dust_below_the_min_buffer() {
+        // an account holding less than the min buffer contributes 0 (saturating_sub), never panics
+        let staker = Pubkey::new_unique();
+        let withdrawer = Pubkey::new_unique();
+        let accounts: CollectedStakeAccounts = vec![(
+            Pubkey::new_unique(),
+            MIN / 2,
+            initialized_stake(staker, withdrawer),
+        )];
+        assert_eq!(
+            settlement_funded_claimable_lamports(&staker, &accounts, MIN),
+            0
+        );
+    }
 }

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -232,19 +232,14 @@ pub fn filter_settlement_funded(
         .collect()
 }
 
-/// Claimable lamports already funded to a Settlement via on-chain stake accounts whose staker
-/// authority equals the settlement's `settlement_staker_authority`.
+/// Sum of lamports held by the stake accounts funding a Settlement — those whose staker authority
+/// is `settlement_staker_authority` — with each account's retained `minimal_stake_lamports` buffer
+/// excluded so the result reflects the claim-covering amount. It is a balance check only and does
+/// not consider delegation or lockup state.
 ///
-/// The on-chain `Settlement.lamports_funded` field is increased only by the `fund_settlement`
-/// instruction (the ValidatorBond funding path). Marinade-funded settlements are funded by
-/// creating a stake account assigned to the settlement staker authority directly, without calling
-/// `fund_settlement`, so their `lamports_funded` stays `0` forever. For those settlements the
-/// lamports held by the stake accounts under the settlement staker authority are the only on-chain
-/// source of truth for how much has been funded.
-///
-/// Each funding stake account must keep `minimal_stake_lamports` (minimum delegation + rent
-/// exemption) to remain a valid stake account once claims have drained it, so that buffer is
-/// excluded per account — the remainder is what is actually claimable.
+/// Used because Marinade-funded settlements are funded by creating such a stake account directly
+/// instead of via the `fund_settlement` instruction, so their `Settlement.lamports_funded` stays
+/// `0` and the stake accounts are the only on-chain record of how much was funded.
 pub fn settlement_funded_claimable_lamports(
     settlement_staker_authority: &Pubkey,
     stake_accounts: &CollectedStakeAccounts,

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -256,7 +256,7 @@ pub fn settlement_funded_claimable_lamports(
 
 /// Preparing instructions to merge stake accounts from stake_accounts_to_merge into destination_stake
 /// Returning list of stake accounts addresses that cannot be merged.
-/// Prepared transactions are passed from the function through mutable referecne of `transaction_builder`.
+/// Prepared transactions are passed from the function through mutable reference of `transaction_builder`.
 #[allow(clippy::too_many_arguments)]
 pub async fn prepare_merge_instructions(
     stake_accounts_to_merge: Vec<&CollectedStakeAccount>,


### PR DESCRIPTION
## Summary

Fix a critical bug in `verify_settlement` where Marinade-funded settlements were incorrectly flagged as non-funded. The issue occurs because Marinade settlements are funded by creating stake accounts assigned to the settlement's staker authority directly, without calling the `fund_settlement` instruction. This means `Settlement.lamports_funded` remains 0 forever for Marinade settlements, even when fully funded and claimed.

## Key Changes

- **verify_settlement.rs**: Updated settlement funding detection logic to recognize three valid funding states:
  1. `lamports_funded > 0` (ValidatorBond path via `fund_settlement` instruction)
  2. `lamports_claimed > 0` (settlement already claimed, implying it was funded)
  3. Stake accounts assigned to the settlement's staker authority hold sufficient lamports (Marinade path)

- **stake_accounts.rs**: Added `settlement_funded_claimable_lamports()` function to calculate claimable lamports from stake accounts assigned to a settlement's staker authority, accounting for the minimum buffer (`minimal_stake_lamports`) that must remain in each account.

- **fund_settlement.rs**: Updated funding amount calculation to use `settlement_funded_claimable_lamports()` for Marinade settlements, making the funding process idempotent (prevents duplicate stake account creation on repeated runs).

- **Tests**: Added comprehensive test coverage for:
  - Marinade-funded settlements (claimed and unclaimed)
  - ValidatorBond-funded settlements
  - Underfunded settlements (still correctly flagged)
  - Edge cases (dust accounts, no matching stake accounts, saturation)

## Implementation Details

The fix mirrors how the on-chain `fund_settlement` and `close_settlement` instructions load stake accounts — by querying for accounts whose staker authority matches the settlement's staker authority. For Marinade settlements, this is the only on-chain source of truth for funding status since `lamports_funded` is never bumped.

The `minimal_stake_lamports` buffer (minimum delegation + rent exemption) is subtracted per account to account for the minimum amount that must remain to keep the stake account valid after claims drain it.

https://claude.ai/code/session_01JM7GC7A3LY4GPY8W5Tb9Tu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settlement funding calculations for Marinade- and ValidatorBond-funded settlements.
  * Prevented repeated funding runs from incorrectly creating duplicate stake accounts.
  * Improved settlement verification to recognize funding reflected through claimed or stake-backed balances.
  * Reduced false reports of unfunded Marinade settlements while continuing to identify genuinely unfunded or underfunded settlements.
  * Added safeguards for small residual balances to ensure accurate funding status without calculation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->