### PR TITLE
[api] update api to get more info about auction when eventing is run [GEN-8188]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -36,7 +36,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
@@ -1004,6 +1004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bonds-collector"
 version = "0.0.0"
 dependencies = [
@@ -1321,6 +1330,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,7 +1369,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -1417,6 +1437,12 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -1508,6 +1534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +1581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,18 +1619,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1606,6 +1647,15 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1628,6 +1678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,7 +1706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1834,8 +1893,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1875,7 +1946,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2079,7 +2150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2448,9 +2519,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2672,6 +2755,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2856,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2904,7 +3005,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3333,7 +3434,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3365,13 +3466,14 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.5.18",
+ "plain",
+ "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -3534,12 +3636,12 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3805,7 +3907,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4225,13 +4327,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4265,32 +4373,34 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.9"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbef655056b916eb868048276cfd5d6a7dea4f81560dfd047f97c8c6fe3fcfd4"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "md-5",
  "memchr",
- "rand 0.9.2",
- "sha2 0.10.9",
+ "rand 0.10.2",
+ "sha2 0.11.0",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4605b7c057056dd35baeb6ac0c0338e4975b1f2bef0f65da953285eb007095"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]
@@ -4566,7 +4676,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.33",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4575,9 +4685,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -4605,9 +4715,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4624,6 +4734,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -4663,6 +4779,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4721,6 +4848,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -4783,6 +4916,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -5123,7 +5265,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5551,7 +5693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -5563,7 +5705,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -5575,8 +5717,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -9079,9 +9232,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spinning_top"
@@ -9890,7 +10043,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10104,9 +10257,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b40d66d9b2cfe04b628173409368e58247e8eddbbd3b0e6c6ba1d09f20f6c9e"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -10121,7 +10274,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.10.2",
  "socket2 0.6.1",
  "tokio",
  "tokio-util",
@@ -10511,9 +10664,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -10578,7 +10731,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -10808,6 +10961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10818,9 +10980,12 @@ dependencies = [
 
 [[package]]
 name = "wasite"
-version = "0.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -10961,9 +11126,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
 dependencies = [
  "libredox",
  "wasite",
@@ -10992,7 +11157,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ solana-transaction-executor = { git = "https://github.com/marinade-finance/solan
 solana-transaction-builder = { git = "https://github.com/marinade-finance/solana-transaction-builder", tag = "solana-2.3.x" }
 solana-transaction-builder-executor = { git = "https://github.com/marinade-finance/solana-transaction-builder", tag = "solana-2.3.x" }
 tokio = { version = "1", features = ["full"] }
-tokio-postgres = { version = "0.7.7", features = ["with-chrono-0_4"] }
+tokio-postgres = { version = "0.7.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tracing = "0.1.37"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3" }

--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -31,9 +31,10 @@ use utoipa::{
         schemas(SettlementFunder),
         schemas(ProtectedEvent),
         schemas(bonds::BondsResponse),
+        schemas(bonds::AuctionContextResponse),
         schemas(protected_events::ProtectedEventsResponse),
     ),
-    paths(docs::handler, bonds::handler, bonds::handler_institutional, bonds::handler_bidding, protected_events::handler),
+    paths(docs::handler, bonds::handler, bonds::handler_institutional, bonds::handler_bidding, bonds::handler_bidding_auction, protected_events::handler),
     modifiers(&PubkeyScheme),
 )]
 pub struct ApiDoc;

--- a/api/src/bin/api.rs
+++ b/api/src/bin/api.rs
@@ -119,6 +119,14 @@ async fn main() -> anyhow::Result<()> {
         .and(with_context(context.clone()))
         .and_then(bonds::handler_bidding);
 
+    let route_bonds_bidding_auction = warp::path!("bonds" / "bidding" / "auction")
+        .and(warp::path::end())
+        .and(warp::get())
+        .and(with_rate_limit(public_limiter.clone()))
+        .and(warp::query::<bonds::QueryParams>())
+        .and(with_context(context.clone()))
+        .and_then(bonds::handler_bidding_auction);
+
     let route_bonds_institutional = warp::path!("bonds" / "institutional")
         .and(warp::path::end())
         .and(warp::get())
@@ -140,6 +148,7 @@ async fn main() -> anyhow::Result<()> {
         .or(route_api_docs_html)
         .or(route_bonds)
         .or(route_bonds_bidding)
+        .or(route_bonds_bidding_auction)
         .or(route_bonds_institutional)
         .or(route_protected_events);
 

--- a/api/src/handlers/bonds.rs
+++ b/api/src/handlers/bonds.rs
@@ -1,13 +1,23 @@
 use crate::context::WrappedContext;
 use crate::error::CustomError;
-use crate::repositories::bond::get_bonds_by_type;
+use crate::repositories::bond::{get_auction_context, get_bonds_by_type};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use validator_bonds_common::dto::{BondType, ValidatorBondRecord};
 use warp::reply::{json, Reply};
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct BondsResponse {
     bonds: Vec<ValidatorBondRecord>,
+}
+
+// ds-sam-calc relay for the CLI (separate endpoint keeps /bonds/bidding lean). Epoch
+// contract: reconcile `auction_meta.epoch` against a bond's `epoch` — separate pipelines.
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct AuctionContextResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auction_meta: Option<serde_json::Value>,
+    auction_validators: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
@@ -51,6 +61,33 @@ pub async fn handler_institutional(
             message: format!("Failed to fetch bonds. Error: {error:?}"),
         })),
     }
+}
+
+#[utoipa::path(
+    get,
+    tag = "Bonds",
+    operation_id = "Auction context for bidding validator bonds",
+    path = "/bonds/bidding/auction",
+    responses(
+        (status = 200, body = AuctionContextResponse),
+    )
+)]
+pub async fn handler_bidding_auction(
+    _query_params: QueryParams,
+    context: WrappedContext,
+) -> Result<impl Reply, warp::Rejection> {
+    // Best-effort: auxiliary CLI hints. Missing eventing tables (migration not yet
+    // applied) or empty → empty context, not a 500.
+    let auction = get_auction_context(&context.read().await.psql_client, BondType::Bidding)
+        .await
+        .unwrap_or_else(|error| {
+            tracing::warn!("Auction context unavailable: {error:?}");
+            Default::default()
+        });
+    Ok(json(&AuctionContextResponse {
+        auction_meta: auction.meta,
+        auction_validators: auction.validators,
+    }))
 }
 
 #[utoipa::path(

--- a/api/src/repositories/bond.rs
+++ b/api/src/repositories/bond.rs
@@ -4,10 +4,55 @@ use crate::dto::SqlSerializableBondType;
 use openssl::ssl::{SslConnector, SslMethod};
 use postgres_openssl::MakeTlsConnector;
 use rust_decimal::Decimal;
+use serde_json::Value;
 use std::collections::HashMap;
 use tokio_postgres::{types::ToSql, Client};
 use validator_bonds_common::cli_result::CliError;
 use validator_bonds_common::dto::{BondType, ValidatorBondRecord};
+
+/// ds-sam-calc relay from bonds-eventing: per-validator calc blobs (keyed by vote
+/// account) + the per-epoch meta. Untyped — the CLI's ds-sam-calc owns the shape.
+#[derive(Default)]
+pub struct AuctionContext {
+    pub meta: Option<Value>,
+    pub validators: HashMap<String, Value>,
+}
+
+pub async fn get_auction_context(
+    psql_client: &Client,
+    bond_type: BondType,
+) -> anyhow::Result<AuctionContext> {
+    let sql_bond_type: SqlSerializableBondType = bond_type.into();
+
+    // One statement → one snapshot: meta and the per-validator blobs can't come from two
+    // different auctions, and validators are pinned to the meta epoch so a partially-saved
+    // (failed-event) validator's stale-epoch blob is excluded from the reconstructed result.
+    let rows = psql_client
+        .query(
+            "SELECT
+               (SELECT data FROM bond_event_meta WHERE bond_type = $1) AS meta,
+               (SELECT json_object_agg(vote_account, auction_validator)
+                  FROM bond_event_state
+                  WHERE bond_type = $1
+                    AND auction_validator IS NOT NULL
+                    AND epoch = (SELECT epoch FROM bond_event_meta WHERE bond_type = $1)
+               ) AS validators",
+            &[&sql_bond_type],
+        )
+        .await?;
+
+    let Some(row) = rows.first() else {
+        return Ok(AuctionContext::default());
+    };
+
+    let meta = row.get::<_, Option<Value>>("meta");
+    let validators = match row.get::<_, Option<Value>>("validators") {
+        Some(Value::Object(map)) => map.into_iter().collect(),
+        _ => HashMap::new(),
+    };
+
+    Ok(AuctionContext { meta, validators })
+}
 
 fn pg_transient(err: tokio_postgres::Error) -> CliError {
     let is_transient = err.is_closed()

--- a/migrations/0009-add-auction-context.sql
+++ b/migrations/0009-add-auction-context.sql
@@ -1,0 +1,13 @@
+-- Per-validator calc blob relayed to the CLI (ds-sam-calc), from the auction
+-- bonds-eventing runs.
+ALTER TABLE bond_event_state
+    ADD COLUMN IF NOT EXISTS auction_validator JSONB;
+
+-- Auction-wide context (winningTotalPmpe, TVL, DsSamConfig scalars, blacklist):
+-- one row per bond_type, overwritten each eventing run.
+CREATE TABLE IF NOT EXISTS bond_event_meta (
+    bond_type TEXT PRIMARY KEY,
+    epoch INTEGER NOT NULL,
+    data JSONB NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/packages/bonds-eventing/__tests__/calc-relay.spec.ts
+++ b/packages/bonds-eventing/__tests__/calc-relay.spec.ts
@@ -1,0 +1,126 @@
+import { jsonSafe, toCalcValidator } from '../src/calc-relay'
+
+import type { AuctionValidator } from '@marinade.finance/ds-sam-sdk'
+
+function calcValidator(
+  overrides: Record<string, unknown> = {},
+): AuctionValidator {
+  return {
+    voteAccount: '11111111111111111111111111111112',
+    bondBalanceSol: 10,
+    claimableBondBalanceSol: 9,
+    marinadeActivatedStakeSol: 50000,
+    unprotectedStakeSol: 0,
+    maxStakeWanted: null,
+    samEligible: true,
+    samBlocked: false,
+    minBondPmpe: 4.2,
+    idealBondPmpe: 12.5,
+    minUnprotectedReserve: 0,
+    idealUnprotectedReserve: 0,
+    bondGoodForNEpochs: 5,
+    unstakePriority: 1,
+    auctionStake: { marinadeSamTargetSol: 1000, externalActivatedSol: 0 },
+    bondForcedUndelegation: { value: 3, coef: 0, base: 0 },
+    revShare: {
+      totalPmpe: 20,
+      expectedMaxEffBidPmpe: 3.2,
+      onchainDistributedPmpe: 0.5,
+      bidPmpe: 1,
+      effParticipatingBidPmpe: 1,
+      bondObligationPmpe: 0,
+      bidTooLowPenaltyPmpe: 0,
+      blacklistPenaltyPmpe: 0,
+    },
+    values: { bondRiskFeeSol: 0, paidUndelegationSol: 0 },
+    lastCapConstraint: null,
+    auctions: [{ bidPmpe: 1, effParticipatingBidPmpe: 1 }],
+    ...overrides,
+  } as unknown as AuctionValidator
+}
+
+describe('jsonSafe', () => {
+  it('coerces NaN and ±Infinity to null', () => {
+    expect(jsonSafe(NaN)).toBeNull()
+    expect(jsonSafe(Infinity)).toBeNull()
+    expect(jsonSafe(-Infinity)).toBeNull()
+  })
+
+  it('preserves finite numbers, strings, booleans, and null', () => {
+    expect(jsonSafe(1.5)).toBe(1.5)
+    expect(jsonSafe(0)).toBe(0)
+    expect(jsonSafe('x')).toBe('x')
+    expect(jsonSafe(true)).toBe(true)
+    expect(jsonSafe(null)).toBeNull()
+  })
+
+  it('recurses into nested arrays and objects', () => {
+    expect(jsonSafe({ a: NaN, b: [1, Infinity, { c: -Infinity }] })).toEqual({
+      a: null,
+      b: [1, null, { c: null }],
+    })
+  })
+
+  it('produces JSON-serializable output (the slonik strict-stringify hazard)', () => {
+    const out = jsonSafe({ a: NaN, b: [Infinity] })
+    expect(() => JSON.stringify(out)).not.toThrow()
+    expect(JSON.stringify(out)).toBe('{"a":null,"b":[null]}')
+  })
+})
+
+describe('toCalcValidator', () => {
+  it('relays the fields ds-sam-calc reads', () => {
+    const blob = toCalcValidator(calcValidator())
+    expect(blob.voteAccount).toBe('11111111111111111111111111111112')
+    expect(blob.minBondPmpe).toBe(4.2)
+    expect(blob.idealBondPmpe).toBe(12.5)
+    expect(blob.bondGoodForNEpochs).toBe(5)
+    expect(blob.unstakePriority).toBe(1)
+    expect(
+      (blob.auctionStake as Record<string, unknown>).marinadeSamTargetSol,
+    ).toBe(1000)
+    expect((blob.bondForcedUndelegation as Record<string, unknown>).value).toBe(
+      3,
+    )
+    expect((blob.revShare as Record<string, unknown>).totalPmpe).toBe(20)
+    expect((blob.values as Record<string, unknown>).bondRiskFeeSol).toBe(0)
+    expect(blob.auctions).toEqual([{ bidPmpe: 1, effParticipatingBidPmpe: 1 }])
+  })
+
+  it('drops the recursive lastCapConstraint.validators back-reference', () => {
+    const cap: Record<string, unknown> = {
+      constraintType: 'BOND',
+      constraintName: 'c',
+      totalStakeSol: 1,
+      totalLeftToCapSol: 0,
+      marinadeStakeSol: 1,
+      marinadeLeftToCapSol: 0,
+      validators: [] as unknown[],
+    }
+    const v = calcValidator({ lastCapConstraint: cap })
+    // Real auction shape: the constraint lists validators, each pointing back at
+    // the same constraint — a genuine cycle. JSON.stringify would throw if kept.
+    ;(cap.validators as unknown[]).push(v)
+
+    const blob = toCalcValidator(v)
+    const outCap = blob.lastCapConstraint as Record<string, unknown>
+    expect(outCap).not.toHaveProperty('validators')
+    expect(outCap.constraintType).toBe('BOND')
+    expect(outCap.totalLeftToCapSol).toBe(0)
+    expect(() => JSON.stringify(blob)).not.toThrow()
+  })
+
+  it('sanitizes NaN aggregate fields (ineligible validators) to null', () => {
+    const blob = toCalcValidator(
+      calcValidator({
+        minBondPmpe: NaN,
+        idealBondPmpe: Infinity,
+        revShare: { totalPmpe: NaN, expectedMaxEffBidPmpe: 3.2 },
+      }),
+    )
+    expect(blob.minBondPmpe).toBeNull()
+    expect(blob.idealBondPmpe).toBeNull()
+    expect((blob.revShare as Record<string, unknown>).totalPmpe).toBeNull()
+    expect(() => JSON.stringify(blob)).not.toThrow()
+  })
+})

--- a/packages/bonds-eventing/__tests__/evaluate-deltas.spec.ts
+++ b/packages/bonds-eventing/__tests__/evaluate-deltas.spec.ts
@@ -1044,5 +1044,9 @@ describe('validatorToState', () => {
     expect(state.funded_amount_lamports).toBe(10_000_000_000n)
     expect(state.deficit_lamports).toBe(175_000_000_000n) // requiredSol(185) - bondBalance(10) = 175
     expect(state.sam_eligible).toBe(true)
+    expect(state.auction_validator).toBeDefined()
+    expect(
+      (state.auction_validator as Record<string, unknown>).voteAccount,
+    ).toBe(TEST_VOTE_ACCOUNT)
   })
 })

--- a/packages/bonds-eventing/package.json
+++ b/packages/bonds-eventing/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@marinade.finance/cli-common": "4.2.5",
-    "@marinade.finance/ds-sam-sdk": "0.0.51",
+    "@marinade.finance/ds-sam-sdk": "0.1.1",
     "@marinade.finance/ts-common": "4.2.5",
     "@marinade.finance/validator-bonds-sdk": "workspace:*",
     "@marinade.finance/notifications-bonds-event-v1": "1.0.4",

--- a/packages/bonds-eventing/src/calc-relay.ts
+++ b/packages/bonds-eventing/src/calc-relay.ts
@@ -1,0 +1,79 @@
+import type { AuctionValidator } from '@marinade.finance/ds-sam-sdk'
+
+// Auction-wide context (one value per epoch, not per validator) the CLI needs to
+// reconstruct the AuctionResult for ds-sam-calc without re-running the auction.
+export interface AuctionMeta {
+  epoch: number
+  winningTotalPmpe: number
+  marinadeSamTvlSol: number
+  minBondEpochs: number
+  idealBondEpochs: number
+  minBondBalanceSol: number
+  bondRiskFeeMult: number
+  bidTooLowPenaltyHistoryEpochs: number
+  bidTooLowPenaltyPermittedDeviationPmpe: number
+  minMaxStakeWanted: number | null
+  blacklist: string[]
+}
+
+// Coerce NaN/±Infinity (SDK leaves these on ineligible validators) to null: slonik
+// sql.jsonb throws on non-finite, and calc reads them back through its own finite() guards.
+export function jsonSafe<T>(value: T): T {
+  if (typeof value === 'number') {
+    return (Number.isFinite(value) ? value : null) as T
+  }
+  if (Array.isArray(value)) {
+    return value.map(jsonSafe) as T
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = jsonSafe(val)
+    }
+    return out as T
+  }
+  return value
+}
+
+// Calc-relevant subset of AuctionValidator that ds-sam-calc reads. lastCapConstraint.validators
+// is dropped — it back-references the whole validator set (recursion / payload blowup).
+export function toCalcValidator(v: AuctionValidator): Record<string, unknown> {
+  const cap = v.lastCapConstraint
+  return jsonSafe({
+    voteAccount: v.voteAccount,
+    bondBalanceSol: v.bondBalanceSol,
+    claimableBondBalanceSol: v.claimableBondBalanceSol,
+    marinadeActivatedStakeSol: v.marinadeActivatedStakeSol,
+    unprotectedStakeSol: v.unprotectedStakeSol,
+    maxStakeWanted: v.maxStakeWanted,
+    samEligible: v.samEligible,
+    samBlocked: v.samBlocked,
+    minBondPmpe: v.minBondPmpe,
+    idealBondPmpe: v.idealBondPmpe,
+    minUnprotectedReserve: v.minUnprotectedReserve,
+    idealUnprotectedReserve: v.idealUnprotectedReserve,
+    bondGoodForNEpochs: v.bondGoodForNEpochs,
+    unstakePriority: v.unstakePriority,
+    auctionStake: { marinadeSamTargetSol: v.auctionStake.marinadeSamTargetSol },
+    bondForcedUndelegation: { value: v.bondForcedUndelegation?.value ?? null },
+    revShare: { ...v.revShare },
+    values: {
+      bondRiskFeeSol: v.values.bondRiskFeeSol,
+      paidUndelegationSol: v.values.paidUndelegationSol,
+    },
+    lastCapConstraint: cap
+      ? {
+          constraintType: cap.constraintType,
+          constraintName: cap.constraintName,
+          totalStakeSol: cap.totalStakeSol,
+          totalLeftToCapSol: cap.totalLeftToCapSol,
+          marinadeStakeSol: cap.marinadeStakeSol,
+          marinadeLeftToCapSol: cap.marinadeLeftToCapSol,
+        }
+      : null,
+    auctions: (v.auctions ?? []).map(a => ({
+      bidPmpe: a.bidPmpe,
+      effParticipatingBidPmpe: a.effParticipatingBidPmpe,
+    })),
+  })
+}

--- a/packages/bonds-eventing/src/calc-relay.ts
+++ b/packages/bonds-eventing/src/calc-relay.ts
@@ -1,18 +1,16 @@
-import type { AuctionValidator } from '@marinade.finance/ds-sam-sdk'
+import type {
+  AuctionValidator,
+  DsSamConfig,
+} from '@marinade.finance/ds-sam-sdk'
 
 // Auction-wide context (one value per epoch, not per validator) the CLI needs to
 // reconstruct the AuctionResult for ds-sam-calc without re-running the auction.
-export interface AuctionMeta {
+// Extends the full DsSamConfig so new SDK config fields are carried through
+// automatically instead of requiring a matching edit here.
+export interface AuctionMeta extends DsSamConfig {
   epoch: number
   winningTotalPmpe: number
   marinadeSamTvlSol: number
-  minBondEpochs: number
-  idealBondEpochs: number
-  minBondBalanceSol: number
-  bondRiskFeeMult: number
-  bidTooLowPenaltyHistoryEpochs: number
-  bidTooLowPenaltyPermittedDeviationPmpe: number
-  minMaxStakeWanted: number | null
   blacklist: string[]
 }
 

--- a/packages/bonds-eventing/src/commands/bidding.ts
+++ b/packages/bonds-eventing/src/commands/bidding.ts
@@ -12,6 +12,7 @@ import { runAuction } from '../run-auction'
 import {
   deleteRemovedValidators,
   loadPreviousState,
+  saveAuctionMeta,
   saveCurrentState,
 } from '../state'
 
@@ -118,7 +119,7 @@ async function manageBidding(opts: Record<string, unknown>) {
   )
 
   // 1. Run auction simulation
-  const { validators, epoch } = await runAuction(config, logger)
+  const { validators, epoch, meta } = await runAuction(config, logger)
 
   // 2. Load previous state and evaluate deltas
   let previousState = new Map<string, ValidatorState>()
@@ -207,6 +208,7 @@ async function manageBidding(opts: Record<string, unknown>) {
           await saveCurrentState(tx, succeededStates, logger)
         }
         await deleteRemovedValidators(tx, bondType, keepVoteAccounts, logger)
+        await saveAuctionMeta(tx, bondType, meta, logger)
       })
     }
 

--- a/packages/bonds-eventing/src/evaluate-deltas.ts
+++ b/packages/bonds-eventing/src/evaluate-deltas.ts
@@ -6,6 +6,8 @@ import {
 } from '@marinade.finance/validator-bonds-sdk'
 import { PublicKey } from '@solana/web3.js'
 
+import { toCalcValidator } from './calc-relay'
+
 import type {
   BondType,
   BondsEventV1,
@@ -705,5 +707,6 @@ export function validatorToState(
     deficit_lamports: solToLamports(computeDeficitMetrics(v).deficit_sol),
     sam_eligible: v.samEligible,
     updated_at: new Date().toISOString(),
+    auction_validator: toCalcValidator(v),
   }
 }

--- a/packages/bonds-eventing/src/run-auction.ts
+++ b/packages/bonds-eventing/src/run-auction.ts
@@ -7,6 +7,7 @@ import {
   loadSamConfig,
 } from '@marinade.finance/ds-sam-sdk'
 
+import type { AuctionMeta } from './calc-relay'
 import type { EventingConfig } from './types'
 import type { LoggerWrapper } from '@marinade.finance/ts-common'
 
@@ -16,7 +17,7 @@ export async function runAuction(
 ): Promise<{
   validators: AuctionValidator[]
   epoch: number
-  winningTotalPmpe: number
+  meta: AuctionMeta
 }> {
   const productionConfig = await loadSamConfig()
 
@@ -48,6 +49,19 @@ export async function runAuction(
   return {
     validators,
     epoch,
-    winningTotalPmpe: result.winningTotalPmpe,
+    meta: {
+      epoch,
+      winningTotalPmpe: result.winningTotalPmpe,
+      marinadeSamTvlSol: result.auctionData.stakeAmounts.marinadeSamTvlSol,
+      minBondEpochs: sdkConfig.minBondEpochs,
+      idealBondEpochs: sdkConfig.idealBondEpochs,
+      minBondBalanceSol: sdkConfig.minBondBalanceSol,
+      bondRiskFeeMult: sdkConfig.bondRiskFeeMult,
+      bidTooLowPenaltyHistoryEpochs: sdkConfig.bidTooLowPenaltyHistoryEpochs,
+      bidTooLowPenaltyPermittedDeviationPmpe:
+        sdkConfig.bidTooLowPenaltyPermittedDeviationPmpe,
+      minMaxStakeWanted: sdkConfig.minMaxStakeWanted,
+      blacklist: [...result.auctionData.blacklist],
+    },
   }
 }

--- a/packages/bonds-eventing/src/run-auction.ts
+++ b/packages/bonds-eventing/src/run-auction.ts
@@ -50,17 +50,10 @@ export async function runAuction(
     validators,
     epoch,
     meta: {
+      ...sdkConfig,
       epoch,
       winningTotalPmpe: result.winningTotalPmpe,
       marinadeSamTvlSol: result.auctionData.stakeAmounts.marinadeSamTvlSol,
-      minBondEpochs: sdkConfig.minBondEpochs,
-      idealBondEpochs: sdkConfig.idealBondEpochs,
-      minBondBalanceSol: sdkConfig.minBondBalanceSol,
-      bondRiskFeeMult: sdkConfig.bondRiskFeeMult,
-      bidTooLowPenaltyHistoryEpochs: sdkConfig.bidTooLowPenaltyHistoryEpochs,
-      bidTooLowPenaltyPermittedDeviationPmpe:
-        sdkConfig.bidTooLowPenaltyPermittedDeviationPmpe,
-      minMaxStakeWanted: sdkConfig.minMaxStakeWanted,
       blacklist: [...result.auctionData.blacklist],
     },
   }

--- a/packages/bonds-eventing/src/state.ts
+++ b/packages/bonds-eventing/src/state.ts
@@ -1,5 +1,13 @@
-import { type CommonQueryMethods, type DatabasePool, sql } from 'slonik'
+import {
+  type CommonQueryMethods,
+  type DatabasePool,
+  type SerializableValue,
+  sql,
+} from 'slonik'
 
+import { jsonSafe } from './calc-relay'
+
+import type { AuctionMeta } from './calc-relay'
 import type { BondType, ValidatorState } from './types'
 import type { LoggerWrapper } from '@marinade.finance/ts-common'
 
@@ -97,6 +105,7 @@ export async function saveCurrentState(
       ${state.auction_stake_lamports.toString()},
       ${state.deficit_lamports.toString()},
       ${state.sam_eligible},
+      ${sql.jsonb((state.auction_validator ?? null) as SerializableValue)},
       NOW()
     )`,
   )
@@ -107,7 +116,8 @@ export async function saveCurrentState(
       in_auction, bond_good_for_n_epochs, cap_constraint,
       cap_marinade_stake_sol,
       funded_amount_lamports, effective_amount_lamports,
-      auction_stake_lamports, deficit_lamports, sam_eligible, updated_at
+      auction_stake_lamports, deficit_lamports, sam_eligible,
+      auction_validator, updated_at
     ) VALUES
       ${sql.join(valueTuples, sql.fragment`, `)}
     ON CONFLICT (vote_account, bond_type) DO UPDATE SET
@@ -122,10 +132,31 @@ export async function saveCurrentState(
       auction_stake_lamports = EXCLUDED.auction_stake_lamports,
       deficit_lamports = EXCLUDED.deficit_lamports,
       sam_eligible = EXCLUDED.sam_eligible,
+      auction_validator = EXCLUDED.auction_validator,
       updated_at = NOW()
   `)
 
   logger.info(`Saved current state: ${states.length} validators`)
+}
+
+export async function saveAuctionMeta(
+  db: CommonQueryMethods,
+  bondType: BondType,
+  meta: AuctionMeta,
+  logger: LoggerWrapper,
+): Promise<void> {
+  await db.query(sql.unsafe`
+    INSERT INTO bond_event_meta (bond_type, epoch, data, updated_at)
+    VALUES (${bondType}, ${meta.epoch}, ${sql.jsonb(jsonSafe(meta) as unknown as SerializableValue)}, NOW())
+    ON CONFLICT (bond_type) DO UPDATE SET
+      epoch = EXCLUDED.epoch,
+      data = EXCLUDED.data,
+      updated_at = NOW()
+  `)
+
+  logger.info(
+    `Saved auction meta for bond_type=${bondType}, epoch=${meta.epoch}`,
+  )
 }
 
 export async function deleteRemovedValidators(

--- a/packages/bonds-eventing/src/types.ts
+++ b/packages/bonds-eventing/src/types.ts
@@ -33,6 +33,9 @@ export interface ValidatorState {
   deficit_lamports: bigint
   sam_eligible: boolean
   updated_at: string
+  // Calc blob relayed to the CLI; set only on save (validatorToState), not loaded
+  // back — it is not part of the delta comparison.
+  auction_validator?: Record<string, unknown>
 }
 
 export interface EmitResult {

--- a/packages/validator-bonds-sdk/__tests__/test-validator/claimSettlement.spec.ts
+++ b/packages/validator-bonds-sdk/__tests__/test-validator/claimSettlement.spec.ts
@@ -133,7 +133,7 @@ describe('Validator Bonds claim settlement', () => {
       await waitForEpoch(
         provider.connection,
         deactivationEpoch.toNumber() + 1,
-        60,
+        180,
       )
     }
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         specifier: 4.2.5
         version: 4.2.5(@marinade.finance/ts-common@4.2.5)(class-validator@0.14.2)
       '@marinade.finance/ds-sam-sdk':
-        specifier: 0.0.51
-        version: 0.0.51
+        specifier: 0.1.1
+        version: 0.1.1
       '@marinade.finance/notifications-bonds-event-v1':
         specifier: 1.0.4
         version: 1.0.4
@@ -1113,8 +1113,11 @@ packages:
       bn.js: ^5.2.1
       jsbi: ^4.3.0
 
-  '@marinade.finance/ds-sam-sdk@0.0.51':
-    resolution: {integrity: sha512-TbkdAgS5y6nyUZ9N5641PC27UoyfdBKd/6OOvAh+SKu0vvGlG6JGvPIKKzflaMvjXNMtyk8vx4tKmZFgFgdRgQ==}
+  '@marinade.finance/ds-sam-calc@0.1.1':
+    resolution: {integrity: sha512-jwvtC9QpCrdpBVoWwXYZKnL8ySyJ06G/AyIak+y1nmG2gCF10rfbL5GLSVyhvaqeTpAfQv/9uto597kh7uQthA==}
+
+  '@marinade.finance/ds-sam-sdk@0.1.1':
+    resolution: {integrity: sha512-iI8peRHzeW+z1tGEuvUE8ptk4Kk7uk1+XxauOWb0Q7M90L0LDbT4VhGqmJCffgmgJYBGQ4dTfB2i/z8mI6dabw==}
 
   '@marinade.finance/eslint-config@1.3.5':
     resolution: {integrity: sha512-yKLW2vI9QmQ6uWO3SQSbOYDmtSpYPU34zuomKGCfoLF7/bN+c6GinyzUumIPoUshqztRkqjOpFels4F4E6puEg==}
@@ -1164,6 +1167,10 @@ packages:
 
   '@marinade.finance/ts-common@4.2.5':
     resolution: {integrity: sha512-qWMHo1pcWqFqGZ9ng4yxoL3UPkTmj8zUaSnoqsl4l2YtftYQjRQw6ZxIdZRCCmjri25vx7Eg0EGfY90rs15mfg==}
+    engines: {node: '>=14'}
+
+  '@marinade.finance/ts-common@4.3.2':
+    resolution: {integrity: sha512-urqeszjBcFAsZlT9PcP5n+ACphLMTMtxG1L+f5yhm7Bk6JmRVIZ+oWmMUe1ob6dFfRVPvYZhnk5L1PEC0j7CAg==}
     engines: {node: '>=14'}
 
   '@marinade.finance/web3js-1x-testing@4.2.5':
@@ -2239,8 +2246,8 @@ packages:
     resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
 
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3034,8 +3041,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs-constants@1.0.0:
@@ -3173,6 +3180,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   help-me@5.0.0:
@@ -5556,9 +5567,15 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@marinade.finance/ds-sam-sdk@0.0.51':
+  '@marinade.finance/ds-sam-calc@0.1.1':
     dependencies:
-      axios: 1.16.1
+      '@marinade.finance/ts-common': 4.3.2
+      decimal.js: 10.6.0
+
+  '@marinade.finance/ds-sam-sdk@0.1.1':
+    dependencies:
+      '@marinade.finance/ds-sam-calc': 0.1.1
+      axios: 1.18.1
       decimal.js: 10.6.0
       semver: 7.8.0
     transitivePeerDependencies:
@@ -5660,6 +5677,11 @@ snapshots:
   '@marinade.finance/notifications-ts-subscription-client@1.0.3': {}
 
   '@marinade.finance/ts-common@4.2.5':
+    dependencies:
+      async-retry: 1.3.3
+      decimal.js: 10.6.0
+
+  '@marinade.finance/ts-common@4.3.2':
     dependencies:
       async-retry: 1.3.3
       decimal.js: 10.6.0
@@ -6927,10 +6949,10 @@ snapshots:
 
   axe-core@4.11.4: {}
 
-  axios@1.16.1:
+  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -7887,12 +7909,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fs-constants@1.0.0: {}
@@ -8016,6 +8038,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,10 @@ allowBuilds:
   node-hid: true
   unrs-resolver: true
   utf-8-validate: true
+minimumReleaseAgeExclude:
+  - '@marinade.finance/ds-sam-calc@0.1.1'
+  - '@marinade.finance/ds-sam-sdk@0.1.1'
+  - '@marinade.finance/ts-common@4.3.2'
 overrides:
   glob@<8: ^10.3.10
   rpc-websockets: 9.3.10


### PR DESCRIPTION
Providing more data from bond event processing to the API, which the CLI can use to provide guidance to validators.


A follow-up task for implementing CLI guidance.

Once https://github.com/marinade-finance/ds-sam/pull/121 is published as an npm package, this task will use the Bonds API to retrieve the data needed for the CLI to provide guidance to validators.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GET /bonds/bidding/auction` to return bidding auction metadata and participating validators.
  * Auction context is now persisted and served as part of the bidding auction flow.
* **Bug Fixes**
  * Improved auction metadata serialization by sanitizing non-finite numbers and preventing JSON serialization issues from cyclic data.
  * Auction metadata persistence now refreshes correctly on updates.
* **Documentation**
  * Updated OpenAPI documentation to include the new bidding-auction endpoint and schema.
* **Tests**
  * Expanded Jest coverage for relay serialization and validator-to-state conversion (auction fields).
  * Increased settlement test timeout for reliability.
* **Chores**
  * Updated relevant package/dependency versions and enabled additional database feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->