### PR TITLE
[pipelne] small fix to not print discord for institutional [trivial]

### DIFF
--- a/.buildkite/init-settlements.yml
+++ b/.buildkite/init-settlements.yml
@@ -124,8 +124,11 @@ steps:
      - claim_type=$(buildkite-agent meta-data get claim_type)
      - bash ./scripts/settlement-json-listing.sh --merkle-trees settlement-merkle-trees.json --claim-type $$claim_type
      - epoch=$(buildkite-agent meta-data get epoch)
-     - echo "========================================================"
-     - gcloud storage cp "$gs_bucket/$$epoch/$DISCORD_REPORT_FILE" - 2>/dev/null || echo "(discord report not available)"
+     - |
+       if [[ "$$claim_type" == "unified" ]]; then
+         echo "========================================================"
+         gcloud storage cp "$gs_bucket/$$epoch/$DISCORD_REPORT_FILE" - 2>/dev/null || echo "(discord report not available)"
+       fi
     depends_on: "download-json"
 
   - wait: ~


### PR DESCRIPTION
When running the institutional init pipeline, the discord printing adds misleading information as it does not belong to institutional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discord settlement reports are now copied from storage only for unified claims, preventing unnecessary processing for other claim types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->