### PR TITLE
[api] schema fixes [GEN-7694] 

### DIFF
--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -1,11 +1,11 @@
-use crate::dto::ValidatorBondRecordSchema;
+use crate::dto::{SettlementMetaSchema, ValidatorBondRecordSchema};
 use crate::{
     dto::ProtectedEventRecord,
     handlers::{bonds, docs, protected_events},
 };
 use settlement_common::{
     protected_events::ProtectedEvent,
-    settlement_collection::{SettlementFunder, SettlementMeta, SettlementReason},
+    settlement_collection::{SettlementFunder, SettlementReason},
 };
 use solana_sdk::pubkey::Pubkey;
 use utoipa::{
@@ -26,7 +26,7 @@ use utoipa::{
     components(
         schemas(ValidatorBondRecordSchema),
         schemas(ProtectedEventRecord),
-        schemas(SettlementMeta),
+        schemas(SettlementMetaSchema),
         schemas(SettlementReason),
         schemas(SettlementFunder),
         schemas(ProtectedEvent),

--- a/api/src/dto.rs
+++ b/api/src/dto.rs
@@ -2,7 +2,9 @@ use chrono::{DateTime, Utc};
 use merkle_tree::serde_serialize::pubkey_string_conversion;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use settlement_common::settlement_collection::{SettlementMeta, SettlementReason};
+use settlement_common::settlement_collection::{
+    SettlementFunder, SettlementMeta, SettlementReason,
+};
 use solana_sdk::pubkey::Pubkey;
 use std::error::Error;
 use tokio_postgres::types::{FromSql, IsNull, ToSql, Type};
@@ -86,13 +88,21 @@ pub struct ProtectedEventRecord {
     pub amount: u64,
     #[serde(with = "pubkey_string_conversion")]
     pub vote_account: Pubkey,
-    /// DEPRECATED: the `{ "funder": ... }` wrapper is retained only for backward
-    /// compatibility. The generated settlement JSON now exposes `funder` directly;
-    /// this nested `meta` field will be flattened to a top-level `funder` in a future
-    /// API version. Read `meta.funder` for now.
-    #[schema(deprecated)]
     pub meta: SettlementMeta,
     pub reason: SettlementReason,
+}
+
+/// DEPRECATED: the `{ "funder": ... }` wrapper is retained only for backward
+/// compatibility. The generated settlement JSON now exposes `funder` directly;
+/// this nested `meta` field will be flattened to a top-level `funder` in a future
+/// API version. Read `meta.funder` for now.
+// Documented on the component, not on ProtectedEventRecord::meta: utoipa renders a bare
+// `$ref` for that field and drops sibling `description`/`deprecated` keywords.
+#[derive(ToSchema)]
+#[schema(as = SettlementMeta, deprecated)]
+#[allow(dead_code)]
+pub struct SettlementMetaSchema {
+    funder: SettlementFunder,
 }
 
 #[derive(ToSchema)]
@@ -102,15 +112,19 @@ pub struct ValidatorBondRecordSchema {
     pubkey: String,
     vote_account: String,
     authority: String,
+    // value_type = f64: settlement-common enables rust_decimal/serde-float, so these Decimals reach the wire as JSON numbers rather than utoipa's default string.
+    #[schema(value_type = f64)]
     cpmpe: Decimal,
-    // Decimal, not f64: the real DTO (validator_bonds_common::dto::ValidatorBondRecord)
-    // holds rust_decimal::Decimal, which serializes as a JSON *string* — an f64 here
-    // would advertise a lossy number type the API never actually emits.
+    #[schema(value_type = f64)]
     max_stake_wanted: Decimal,
     epoch: u64,
+    #[schema(value_type = f64)]
     funded_amount: Decimal,
+    #[schema(value_type = f64)]
     effective_amount: Decimal,
+    #[schema(value_type = f64)]
     remaining_witdraw_request_amount: Decimal,
+    #[schema(value_type = f64)]
     remainining_settlement_claim_amount: Decimal,
     #[schema(format = "datetime")]
     updated_at: DateTime<Utc>,
@@ -118,4 +132,117 @@ pub struct ValidatorBondRecordSchema {
     inflation_commission_bps: Option<i64>,
     mev_commission_bps: Option<i64>,
     block_commission_bps: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SettlementFunder, SettlementMeta};
+    use crate::api_docs::ApiDoc;
+    use chrono::Utc;
+    use rust_decimal::Decimal;
+    use utoipa::OpenApi;
+    use validator_bonds_common::dto::{BondType, ValidatorBondRecord};
+
+    const NUMERIC_FIELDS: [&str; 6] = [
+        "cpmpe",
+        "max_stake_wanted",
+        "funded_amount",
+        "effective_amount",
+        "remaining_witdraw_request_amount",
+        "remainining_settlement_claim_amount",
+    ];
+
+    fn sample_record() -> ValidatorBondRecord {
+        ValidatorBondRecord {
+            pubkey: "8BopghjQ763ya26YPXSka3eLneU4ENdYMtjtzDLGsMrn".to_owned(),
+            vote_account: "We11J5D4iXcNbdMwCZX2o9RRkwaWBo1AGLADfubmeTb".to_owned(),
+            authority: "Py1iUEHc6YvkotpA1sjxXBAyBgGJDbQiEnApwse1cTq".to_owned(),
+            cpmpe: Decimal::new(2, 1),
+            max_stake_wanted: Decimal::new(3, 0),
+            epoch: 1008,
+            funded_amount: Decimal::new(5, 0),
+            effective_amount: Decimal::new(7, 0),
+            remaining_witdraw_request_amount: Decimal::new(11, 0),
+            remainining_settlement_claim_amount: Decimal::new(13, 0),
+            updated_at: Utc::now(),
+            bond_type: BondType::Bidding,
+            inflation_commission_bps: None,
+            mev_commission_bps: None,
+            block_commission_bps: None,
+        }
+    }
+
+    // The notice lives on the component because utoipa emits a bare `$ref` for the field and drops sibling keywords; the key check guards the doc-only mirror against drifting from the real type.
+    #[test]
+    fn settlement_meta_component_publishes_the_deprecation() {
+        let docs = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        let schema = &docs["components"]["schemas"]["SettlementMeta"];
+
+        assert_eq!(
+            schema["deprecated"].as_bool(),
+            Some(true),
+            "the meta wrapper must be marked deprecated for consumers",
+        );
+        assert!(
+            schema["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("Read `meta.funder` for now"),
+            "the deprecation notice must reach consumers; got {:?}",
+            schema["description"],
+        );
+        assert_eq!(
+            docs["components"]["schemas"]["ProtectedEventRecord"]["properties"]["meta"]["$ref"]
+                .as_str(),
+            Some("#/components/schemas/SettlementMeta"),
+            "the field must still resolve to the deprecated component",
+        );
+
+        let serialized = serde_json::to_value(SettlementMeta {
+            funder: SettlementFunder::Marinade,
+        })
+        .unwrap();
+        let mut documented: Vec<&str> = schema["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let mut actual: Vec<&str> = serialized
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        documented.sort_unstable();
+        actual.sort_unstable();
+        assert_eq!(
+            documented, actual,
+            "SettlementMetaSchema drifted from the serialized SettlementMeta",
+        );
+    }
+
+    // settlement-common enables rust_decimal/serde-float, so the DTO's Decimal fields go out as JSON numbers while utoipa's `decimal` feature would document them as strings.
+    #[test]
+    fn bond_record_schema_matches_serialized_json() {
+        let docs = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        let properties = &docs["components"]["schemas"]["ValidatorBondRecord"]["properties"];
+        let serialized = serde_json::to_value(sample_record()).unwrap();
+
+        for field in NUMERIC_FIELDS {
+            assert_eq!(
+                (
+                    properties[field]["type"].as_str(),
+                    properties[field]["format"].as_str(),
+                ),
+                (Some("number"), Some("double")),
+                "{field}: documented schema type must match the JSON number the API emits",
+            );
+            assert!(
+                serialized[field].is_number(),
+                "{field}: serialized as {:?}, expected a JSON number",
+                serialized[field],
+            );
+        }
+    }
 }


### PR DESCRIPTION
Fixing schema to be backwards compatible in API after https://github.com/marinade-finance/validator-bonds/pull/434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API schema documentation for settlement metadata, including clearer deprecation details.
  * Corrected validator bond fields so decimal values are documented as JSON numbers.
  * Improved generated API schema accuracy for settlement-related data.

* **Bug Fixes**
  * Fixed inconsistencies between documented numeric field types and their serialized API representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->