### PR TITLE
[MIP-22] Adjust DAO fee split from 100% to 90%

### DIFF
--- a/settlement-config.yaml
+++ b/settlement-config.yaml
@@ -7,7 +7,7 @@ fee_config:
     stake_authority: BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x
     withdraw_authority: BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x
   dao:
-    fee_split_share_bps: 10000
+    fee_split_share_bps: 9000 # 90% DAO / 10% Marinade (BBaQ)
     stake_authority: mDAo14E6YJfEHcVZLcc235RVjviypmKMhftq7jeiLJz
     withdraw_authority: mDAo14E6YJfEHcVZLcc235RVjviypmKMhftq7jeiLJz
 


### PR DESCRIPTION
Changes the distributor fee split in `settlement-config.yaml` from 100% DAO to **90% DAO / 10% Marinade (BBaQ)**.

- `dao.fee_split_share_bps`: `10000` → `9000`

The Marinade share is `1 − dao_fee_share`, so BBaQ (`BBaQsiRo…`) now receives 10% of the distributor fee; the remaining 90% continues to the DAO wallet (`mDAo…`).

https://claude.ai/code/session_01VdpxCUt34Ar3cmp2dM6VrL