### PR TITLE
[cli] fixing based on notification adjustments [GEN-8055]

### DIFF
--- a/packages/validator-bonds-cli-core/__tests__/translators.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/translators.spec.ts
@@ -158,6 +158,35 @@ function buildTxArgs(feePayer?: PublicKey): ExecuteTxParams {
   }
 }
 
+describe('translateKnownError → CliCommandError classification', () => {
+  it('keeps an HTTP rejection from a service as the headline', () => {
+    const err = new CliCommandError({
+      valueName: 'subscriptions',
+      value: 'network error',
+      msg:
+        'Failed to fetch subscriptions. subscription not authorized for this pubkey' +
+        ' (HTTP 403 from https://marinade-notifications.marinade.finance)',
+    })
+    const translated = translateKnownError(err, { rpcEndpoint: endpoint })
+    expect(translated).toBe(err)
+    expect(translated.message).not.toContain('Cannot reach RPC')
+    expect(translated.message).not.toContain('Pass a valid RPC URL')
+  })
+
+  it('still translates when the wrapped cause is an RPC connectivity failure', () => {
+    const err = new CliCommandError({
+      valueName: 'bond-address',
+      value: 'unknown',
+      msg: 'Failed to fetch bond account',
+      cause: new Error('fetch failed'),
+    })
+    const translated = translateKnownError(err, { rpcEndpoint: endpoint })
+    expect(translated).toBeInstanceOf(CliCommandError)
+    expect(translated.message).toContain('Cannot reach RPC')
+    expect(translated.message).toContain(endpoint)
+  })
+})
+
 describe('translateKnownError → translateFeePayerMissingError', () => {
   it('translates ExecutionError whose cause carries the debit-credit message', () => {
     const feePayer = Keypair.generate().publicKey

--- a/packages/validator-bonds-cli-core/__tests__/translators.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/translators.spec.ts
@@ -173,7 +173,22 @@ describe('translateKnownError → CliCommandError classification', () => {
     expect(translated.message).not.toContain('Pass a valid RPC URL')
   })
 
-  it('still translates when the wrapped cause is an RPC connectivity failure', () => {
+  it('classifies on the wrapped cause code, not on the composed message', () => {
+    const err = new CliCommandError({
+      valueName: 'bond-address',
+      value: 'unknown',
+      msg: 'Cannot load bond',
+      cause: new SolanaJSONRPCError({
+        code: -32005,
+        message: 'node is behind',
+      }),
+    })
+    const translated = translateKnownError(err, { rpcEndpoint: endpoint })
+    expect(translated).toBeInstanceOf(CliCommandError)
+    expect(translated.message).toContain('rate-limited or unhealthy')
+  })
+
+  it('keeps naming the failing operation when the cause is translated', () => {
     const err = new CliCommandError({
       valueName: 'bond-address',
       value: 'unknown',
@@ -184,6 +199,19 @@ describe('translateKnownError → CliCommandError classification', () => {
     expect(translated).toBeInstanceOf(CliCommandError)
     expect(translated.message).toContain('Cannot reach RPC')
     expect(translated.message).toContain(endpoint)
+    expect(translated.message).toContain('Failed to fetch bond account')
+  })
+
+  it('does not read a command-composed ExecutionError message as RPC evidence', () => {
+    const err = new ExecutionError({
+      msg: 'Failed to fund bond account BondPubkey with 429 from FromPubkey',
+      logs: ['Transfer: insufficient lamports 100, need 200'],
+    })
+    const translated = translateKnownError(err, {
+      txArgs: buildTxArgs(Keypair.generate().publicKey),
+    })
+    expect(translated.message).not.toContain('rate-limited')
+    expect(translated.message).toContain('does not have enough SOL')
   })
 })
 

--- a/packages/validator-bonds-cli-core/__tests__/txOutcomeMessage.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/txOutcomeMessage.spec.ts
@@ -1,0 +1,15 @@
+import { txOutcomeMessage } from '../src/utils'
+
+describe('txOutcomeMessage', () => {
+  it('marks a dry run upfront so the success wording cannot be read as done', () => {
+    expect(txOutcomeMessage(true, 'Bond account B1 successfully created')).toBe(
+      'DRY RUN (nothing sent on-chain): Bond account B1 successfully created',
+    )
+  })
+
+  it('leaves the message untouched for an executed transaction', () => {
+    expect(
+      txOutcomeMessage(false, 'Bond account B1 successfully created'),
+    ).toBe('Bond account B1 successfully created')
+  })
+})

--- a/packages/validator-bonds-cli-core/src/commands/manage/cancelWithdrawRequest.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/cancelWithdrawRequest.ts
@@ -130,18 +130,22 @@ export async function manageCancelWithdrawRequest({
     authority = authority.publicKey
   }
 
-  const { instruction, withdrawRequestAccount } =
-    await cancelWithdrawRequestInstruction({
-      program,
-      withdrawRequestAccount: withdrawRequestAddress,
-      bondAccount,
-      configAccount: config,
-      voteAccount,
-      authority,
-      rentCollector,
-      logger,
-    })
+  const {
+    instruction,
+    withdrawRequestAccount,
+    bondAccount: bondAcc,
+  } = await cancelWithdrawRequestInstruction({
+    program,
+    withdrawRequestAccount: withdrawRequestAddress,
+    bondAccount,
+    configAccount: config,
+    voteAccount,
+    authority,
+    rentCollector,
+    logger,
+  })
   tx.add(instruction)
+  bondAccount = bondAcc
   recordResolvedAccounts({
     bondAccount,
     voteAccount,
@@ -151,7 +155,7 @@ export async function manageCancelWithdrawRequest({
 
   logger.info(
     `Cancelling withdraw request account ${withdrawRequestAccount.toBase58()} ` +
-      `for bond account ${bondAccount?.toBase58()}`,
+      `for bond account ${bondAccount.toBase58()}`,
   )
   await executeTxHandleErrors({
     connection: provider.connection,
@@ -171,7 +175,7 @@ export async function manageCancelWithdrawRequest({
     txOutcomeMessage(
       simulate || printOnly,
       `Withdraw request account ${withdrawRequestAccount.toBase58()} ` +
-        `for bond account ${bondAccount?.toBase58()} successfully cancelled`,
+        `for bond account ${bondAccount.toBase58()} successfully cancelled`,
     ),
   )
 }

--- a/packages/validator-bonds-cli-core/src/commands/manage/cancelWithdrawRequest.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/cancelWithdrawRequest.ts
@@ -20,6 +20,7 @@ import {
   executeTxHandleErrors,
   getBondFromAddress,
   getWithdrawRequestFromAddress,
+  txOutcomeMessage,
 } from '../../utils'
 
 import type {
@@ -167,7 +168,10 @@ export async function manageCancelWithdrawRequest({
     sendOpts: { skipPreflight },
   })
   logger.info(
-    `Withdraw request account ${withdrawRequestAccount.toBase58()} ` +
-      `for bond account ${bondAccount?.toBase58()} successfully cancelled`,
+    txOutcomeMessage(
+      simulate || printOnly,
+      `Withdraw request account ${withdrawRequestAccount.toBase58()} ` +
+        `for bond account ${bondAccount?.toBase58()} successfully cancelled`,
+    ),
   )
 }

--- a/packages/validator-bonds-cli-core/src/commands/manage/claimWithdrawRequest.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/claimWithdrawRequest.ts
@@ -25,6 +25,7 @@ import {
   getBondFromAddress,
   getWithdrawRequestFromAddress,
   splitAndExecuteTxHandleErrors,
+  txOutcomeMessage,
 } from '../../utils'
 
 import type {
@@ -262,7 +263,10 @@ export async function manageClaimWithdrawRequest({
     sendOpts: { skipPreflight },
   })
   logger.info(
-    `Withdraw request accounts: ${withdrawRequestAddress?.toBase58()} ` +
-      `for bond account ${bondAccount?.toBase58()} successfully claimed`,
+    txOutcomeMessage(
+      simulate || printOnly,
+      `Withdraw request accounts: ${withdrawRequestAddress?.toBase58()} ` +
+        `for bond account ${bondAccount?.toBase58()} successfully claimed`,
+    ),
   )
 }

--- a/packages/validator-bonds-cli-core/src/commands/manage/claimWithdrawRequest.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/claimWithdrawRequest.ts
@@ -174,6 +174,7 @@ export async function manageClaimWithdrawRequest({
       withdrawRequestAccount,
       splitStakeAccount,
       voteAccount: voteAcc,
+      bondAccount: bondAcc,
     } = await claimWithdrawRequestInstruction({
       program,
       withdrawRequestAccount: withdrawRequestAddress,
@@ -191,6 +192,7 @@ export async function manageClaimWithdrawRequest({
     instructionsToProcess = [instruction]
     stakeAccountsToWithdraw = [stakeAccount]
     voteAccount = voteAccount ?? voteAcc
+    bondAccount = bondAcc
   } else {
     // default behaviour to search stake account from bond account and merge beforehand
     const {
@@ -200,6 +202,7 @@ export async function manageClaimWithdrawRequest({
       withdrawRequestAccount,
       amountToWithdraw,
       voteAccount: voteAcc,
+      bondAccount: bondAcc,
     } = await orchestrateWithdrawDeposit({
       program,
       withdrawRequestAccount: withdrawRequestAddress,
@@ -216,9 +219,10 @@ export async function manageClaimWithdrawRequest({
     instructionsToProcess = instructions
     stakeAccountsToWithdraw = withdrawStakeAccounts
     voteAccount = voteAccount ?? voteAcc
+    bondAccount = bondAcc
     if (amountToWithdraw <= new BN(0)) {
       logger.info(
-        `Withdraw request ${withdrawRequestAddress?.toBase58()} for bond account ${bondAccount?.toBase58()}` +
+        `Withdraw request ${withdrawRequestAddress?.toBase58()} for bond account ${bondAccount.toBase58()}` +
           'has been fully withdrawn, with nothing left to claim.\n' +
           'If you want to withdraw more funds, please cancel the current request and create a new one.',
       )
@@ -245,7 +249,7 @@ export async function manageClaimWithdrawRequest({
 
   logger.info(
     `Claiming withdraw request ${withdrawRequestAddress?.toBase58()} ` +
-      `for bond account ${bondAccount?.toBase58()} with stake accounts: [` +
+      `for bond account ${bondAccount.toBase58()} with stake accounts: [` +
       `${stakeAccountsToWithdraw.map(s => s.toBase58()).join(',')}]`,
   )
   await splitAndExecuteTxHandleErrors({
@@ -266,7 +270,7 @@ export async function manageClaimWithdrawRequest({
     txOutcomeMessage(
       simulate || printOnly,
       `Withdraw request accounts: ${withdrawRequestAddress?.toBase58()} ` +
-        `for bond account ${bondAccount?.toBase58()} successfully claimed`,
+        `for bond account ${bondAccount.toBase58()} successfully claimed`,
     ),
   )
 }

--- a/packages/validator-bonds-cli-core/src/commands/manage/configureBond.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/configureBond.ts
@@ -256,11 +256,11 @@ export async function manageConfigureBond({
           uniformBps,
         })
       logger.info(
-        'To configure commission parameters, a commission bond configuration account will be initialized. ' +
-          `To pay rent to create the commission bond configuration account the rent payer ${pubkey(rentPayer).toBase58()} is used.`,
+        'Updating commission parameters on the existing commission bond configuration account ' +
+          `${bondProduct.toBase58()}.`,
       )
       logger.debug(
-        `Initializing commission bond product: ${bondProduct.toBase58()}`,
+        `Configuring commission bond product: ${bondProduct.toBase58()}`,
       )
       tx.add(commissionConfigureInstruction)
       computeUnitLimit += CONFIGURE_BOND_CONFIG_COMMISSION_LIMIT_UNITS

--- a/packages/validator-bonds-cli-core/src/commands/manage/configureBond.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/configureBond.ts
@@ -29,7 +29,11 @@ import {
   INIT_BOND_CONFIG_COMMISSION_LIMIT_UNITS,
 } from '../../computeUnits'
 import { getCliContext } from '../../context'
-import { executeTxHandleErrors, getBondFromAddress } from '../../utils'
+import {
+  executeTxHandleErrors,
+  getBondFromAddress,
+  txOutcomeMessage,
+} from '../../utils'
 
 import type { LoggerWrapper } from '@marinade.finance/ts-common'
 import type {
@@ -285,7 +289,12 @@ export async function manageConfigureBond({
     confirmWaitTime,
     sendOpts: { skipPreflight },
   })
-  logger.info(`Bond account ${bondAccount.toBase58()} successfully configured`)
+  logger.info(
+    txOutcomeMessage(
+      simulate || printOnly,
+      `Bond account ${bondAccount.toBase58()} successfully configured`,
+    ),
+  )
 
   await printBondTipBannerFromContext({
     voteAccount: bondAccountData.account.data.voteAccount,

--- a/packages/validator-bonds-cli-core/src/commands/manage/fundBond.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/fundBond.ts
@@ -26,6 +26,7 @@ import {
   executeTxHandleErrors,
   getBondFromAddress,
   isExpectedAnchorTransactionError,
+  txOutcomeMessage,
 } from '../../utils'
 
 import type {
@@ -142,8 +143,11 @@ export async function manageFundBond({
       sendOpts: { skipPreflight },
     })
     logger.info(
-      `Bond account ${bondAccount.toBase58()} successfully funded ` +
-        `with stake account ${stakeAccount.toBase58()}`,
+      txOutcomeMessage(
+        simulate || printOnly,
+        `Bond account ${bondAccount.toBase58()} successfully funded ` +
+          `with stake account ${stakeAccount.toBase58()}`,
+      ),
     )
   } catch (err) {
     await failIfUnexpectedFundingError({

--- a/packages/validator-bonds-cli-core/src/commands/manage/fundBondWithSol.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/fundBondWithSol.ts
@@ -33,6 +33,7 @@ import {
   executeTxHandleErrors,
   formatToSol,
   getBondFromAddress,
+  txOutcomeMessage,
 } from '../../utils'
 
 import type {
@@ -195,8 +196,11 @@ export async function manageFundBondWithSol({
       sendOpts: { skipPreflight },
     })
     logger.info(
-      `Bond account ${bondAccount.toBase58()} successfully funded ` +
-        `with amount ${amount} from ${from.toBase58()}`,
+      txOutcomeMessage(
+        simulate || printOnly,
+        `Bond account ${bondAccount.toBase58()} successfully funded ` +
+          `with amount ${amount} from ${from.toBase58()}`,
+      ),
     )
   } catch (err) {
     await failIfUnexpectedFundingError({

--- a/packages/validator-bonds-cli-core/src/commands/manage/initBond.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/initBond.ts
@@ -20,7 +20,7 @@ import {
   computeUnitLimitOption,
 } from '../../computeUnits'
 import { getCliContext } from '../../context'
-import { executeTxHandleErrors } from '../../utils'
+import { executeTxHandleErrors, txOutcomeMessage } from '../../utils'
 
 import type { LoggerPlaceholder } from '@marinade.finance/ts-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
@@ -157,8 +157,11 @@ export async function manageInitBond({
     })
   tx.add(commissionInstruction)
 
+  const dryRun = simulate || printOnly
   logger.info(
-    `Initializing bond account ${bondAccount.toBase58()} (finalization may take seconds)`,
+    dryRun
+      ? `Dry run of bond account ${bondAccount.toBase58()} initialization, nothing is sent on-chain`
+      : `Initializing bond account ${bondAccount.toBase58()} (finalization may take seconds)`,
   )
   logger.debug(`Commission bond account: ${bondProduct.toBase58()}`)
 
@@ -180,7 +183,10 @@ export async function manageInitBond({
       sendOpts: { skipPreflight },
     })
     logger.info(
-      `Bond account ${bondAccount.toBase58()} of config ${config.toBase58()} successfully created`,
+      txOutcomeMessage(
+        dryRun,
+        `Bond account ${bondAccount.toBase58()} of config ${config.toBase58()} successfully created`,
+      ),
     )
   } catch (err) {
     await failIfUnexpectedError({

--- a/packages/validator-bonds-cli-core/src/commands/manage/initBond.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/initBond.ts
@@ -159,9 +159,7 @@ export async function manageInitBond({
 
   const dryRun = simulate || printOnly
   logger.info(
-    dryRun
-      ? `Dry run of bond account ${bondAccount.toBase58()} initialization, nothing is sent on-chain`
-      : `Initializing bond account ${bondAccount.toBase58()} (finalization may take seconds)`,
+    `Initializing bond account ${bondAccount.toBase58()} (finalization may take seconds)`,
   )
   logger.debug(`Commission bond account: ${bondProduct.toBase58()}`)
 

--- a/packages/validator-bonds-cli-core/src/commands/manage/initWithdrawRequest.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/initWithdrawRequest.ts
@@ -33,6 +33,7 @@ import {
   formatToSol,
   formatToSolWithAll,
   getBondFromAddress,
+  txOutcomeMessage,
 } from '../../utils'
 
 import type { LoggerWrapper } from '@marinade.finance/ts-common'
@@ -223,8 +224,11 @@ export async function manageInitWithdrawRequest({
       sendOpts: { skipPreflight },
     })
     logger.info(
-      `Withdraw request account ${withdrawRequestAccount.toBase58()} ` +
-        `for bond account ${bondAccount.toBase58()} successfully initialized`,
+      txOutcomeMessage(
+        simulate || printOnly,
+        `Withdraw request account ${withdrawRequestAccount.toBase58()} ` +
+          `for bond account ${bondAccount.toBase58()} successfully initialized`,
+      ),
     )
   } catch (err) {
     await failIfUnexpectedError({

--- a/packages/validator-bonds-cli-core/src/commands/manage/mintBond.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/mintBond.ts
@@ -15,7 +15,11 @@ import {
   computeUnitLimitOption,
 } from '../../computeUnits'
 import { getCliContext } from '../../context'
-import { executeTxHandleErrors, getBondFromAddress } from '../../utils'
+import {
+  executeTxHandleErrors,
+  getBondFromAddress,
+  txOutcomeMessage,
+} from '../../utils'
 
 import type {
   Wallet as WalletInterface,
@@ -127,6 +131,9 @@ export async function manageMintBond({
     sendOpts: { skipPreflight },
   })
   logger.info(
-    `Bond ${bondAccount.toBase58()} token ${bondMint.toBase58()} was minted successfully`,
+    txOutcomeMessage(
+      simulate || printOnly,
+      `Bond ${bondAccount.toBase58()} token ${bondMint.toBase58()} was minted successfully`,
+    ),
   )
 }

--- a/packages/validator-bonds-cli-core/src/errorTranslators.ts
+++ b/packages/validator-bonds-cli-core/src/errorTranslators.ts
@@ -202,8 +202,12 @@ const KNOWN_ERROR_TRANSLATORS: Translator[] = [
 ]
 
 export function translateKnownError(err: unknown, ctx: TranslateCtx): Error {
+  // A CliCommandError message is composed by the command, so wording like
+  // 'Failed to fetch subscriptions' must not be read as an RPC connectivity failure;
+  // only the wrapped cause carries evidence about what actually failed.
+  const classified = err instanceof CliCommandError ? err.cause : err
   for (const translator of KNOWN_ERROR_TRANSLATORS) {
-    const translated = translator(err, ctx)
+    const translated = translator(classified, ctx)
     if (translated) return translated
   }
   return err as Error

--- a/packages/validator-bonds-cli-core/src/errorTranslators.ts
+++ b/packages/validator-bonds-cli-core/src/errorTranslators.ts
@@ -48,8 +48,10 @@ function resolveFeePayer(args: ExecuteTxParams): PublicKey | undefined {
 }
 
 function getRpcErrorCode(err: unknown): number | undefined {
-  if (err instanceof SolanaJSONRPCError && typeof err.code === 'number') {
-    return err.code
+  for (const e of getCauseChain(err)) {
+    if (e instanceof SolanaJSONRPCError && typeof e.code === 'number') {
+      return e.code
+    }
   }
   return undefined
 }
@@ -66,13 +68,22 @@ function getCauseChain(err: unknown): unknown[] {
   return chain
 }
 
+// command-composed messages are not evidence about what failed; the wrapped cause is
+function evidenceMessage(err: unknown): string {
+  const evidence =
+    err instanceof CliCommandError || err instanceof ExecutionError
+      ? err.cause
+      : err
+  return evidence instanceof Error ? evidence.message : ''
+}
+
 // Exported solely for unit tests (`__tests__/translators.spec.ts`). Not part of
 // the cli-core public API; treat as internal.
 export const translateRpcConnectivityError: Translator = (err, ctx) => {
   const endpoint = ctx.rpcEndpoint ?? 'the configured RPC endpoint'
 
   const code = getRpcErrorCode(err)
-  const message = err instanceof Error ? err.message : ''
+  const message = evidenceMessage(err)
   if (code === -32601 || /method not found/i.test(message)) {
     return new CliCommandError({
       valueName: '--url',
@@ -135,7 +146,7 @@ export const translateRpcConnectivityError: Translator = (err, ctx) => {
 export const translateRpcRateLimitError: Translator = (err, ctx) => {
   const endpoint = ctx.rpcEndpoint ?? 'the configured RPC endpoint'
   const code = getRpcErrorCode(err)
-  const message = err instanceof Error ? err.message : ''
+  const message = evidenceMessage(err)
   if (code === -32005 || code === -32429 || /\b429\b/.test(message)) {
     return new CliCommandError({
       valueName: '--url',
@@ -202,12 +213,8 @@ const KNOWN_ERROR_TRANSLATORS: Translator[] = [
 ]
 
 export function translateKnownError(err: unknown, ctx: TranslateCtx): Error {
-  // A CliCommandError message is composed by the command, so wording like
-  // 'Failed to fetch subscriptions' must not be read as an RPC connectivity failure;
-  // only the wrapped cause carries evidence about what actually failed.
-  const classified = err instanceof CliCommandError ? err.cause : err
   for (const translator of KNOWN_ERROR_TRANSLATORS) {
-    const translated = translator(classified, ctx)
+    const translated = translator(err, ctx)
     if (translated) return translated
   }
   return err as Error

--- a/packages/validator-bonds-cli-core/src/utils.ts
+++ b/packages/validator-bonds-cli-core/src/utils.ts
@@ -515,8 +515,7 @@ export async function loadTestingVoteAccount(
   }
 }
 
-// `--simulate`/`--print-only` runs reach the same success logging as a sent transaction,
-// so the outcome line must say upfront that the on-chain state was not touched.
+// `--simulate`/`--print-only` runs reach the same success logging as a sent transaction
 export function txOutcomeMessage(dryRun: boolean, message: string): string {
   return dryRun ? `DRY RUN (nothing sent on-chain): ${message}` : message
 }

--- a/packages/validator-bonds-cli-core/src/utils.ts
+++ b/packages/validator-bonds-cli-core/src/utils.ts
@@ -515,6 +515,12 @@ export async function loadTestingVoteAccount(
   }
 }
 
+// `--simulate`/`--print-only` runs reach the same success logging as a sent transaction,
+// so the outcome line must say upfront that the on-chain state was not touched.
+export function txOutcomeMessage(dryRun: boolean, message: string): string {
+  return dryRun ? `DRY RUN (nothing sent on-chain): ${message}` : message
+}
+
 export async function executeTxHandleErrors(
   args: ExecuteTxParams,
 ): Promise<ExecuteTxReturn> {

--- a/packages/validator-bonds-cli/__tests__/test-validator/cancelWithdrawRequest.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/cancelWithdrawRequest.spec.ts
@@ -17,6 +17,8 @@ import {
 } from '@marinade.finance/web3js-1x'
 import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 
+import { dryRunOutput } from './utils'
+
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
 import type { Keypair, PublicKey } from '@solana/web3.js'
@@ -121,7 +123,7 @@ describe('Cancel withdraw request using CLI', () => {
   })
 
   it('cancel withdraw request in print-only mode', async () => {
-    const toMatch = new RegExp(
+    const toMatch = dryRunOutput(
       `${withdrawRequestAccount.toBase58()}.*successfully cancelled`,
     )
     await expect([
@@ -151,5 +153,32 @@ describe('Cancel withdraw request using CLI', () => {
       withdrawRequestAccount,
     )
     expect(withdrawRequestData.requestedAmount).toEqual(stakeAccountLamports)
+  })
+
+  it('cancel withdraw request derived from config and vote account', async () => {
+    await expect([
+      'pnpm',
+      [
+        'cli',
+        '-u',
+        provider.connection.rpcEndpoint,
+        '--program-id',
+        program.programId.toBase58(),
+        'cancel-withdraw-request',
+        '--config',
+        configAccount.toBase58(),
+        '--vote-account',
+        voteAccount.toBase58(),
+        '--authority',
+        validatorIdentityKeypair.publicKey.toBase58(),
+        '--print-only',
+      ],
+    ]).toHaveMatchingSpawnOutput({
+      code: 0,
+      stdout: dryRunOutput(
+        `${withdrawRequestAccount.toBase58()}.*for bond account ` +
+          `${bondAccount.toBase58()} successfully cancelled`,
+      ),
+    })
   })
 })

--- a/packages/validator-bonds-cli/__tests__/test-validator/claimWithdrawRequest.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/claimWithdrawRequest.spec.ts
@@ -30,6 +30,8 @@ import {
 import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 import BN from 'bn.js'
 
+import { dryRunOutput } from './utils'
+
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
 import type { Keypair, PublicKey } from '@solana/web3.js'
@@ -336,7 +338,7 @@ describe('Claim withdraw request using CLI', () => {
     ]).toHaveMatchingSpawnOutput({
       code: 0,
       // stderr: '',
-      stdout: /successfully claimed/,
+      stdout: dryRunOutput(/successfully claimed/),
     })
   })
 })

--- a/packages/validator-bonds-cli/__tests__/test-validator/configureBond.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/configureBond.spec.ts
@@ -30,7 +30,7 @@ import {
   getAssociatedTokenAddressSync,
 } from 'solana-spl-token-modern'
 
-import { airdrop } from './utils'
+import { airdrop, dryRunOutput } from './utils'
 
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
@@ -477,7 +477,7 @@ describe('Configure bond account using CLI', () => {
     ]).toHaveMatchingSpawnOutput({
       code: 0,
       // stderr: '',
-      stdout: /successfully configured/,
+      stdout: dryRunOutput(/successfully configured/),
     })
 
     expect((await getBond(program, bondAccount)).authority).toEqual(

--- a/packages/validator-bonds-cli/__tests__/test-validator/configureConfig.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/configureConfig.spec.ts
@@ -7,6 +7,8 @@ import { executeInitConfigInstruction } from '@marinade.finance/validator-bonds-
 import { createTempFileKeypair } from '@marinade.finance/web3js-1x'
 import { Keypair, PublicKey } from '@solana/web3.js'
 
+import { dryRunOutput } from './utils'
+
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
 
@@ -140,7 +142,7 @@ describe('Configure config account using CLI', () => {
     ]).toHaveMatchingSpawnOutput({
       code: 0,
       // stderr: '',
-      stdout: /successfully configured/,
+      stdout: dryRunOutput(/successfully configured/),
     })
     expect((await getConfig(program, configAccount)).operatorAuthority).toEqual(
       operatorAuthority.publicKey,

--- a/packages/validator-bonds-cli/__tests__/test-validator/emergencyPauseAndResume.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/emergencyPauseAndResume.spec.ts
@@ -7,6 +7,8 @@ import { initTest } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/
 import { executeInitConfigInstruction } from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/testTransactions'
 import { createTempFileKeypair } from '@marinade.finance/web3js-1x'
 
+import { dryRunOutput } from './utils'
+
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
 import type { Keypair, PublicKey } from '@solana/web3.js'
@@ -117,7 +119,7 @@ describe('Pause and resume using CLI', () => {
     ]).toHaveMatchingSpawnOutput({
       code: 0,
       // stderr: '',
-      stdout: /Succeeded to pause/,
+      stdout: dryRunOutput(/Succeeded to pause/),
     })
     expect((await getConfig(program, config)).paused).toEqual(false)
 
@@ -136,7 +138,7 @@ describe('Pause and resume using CLI', () => {
     ]).toHaveMatchingSpawnOutput({
       code: 0,
       // stderr: '',
-      stdout: /Succeeded to resume/,
+      stdout: dryRunOutput(/Succeeded to resume/),
     })
     expect((await getConfig(program, config)).paused).toEqual(false)
   })

--- a/packages/validator-bonds-cli/__tests__/test-validator/fundBond.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/fundBond.spec.ts
@@ -18,6 +18,8 @@ import {
 import { createTempFileKeypair } from '@marinade.finance/web3js-1x'
 import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 
+import { dryRunOutput } from './utils'
+
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
 import type { Keypair, PublicKey } from '@solana/web3.js'
@@ -214,7 +216,7 @@ describe('Fund bond account using CLI', () => {
     ]).toHaveMatchingSpawnOutput({
       code: 0,
       // stderr: '',
-      stdout: /successfully funded/,
+      stdout: dryRunOutput(/successfully funded/),
     })
 
     const stakeAccountData = await getStakeAccount(provider, stakeAccount)

--- a/packages/validator-bonds-cli/__tests__/test-validator/initBond.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/initBond.spec.ts
@@ -16,7 +16,7 @@ import { executeInitConfigInstruction } from '@marinade.finance/validator-bonds-
 import { createTempFileKeypair } from '@marinade.finance/web3js-1x'
 import { Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js'
 
-import { airdrop } from './utils'
+import { airdrop, dryRunOutput } from './utils'
 
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
@@ -289,7 +289,7 @@ describe('Init bond account using CLI', () => {
     ]).toHaveMatchingSpawnOutput({
       code: 0,
       // stderr: '',
-      stdout: /successfully created/,
+      stdout: dryRunOutput(/successfully created/),
     })
     const [bondAccount] = bondAddress(
       configAccount,

--- a/packages/validator-bonds-cli/__tests__/test-validator/initConfig.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/initConfig.spec.ts
@@ -11,7 +11,7 @@ import {
   Transaction,
 } from '@solana/web3.js'
 
-import { airdrop } from './utils'
+import { airdrop, dryRunOutput } from './utils'
 
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
@@ -170,7 +170,7 @@ describe('Init config account using CLI', () => {
     ]).toHaveMatchingSpawnOutput({
       code: 0,
       // stderr: '',
-      stdout: /successfully created/,
+      stdout: dryRunOutput(/successfully created/),
     })
     expect(
       await provider.connection.getAccountInfo(configKeypair.publicKey),

--- a/packages/validator-bonds-cli/__tests__/test-validator/initWithdrawRequest.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/initWithdrawRequest.spec.ts
@@ -19,6 +19,8 @@ import {
 } from '@marinade.finance/web3js-1x'
 import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 
+import { dryRunOutput } from './utils'
+
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
 import type { Keypair, PublicKey } from '@solana/web3.js'
@@ -203,7 +205,7 @@ describe('Init withdraw request using CLI', () => {
       bondAccount,
       program.programId,
     )
-    const toMatch = new RegExp(
+    const toMatch = dryRunOutput(
       `${withdrawRequestAddr.toBase58()}.*successfully initialized`,
     )
     await expect([

--- a/packages/validator-bonds-cli/__tests__/test-validator/mergeStake.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/mergeStake.spec.ts
@@ -11,6 +11,8 @@ import { executeInitConfigInstruction } from '@marinade.finance/validator-bonds-
 import { waitForNextEpoch } from '@marinade.finance/web3js-1x'
 import { Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js'
 
+import { dryRunOutput } from './utils'
+
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
 import type { ExtendedProvider } from '@marinade.finance/web3js-1x'
@@ -112,7 +114,7 @@ describe('Merge stake accounts using CLI', () => {
     ]).toHaveMatchingSpawnOutput({
       code: 0,
       // stderr: '',
-      stdout: /successfully merged/,
+      stdout: dryRunOutput(/successfully merged/),
     })
     expect(
       await provider.connection.getAccountInfo(stakeAccount1),

--- a/packages/validator-bonds-cli/__tests__/test-validator/utils.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/utils.ts
@@ -4,6 +4,11 @@ import { LAMPORTS_PER_SOL, SystemProgram, Transaction } from '@solana/web3.js'
 import type { AnchorExtendedProvider } from '@marinade.finance/anchor-common'
 import type { Connection, Keypair, PublicKey } from '@solana/web3.js'
 
+export function dryRunOutput(outcome: RegExp | string): RegExp {
+  const source = typeof outcome === 'string' ? outcome : outcome.source
+  return new RegExp(`DRY RUN \\(nothing sent on-chain\\): .*${source}`)
+}
+
 export async function getRentPayer(provider: AnchorExtendedProvider): Promise<{
   path: string
   cleanup: () => Promise<void>

--- a/packages/validator-bonds-cli/src/commands/manage/closeSettlement.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/closeSettlement.ts
@@ -4,6 +4,7 @@ import {
   executeTxHandleErrors,
   getCliContext,
   setProgramTelemetryFields,
+  txOutcomeMessage,
 } from '@marinade.finance/validator-bonds-cli-core'
 import {
   closeSettlementV2Instruction,
@@ -117,5 +118,10 @@ export async function manageCloseSettlement({
     confirmWaitTime,
     sendOpts: { skipPreflight },
   })
-  logger.info(`Settlement account ${address.toBase58()} successfully closed`)
+  logger.info(
+    txOutcomeMessage(
+      simulate || printOnly,
+      `Settlement account ${address.toBase58()} successfully closed`,
+    ),
+  )
 }

--- a/packages/validator-bonds-cli/src/commands/manage/configureConfig.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/configureConfig.ts
@@ -5,6 +5,7 @@ import {
   getCliContext,
   setProgramTelemetryFields,
   toBN,
+  txOutcomeMessage,
 } from '@marinade.finance/validator-bonds-cli-core'
 import {
   MARINADE_CONFIG_ADDRESS,
@@ -212,5 +213,10 @@ async function manageConfigureConfig({
     confirmWaitTime,
     sendOpts: { skipPreflight },
   })
-  logger.info(`Config account ${address.toBase58()} successfully configured`)
+  logger.info(
+    txOutcomeMessage(
+      simulate || printOnly,
+      `Config account ${address.toBase58()} successfully configured`,
+    ),
+  )
 }

--- a/packages/validator-bonds-cli/src/commands/manage/emergencyPauseAndResume.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/emergencyPauseAndResume.ts
@@ -3,6 +3,7 @@ import {
   executeTxHandleErrors,
   getCliContext,
   setProgramTelemetryFields,
+  txOutcomeMessage,
 } from '@marinade.finance/validator-bonds-cli-core'
 import { EMERGENCY_LIMIT_UNITS } from '@marinade.finance/validator-bonds-cli-core'
 import {
@@ -154,7 +155,7 @@ async function manageEmergencyPauseAndResume({
   await executeTxHandleErrors({
     connection: provider.connection,
     transaction: tx,
-    errMessage: `'Failed to ${action} validator bonds contract config account ${address.toBase58()}`,
+    errMessage: `Failed to ${action} validator bonds contract config account ${address.toBase58()}`,
     signers,
     logger,
     computeUnitLimit,
@@ -166,6 +167,9 @@ async function manageEmergencyPauseAndResume({
     sendOpts: { skipPreflight },
   })
   logger.info(
-    `Succeeded to ${action} validator bonds config account ${address.toBase58()}`,
+    txOutcomeMessage(
+      simulate || printOnly,
+      `Succeeded to ${action} validator bonds config account ${address.toBase58()}`,
+    ),
   )
 }

--- a/packages/validator-bonds-cli/src/commands/manage/initConfig.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/initConfig.ts
@@ -2,6 +2,7 @@ import {
   computeUnitLimitOption,
   executeTxHandleErrors,
   getCliContext,
+  txOutcomeMessage,
 } from '@marinade.finance/validator-bonds-cli-core'
 import { INIT_CONFIG_LIMIT_UNITS } from '@marinade.finance/validator-bonds-cli-core'
 import { initConfigInstruction } from '@marinade.finance/validator-bonds-sdk'
@@ -167,6 +168,9 @@ async function manageInitConfig({
     sendOpts: { skipPreflight },
   })
   logger.info(
-    `Config account ${address.publicKey.toBase58()} successfully created`,
+    txOutcomeMessage(
+      simulate || printOnly,
+      `Config account ${address.publicKey.toBase58()} successfully created`,
+    ),
   )
 }

--- a/packages/validator-bonds-cli/src/commands/manage/mergeStake.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/mergeStake.ts
@@ -2,6 +2,7 @@ import {
   computeUnitLimitOption,
   executeTxHandleErrors,
   getCliContext,
+  txOutcomeMessage,
 } from '@marinade.finance/validator-bonds-cli-core'
 import { MERGE_STAKE_LIMIT_UNITS } from '@marinade.finance/validator-bonds-cli-core'
 import {
@@ -124,6 +125,9 @@ async function manageMerge({
     sendOpts: { skipPreflight },
   })
   logger.info(
-    `Stake account ${source.toBase58()} successfully merged to ${destination.toBase58()}`,
+    txOutcomeMessage(
+      simulate || printOnly,
+      `Stake account ${source.toBase58()} successfully merged to ${destination.toBase58()}`,
+    ),
   )
 }

--- a/packages/validator-bonds-cli/src/commands/manage/resetStake.ts
+++ b/packages/validator-bonds-cli/src/commands/manage/resetStake.ts
@@ -5,6 +5,7 @@ import {
   executeTxHandleErrors,
   getCliContext,
   setProgramTelemetryFields,
+  txOutcomeMessage,
 } from '@marinade.finance/validator-bonds-cli-core'
 import { resetStakeInstruction } from '@marinade.finance/validator-bonds-sdk'
 import {
@@ -119,5 +120,10 @@ export async function manageResetStake({
     confirmWaitTime,
     sendOpts: { skipPreflight },
   })
-  logger.info(`Stake account ${address.toBase58()} successfully reset`)
+  logger.info(
+    txOutcomeMessage(
+      simulate || printOnly,
+      `Stake account ${address.toBase58()} successfully reset`,
+    ),
+  )
 }

--- a/packages/validator-bonds-sdk/src/instructions/claimWithdrawRequest.ts
+++ b/packages/validator-bonds-sdk/src/instructions/claimWithdrawRequest.ts
@@ -59,6 +59,7 @@ export async function claimWithdrawRequestInstruction({
   splitStakeAccount: Keypair
   withdrawRequestAccount: PublicKey
   voteAccount: PublicKey
+  bondAccount: PublicKey
 }> {
   if (
     configAccount !== undefined &&
@@ -165,5 +166,6 @@ export async function claimWithdrawRequestInstruction({
     withdrawRequestAccount,
     splitStakeAccount,
     voteAccount,
+    bondAccount,
   }
 }

--- a/packages/validator-bonds-sdk/src/orchestrators/orchestrateWithdrawRequest.ts
+++ b/packages/validator-bonds-sdk/src/orchestrators/orchestrateWithdrawRequest.ts
@@ -57,6 +57,7 @@ export async function orchestrateWithdrawDeposit({
   withdrawStakeAccounts: PublicKey[]
   amountToWithdraw: BN
   voteAccount: PublicKey
+  bondAccount: PublicKey
 }> {
   if (
     configAccount !== undefined &&
@@ -241,6 +242,7 @@ export async function orchestrateWithdrawDeposit({
     withdrawStakeAccounts,
     amountToWithdraw,
     voteAccount,
+    bondAccount,
   }
 }
 


### PR DESCRIPTION
Make Select bond notifications work more properly.

---

CLI output stops misleading operators: dry runs are labelled as such, and error diagnoses come from the underlying failure instead of the message the command composed.

- Prefix every dry-run outcome line with `DRY RUN (nothing sent on-chain)` through a shared `txOutcomeMessage` helper, so `--simulate`/`--print-only` can no longer be read as executed — pause/resume included, where the stale wording was worst
- Classify RPC errors on the wrapped cause (its message plus the JSON-RPC code found along the cause chain), so a notifications-API `HTTP 403` no longer reports as "Cannot reach RPC" and `fund-bond-sol --amount 429` is no longer diagnosed as
rate limiting
- Return `bondAccount` from `claimWithdrawRequestInstruction` and `orchestrateWithdrawDeposit` so the withdraw-request commands stop logging `for bond account undefined` when the account is derived from `--config`/`--vote-account`
- Reword `configure-bond`'s existing-commission-product branch, which told validators a rent-paying account was being created on a path that only updates one
- Require the dry-run marker in the print-only CLI specs and swap in translator tests that fail on `main`, since the previous assertions passed either way


---

3 dependent PRs:

* https://github.com/marinade-finance/telegram-bot/pull/14
* https://github.com/marinade-finance/validator-bonds/pull/482
* https://github.com/marinade-finance/marinade-notifications/pull/58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Transaction success output now consistently includes a **DRY RUN (nothing sent on-chain)** prefix when running in simulation or print-only mode, across multiple bond, configuration, withdrawal, and stake management commands.

- **Bug Fixes**
  - Improved known-error translation for RPC connectivity/rate-limit scenarios, ensuring the correct cause details are used for more accurate guidance.
  - Withdraw/claim flows now reliably use the resolved bond account for subsequent output/logging.

- **Tests**
  - Expanded unit and CLI tests to cover dry-run output formatting and updated error-translation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->