### PR TITLE
[GEN-8460] api: switch docs from Redocly to Swagger UI

### DIFF
--- a/api/src/handlers/docs.rs
+++ b/api/src/handlers/docs.rs
@@ -2,20 +2,36 @@ use axum::http::header;
 use axum::response::IntoResponse;
 use log::info;
 
-// Swagger UI is pinned to a specific version for reproducible rendering.
+// Swagger UI is pinned to a specific version for reproducible rendering, with
+// subresource integrity hashes so a compromised or mirrored CDN cannot swap the
+// assets. When bumping the version both `integrity` hashes must be regenerated:
+//   curl -sSL https://cdn.jsdelivr.net/npm/swagger-ui-dist@<ver>/<file> \
+//     | openssl dgst -sha384 -binary | openssl base64 -A
 // The OpenAPI spec is served separately at `/docs.json`; Swagger UI links it
 // right under the title so consumers can download / reference the raw spec.
+//
+// The page is deliberately read-only, matching the Redoc page it replaced:
+// `supportedSubmitMethods: []` drops the "Try it out" / "Execute" console, which
+// would otherwise call production and render multi-megabyte responses (e.g.
+// `/protected-events`) through the syntax highlighter in the visitor's browser.
+// `validatorUrl: null` keeps the spec from being shipped to the public
+// validator.swagger.io service.
 const HTML: &str = r##"<!doctype html>
 <html lang="en">
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Marinade's Validator Bonds API</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.17.14/swagger-ui.css"/>
+  <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.11/swagger-ui.css"
+        integrity="sha384-9Q2fpS+xeS4ffJy6CagnwoUl+4ldAYhOs9pgZuEKxypVModhmZFzeMlvVsAjf7uT"
+        crossorigin="anonymous"/>
 </head>
 <body>
   <div id="swagger-ui"></div>
-  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.17.14/swagger-ui-bundle.js" crossorigin></script>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.11/swagger-ui-bundle.js"
+          integrity="sha384-vfl/klfTFrIz5urj0HnhcXLAbzPdRHezizfy+XgFB6GqcKkhlk0lS3bIbyB39NLA"
+          crossorigin="anonymous"></script>
   <script>
     window.onload = function () {
       window.ui = SwaggerUIBundle({
@@ -23,7 +39,9 @@ const HTML: &str = r##"<!doctype html>
         dom_id: "#swagger-ui",
         deepLinking: true,
         presets: [SwaggerUIBundle.presets.apis],
-        layout: "BaseLayout"
+        layout: "BaseLayout",
+        supportedSubmitMethods: [],
+        validatorUrl: null
       });
     };
   </script>

--- a/api/src/handlers/docs.rs
+++ b/api/src/handlers/docs.rs
@@ -15,7 +15,8 @@ use log::info;
 // would otherwise call production and render multi-megabyte responses (e.g.
 // `/protected-events`) through the syntax highlighter in the visitor's browser.
 // `validatorUrl: null` keeps the spec from being shipped to the public
-// validator.swagger.io service.
+// validator.swagger.io service, and `queryConfigEnabled: false` pins the
+// current default so `?url=` cannot point the page at a foreign spec.
 const HTML: &str = r##"<!doctype html>
 <html lang="en">
 <head>
@@ -41,7 +42,8 @@ const HTML: &str = r##"<!doctype html>
         presets: [SwaggerUIBundle.presets.apis],
         layout: "BaseLayout",
         supportedSubmitMethods: [],
-        validatorUrl: null
+        validatorUrl: null,
+        queryConfigEnabled: false
       });
     };
   </script>

--- a/api/src/handlers/docs.rs
+++ b/api/src/handlers/docs.rs
@@ -2,16 +2,33 @@ use axum::http::header;
 use axum::response::IntoResponse;
 use log::info;
 
-const HTML: &str = "<!doctype html>
-<html>
+// Swagger UI is pinned to a specific version for reproducible rendering.
+// The OpenAPI spec is served separately at `/docs.json`; Swagger UI links it
+// right under the title so consumers can download / reference the raw spec.
+const HTML: &str = r##"<!doctype html>
+<html lang="en">
 <head>
-  <meta charset=\"UTF-8\"/>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Marinade's Validator Bonds API</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.17.14/swagger-ui.css"/>
 </head>
 <body>
-  <redoc spec-url=\"/docs.json\" native-scrollbars></redoc>
-  <script src=\"https://public.marinade.finance/redoc.v2.0.0.standalone.js\"></script>
+  <div id="swagger-ui"></div>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.17.14/swagger-ui-bundle.js" crossorigin></script>
+  <script>
+    window.onload = function () {
+      window.ui = SwaggerUIBundle({
+        url: "/docs.json",
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis],
+        layout: "BaseLayout"
+      });
+    };
+  </script>
 </body>
-</html>";
+</html>"##;
 
 #[utoipa::path(
     get,

--- a/api/tests/http_behavior.rs
+++ b/api/tests/http_behavior.rs
@@ -119,7 +119,7 @@ async fn docs_json_returns_openapi() {
 }
 
 #[tokio::test]
-async fn docs_html_returns_redoc_page() {
+async fn docs_html_returns_swagger_ui_page() {
     let base = spawn_test_server().await;
     let resp = client().get(format!("{base}/docs")).send().await.unwrap();
     assert_eq!(resp.status(), 200);
@@ -131,7 +131,43 @@ async fn docs_html_returns_redoc_page() {
         .unwrap()
         .to_string();
     assert!(ct.contains("text/html"), "content-type was {ct}");
-    assert!(resp.text().await.unwrap().contains("redoc"));
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("SwaggerUIBundle"),
+        "docs page is not Swagger UI"
+    );
+    assert!(!body.contains("redoc"), "docs page still references Redoc");
+    assert!(body.contains("/docs.json"), "spec URL is not wired up");
+}
+
+/// The `/docs` page pulls Swagger UI off a public CDN and is served to anyone.
+/// Each assertion below stands for a review finding on the Redoc -> Swagger UI
+/// switch, so a later edit cannot quietly undo one of them.
+#[tokio::test]
+async fn docs_html_keeps_the_swagger_ui_hardening() {
+    let base = spawn_test_server().await;
+    let resp = client().get(format!("{base}/docs")).send().await.unwrap();
+    let body = resp.text().await.unwrap();
+
+    // Subresource integrity on every CDN asset: without it a compromised or
+    // mirroring CDN can swap the bundle. A version bump that forgets to
+    // regenerate the hashes trips this too, as the counts must stay in step.
+    let assets = body.matches("cdn.jsdelivr.net").count();
+    let hashes = body.matches("integrity=\"sha384-").count();
+    let cors = body.matches("crossorigin=\"anonymous\"").count();
+    assert!(assets > 0, "no CDN assets found; update this test");
+    assert_eq!(assets, hashes, "a CDN asset is missing its SRI hash");
+    assert_eq!(assets, cors, "SRI needs crossorigin on every CDN asset");
+
+    // Read-only docs, matching the Redoc page this replaced: a live console
+    // would call production and push multi-megabyte responses through Swagger
+    // UI's syntax highlighter, which has no size guard.
+    let read_only = body.contains("supportedSubmitMethods: []");
+    assert!(read_only, "docs must not offer a live Execute console");
+
+    // Keep the spec from being shipped to public validator.swagger.io.
+    let no_validator = body.contains("validatorUrl: null");
+    assert!(no_validator, "external Swagger validator must stay off");
 }
 
 #[tokio::test]

--- a/api/tests/http_behavior.rs
+++ b/api/tests/http_behavior.rs
@@ -149,15 +149,20 @@ async fn docs_html_keeps_the_swagger_ui_hardening() {
     let resp = client().get(format!("{base}/docs")).send().await.unwrap();
     let body = resp.text().await.unwrap();
 
-    // Subresource integrity on every CDN asset: without it a compromised or
-    // mirroring CDN can swap the bundle. A version bump that forgets to
-    // regenerate the hashes trips this too, as the counts must stay in step.
-    let assets = body.matches("cdn.jsdelivr.net").count();
-    let hashes = body.matches("integrity=\"sha384-").count();
-    let cors = body.matches("crossorigin=\"anonymous\"").count();
-    assert!(assets > 0, "no CDN assets found; update this test");
-    assert_eq!(assets, hashes, "a CDN asset is missing its SRI hash");
-    assert_eq!(assets, cors, "SRI needs crossorigin on every CDN asset");
+    // Subresource integrity, pinned per asset: a hash is only worth anything
+    // if it is *this* asset's hash, so bumping the version without
+    // regenerating the hash has to fail here rather than in the browser.
+    let css = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.11/swagger-ui.css";
+    let css_sri = "sha384-9Q2fpS+xeS4ffJy6CagnwoUl+4ldAYhOs9pgZuEKxypVModhmZFzeMlvVsAjf7uT";
+    let js = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.11/swagger-ui-bundle.js";
+    let js_sri = "sha384-vfl/klfTFrIz5urj0HnhcXLAbzPdRHezizfy+XgFB6GqcKkhlk0lS3bIbyB39NLA";
+    assert_pinned_asset(&body, css, css_sri);
+    assert_pinned_asset(&body, js, js_sri);
+
+    // ...and nothing else: an unpinned third asset would slip past the two
+    // checks above, which only look at the assets they already know about.
+    let found = body.matches("cdn.jsdelivr.net").count();
+    assert_eq!(found, 2, "an unpinned CDN asset crept in");
 
     // Read-only docs, matching the Redoc page this replaced: a live console
     // would call production and push multi-megabyte responses through Swagger
@@ -168,6 +173,27 @@ async fn docs_html_keeps_the_swagger_ui_hardening() {
     // Keep the spec from being shipped to public validator.swagger.io.
     let no_validator = body.contains("validatorUrl: null");
     assert!(no_validator, "external Swagger validator must stay off");
+
+    // `?url=` / `?configUrl=` overrides stay off. This is already the Swagger
+    // UI default; pinning it means an asset upgrade cannot flip the policy.
+    let no_query_cfg = body.contains("queryConfigEnabled: false");
+    assert!(no_query_cfg, "URL config overrides must stay disabled");
+}
+
+/// Assert `html` loads `url` carrying exactly `sri`, on that same tag.
+///
+/// Counting `integrity=` attributes across the page would pass a stale hash,
+/// or one that belongs to a different asset — so match the tag, not the page.
+fn assert_pinned_asset(html: &str, url: &str, sri: &str) {
+    assert!(html.contains(url), "docs page dropped {url}");
+    let at = html.find(url).expect("presence checked above");
+    let start = html[..at].rfind('<').expect("tag has no start");
+    let end = at + html[at..].find('>').expect("tag has no end");
+    let tag = &html[start..=end];
+    let has_sri = tag.contains(&format!("integrity=\"{sri}\""));
+    let has_cors = tag.contains("crossorigin=\"anonymous\"");
+    assert!(has_sri, "wrong or missing SRI hash on {url}: {tag}");
+    assert!(has_cors, "missing crossorigin on {url}: {tag}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Goal

Replace [Redocly](https://redocly.com/) with [Swagger UI](https://swagger.io/tools/swagger-ui/) as the renderer for the Validator Bonds API documentation, currently served at [validator-bonds-api.marinade.finance/docs](https://validator-bonds-api.marinade.finance/docs).

Ticket: GEN-8460.

## Changes

- `api/src/handlers/docs.rs`: the `/docs` page now bootstraps Swagger UI instead of the `<redoc>` element. The OpenAPI spec is still consumed from `/docs.json`.

## Requirements

- [x] **Render the OpenAPI docs with Swagger UI instead of Redocly** — the `/docs` page mounts `SwaggerUIBundle` against `/docs.json`.
- [x] **Keep a link to the OpenAPI spec** — Swagger UI renders the raw spec URL (`/docs.json`) as a link directly under the API title, so consumers can download / reference the spec. (Per reviewer feedback, no extra custom header bar was added — the built-in link under the title is sufficient.)
- [x] **Preserve the existing `/docs` route** — routing in `api/src/bin/api.rs` is unchanged; both `/docs` and `/docs.json` keep working, so current links are unaffected.
- [x] **Verify all endpoints, schemas, and examples render correctly** — rendered locally against the production spec with a headless browser: all 6 endpoints (`/bonds`, `/bonds/bidding`, `/bonds/bidding/auction`, `/bonds/institutional`, `/docs`, `/protected-events`), all 10 component schemas, and the response examples render.

## Notes

- Swagger UI assets are loaded from the jsdelivr CDN, pinned to `swagger-ui-dist@5.32.11`, with `sha384` subresource integrity hashes on both files. The hashes were generated from jsDelivr and cross-checked byte-for-byte against unpkg. The regeneration command is kept in a comment above the HTML literal so a future bump cannot silently leave stale hashes behind.
- The page is **read-only**, matching the Redoc page it replaces: `supportedSubmitMethods: []` removes the "Try it out" / "Execute" console. Without it the docs page would issue live calls against production and push multi-megabyte responses (`/protected-events` is ~8.7 MiB) through Swagger UI's syntax highlighter, which has no size guard.
- `validatorUrl: null` prevents the spec being sent to the public `validator.swagger.io` service.
- The previous Redoc bundle was self-hosted at `public.marinade.finance`; there is currently no Swagger UI asset hosted there. Mirroring the two pinned files would be a reasonable follow-up — it would also give a single place to update the version, which today lives in a Rust string literal where no dependency tooling (Dependabot, Renovate, `cargo audit`, `pnpm audit`) can see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSEYqQ9vLjVDEwzMvjv7cx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSEYqQ9vLjVDEwzMvjv7cx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the `/docs` documentation viewer with Swagger UI.
  * Documentation now loads the OpenAPI specification from `/docs.json`.
  * Added deep linking for easier navigation within API documentation.
  * Disabled “Try it out” requests and external specification validation.
  * Added read-only documentation configuration.
  * Pinned Swagger UI assets to specific CDN versions with integrity verification for consistent, secure rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
