### PR TITLE
[GEN-8632][cli] better error handling on npm fetch failures

### DIFF
--- a/packages/validator-bonds-cli-core/__tests__/npmRegistry.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/npmRegistry.spec.ts
@@ -7,6 +7,16 @@ import type { Logger } from 'pino'
 
 const mockLogger = { debug: jest.fn() } as unknown as Logger
 
+// a fetch that only settles once the caller's own deadline fires, so tests exercise the real abort
+const rejectOnAbort =
+  (error: Error) =>
+  (...args: unknown[]) => {
+    const { signal } = args[1] as { signal: AbortSignal }
+    return new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(error))
+    })
+  }
+
 describe('compareVersions', () => {
   it('compares basic versions', () => {
     expect(compareVersions('1.0.0', '1.0.0')).toBe(0)
@@ -83,10 +93,12 @@ describe('fetchLatestVersionInNpmRegistry', () => {
 
   afterEach(() => {
     global.fetch = originalFetch
+    jest.clearAllMocks()
   })
 
   it('returns latest stable version ignoring prereleases', async () => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: () => ({
         name: '@marinade.finance/validator-bonds-cli',
         versions: {
@@ -110,6 +122,7 @@ describe('fetchLatestVersionInNpmRegistry', () => {
 
   it('falls back to all versions when no stable versions exist', async () => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: () => ({
         name: '@marinade.finance/validator-bonds-cli',
         versions: {
@@ -127,5 +140,205 @@ describe('fetchLatestVersionInNpmRegistry', () => {
       name: '@marinade.finance/validator-bonds-cli',
       version: '2.4.1-beta.2',
     })
+  })
+
+  it('retries once and stays silent when a transport failure recovers', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValueOnce(
+        new TypeError('fetch failed', { cause: new Error('ECONNRESET') }),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => ({
+          name: '@marinade.finance/validator-bonds-cli',
+          versions: { '2.5.0': {} },
+        }),
+      })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await fetchLatestVersionInNpmRegistry(
+      mockLogger,
+      'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli',
+    )
+    expect(result).toEqual({
+      name: '@marinade.finance/validator-bonds-cli',
+      version: '2.5.0',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(mockLogger.debug).not.toHaveBeenCalled()
+  })
+
+  it('does not retry an HTTP status and reports it', async () => {
+    const json = jest.fn()
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      json,
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await fetchLatestVersionInNpmRegistry(
+      mockLogger,
+      'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli',
+    )
+    expect(result).toEqual({
+      name: '@marinade.finance/validator-bonds-cli',
+      version: '0.0.0',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(json).not.toHaveBeenCalled()
+    expect(mockLogger.debug).toHaveBeenCalledTimes(1)
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Error: HTTP 429 Too Many Requests'),
+    )
+  })
+
+  it('reports the transport cause once both attempts fail', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValue(
+        new TypeError('fetch failed', { cause: new Error('ECONNRESET') }),
+      )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await fetchLatestVersionInNpmRegistry(
+      mockLogger,
+      'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli',
+    )
+    expect(result).toEqual({
+      name: '@marinade.finance/validator-bonds-cli',
+      version: '0.0.0',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(mockLogger.debug).toHaveBeenCalledTimes(1)
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'TypeError: fetch failed (cause: Error: ECONNRESET)',
+      ),
+    )
+  })
+
+  it('falls back to the known package name when the packument omits it', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => ({ versions: { '2.9.0': {} } }),
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await fetchLatestVersionInNpmRegistry(
+      mockLogger,
+      'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli',
+    )
+    expect(result).toEqual({
+      name: '@marinade.finance/validator-bonds-cli',
+      version: '2.9.0',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mockLogger.debug).not.toHaveBeenCalled()
+  })
+
+  it('does not retry a malformed packument and reports no TypeError', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => ({ name: '@marinade.finance/validator-bonds-cli' }),
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await fetchLatestVersionInNpmRegistry(
+      mockLogger,
+      'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli',
+    )
+    expect(result).toEqual({
+      name: '@marinade.finance/validator-bonds-cli',
+      version: '0.0.0',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mockLogger.debug).toHaveBeenCalledTimes(1)
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Error: registry response contains no versions'),
+    )
+    expect(mockLogger.debug).not.toHaveBeenCalledWith(
+      expect.stringContaining('TypeError:'),
+    )
+  })
+
+  it('keeps the transport cause when the retry hits the shared deadline', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValueOnce(
+        new TypeError('fetch failed', { cause: new Error('ECONNRESET') }),
+      )
+      .mockImplementationOnce(
+        rejectOnAbort(
+          new DOMException('This operation was aborted', 'AbortError'),
+        ),
+      )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await fetchLatestVersionInNpmRegistry(
+      mockLogger,
+      'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli',
+    )
+    expect(result).toEqual({
+      name: '@marinade.finance/validator-bonds-cli',
+      version: '0.0.0',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(mockLogger.debug).toHaveBeenCalledTimes(1)
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'TypeError: fetch failed (cause: Error: ECONNRESET)',
+      ),
+    )
+  })
+
+  it('does not retry a transport failure that lands after the deadline', async () => {
+    const fetchMock = jest.fn(
+      rejectOnAbort(
+        new TypeError('fetch failed', { cause: new Error('ECONNRESET') }),
+      ),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await fetchLatestVersionInNpmRegistry(
+      mockLogger,
+      'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli',
+    )
+    expect(result).toEqual({
+      name: '@marinade.finance/validator-bonds-cli',
+      version: '0.0.0',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mockLogger.debug).toHaveBeenCalledTimes(1)
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'TypeError: fetch failed (cause: Error: ECONNRESET)',
+      ),
+    )
+  })
+
+  it('does not retry a timeout and reports it without a cause suffix', async () => {
+    const fetchMock = jest.fn(
+      rejectOnAbort(
+        new DOMException('This operation was aborted', 'AbortError'),
+      ),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await fetchLatestVersionInNpmRegistry(
+      mockLogger,
+      'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli',
+    )
+    expect(result).toEqual({
+      name: '@marinade.finance/validator-bonds-cli',
+      version: '0.0.0',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mockLogger.debug).toHaveBeenCalledTimes(1)
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      'NPM registry fetch timed out after 1000ms',
+    )
   })
 })

--- a/packages/validator-bonds-cli-core/__tests__/npmRegistry.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/npmRegistry.spec.ts
@@ -1,6 +1,7 @@
 import {
   compareVersions,
   fetchLatestVersionInNpmRegistry,
+  requireLatestCliVersion,
 } from '../src/npmRegistry'
 
 import type { Logger } from 'pino'
@@ -339,6 +340,35 @@ describe('fetchLatestVersionInNpmRegistry', () => {
     expect(mockLogger.debug).toHaveBeenCalledTimes(1)
     expect(mockLogger.debug).toHaveBeenCalledWith(
       'NPM registry fetch timed out after 1000ms',
+    )
+  })
+})
+
+describe('requireLatestCliVersion', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.clearAllMocks()
+  })
+
+  it('recommends the exact version it compared against, not @latest', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => ({
+        name: '@marinade.finance/validator-bonds-cli',
+        versions: { '2.4.0': {}, '2.5.0': {} },
+      }),
+    }) as unknown as typeof fetch
+
+    await expect(
+      requireLatestCliVersion(
+        mockLogger,
+        'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli',
+        '2.4.0',
+      ),
+    ).rejects.toThrow(
+      'npm install -g @marinade.finance/validator-bonds-cli@2.5.0',
     )
   })
 })

--- a/packages/validator-bonds-cli-core/src/npmRegistry.ts
+++ b/packages/validator-bonds-cli-core/src/npmRegistry.ts
@@ -101,10 +101,11 @@ export async function requireLatestCliVersion(
 ): Promise<void> {
   const npmData = await fetchLatestVersionInNpmRegistry(logger, npmRegistryUrl)
   if (compareVersions(currentVersion, npmData.version) < 0) {
+    // @latest resolves through the dist-tag, which can lag the version this gate compares against
     throw new Error(
       `CLI version ${currentVersion} is outdated. The latest available version is ${npmData.version}.\n` +
         '  Please update before proceeding:\n' +
-        `  npm install -g ${npmData.name}@latest`,
+        `  npm install -g ${npmData.name}@${npmData.version}`,
     )
   }
 }

--- a/packages/validator-bonds-cli-core/src/npmRegistry.ts
+++ b/packages/validator-bonds-cli-core/src/npmRegistry.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+import { fetchWithRetry } from '@marinade.finance/ts-common'
+
 import type { Logger } from 'pino'
 
 export type NpmPackageData = {
@@ -7,9 +9,28 @@ export type NpmPackageData = {
 }
 
 const NPM_REGISTRY_FETCH_TIMEOUT_MS = 1000
+const NPM_REGISTRY_RETRY_DELAY_MS = 50
 const FALLBACK_PACKAGE: NpmPackageData = {
   name: '@marinade.finance/validator-bonds-cli',
   version: '0.0.0',
+}
+
+function latestVersionInPackument(fetchedJson: any): NpmPackageData {
+  const versionsData: unknown = fetchedJson?.versions
+  if (typeof versionsData !== 'object' || versionsData === null) {
+    throw new Error('registry response contains no versions')
+  }
+  const name: string =
+    typeof fetchedJson.name === 'string'
+      ? fetchedJson.name
+      : FALLBACK_PACKAGE.name
+  const versions = Object.keys(versionsData) // ['1.0.0', 1.0.1', '1.0.2']
+  const stableVersions = versions.filter(v => !v.includes('-'))
+  const sortedVersions = (
+    stableVersions.length > 0 ? stableVersions : versions
+  ).sort(compareVersions)
+  const latestVersion = sortedVersions[sortedVersions.length - 1] || '0.0.0'
+  return { name, version: latestVersion }
 }
 
 export async function fetchLatestVersionInNpmRegistry(
@@ -21,29 +42,45 @@ export async function fetchLatestVersionInNpmRegistry(
     () => controller.abort(),
     NPM_REGISTRY_FETCH_TIMEOUT_MS,
   )
+  let transportError: TypeError | undefined
   try {
-    const fetched = await fetch(npmRegistryUrl, {
-      method: 'GET',
-      signal: controller.signal,
-    })
-    const fetchedJson = await fetched.json()
-    const name: string = fetchedJson.name
-    const versionsData: any[] = fetchedJson.versions
-    const versions = Object.keys(versionsData) // ['1.0.0', 1.0.1', '1.0.2']
-    const stableVersions = versions.filter(v => !v.includes('-'))
-    const sortedVersions = (
-      stableVersions.length > 0 ? stableVersions : versions
-    ).sort(compareVersions)
-    const latestVersion = sortedVersions[sortedVersions.length - 1] || '0.0.0'
-    return { name, version: latestVersion }
+    const fetched = await fetchWithRetry(
+      npmRegistryUrl,
+      { method: 'GET', signal: controller.signal },
+      {
+        retries: 1,
+        baseDelayMs: NPM_REGISTRY_RETRY_DELAY_MS,
+        // retrying a 429 would only make registry throttling worse
+        shouldRetryResponse: () => false,
+        shouldRetryError: err => {
+          // fetch reports transport failures as TypeError; an elapsed shared deadline leaves the retry nothing to spend
+          if (!(err instanceof TypeError)) {
+            return false
+          }
+          transportError = err
+          return !controller.signal.aborted
+        },
+      },
+    )
+    if (!fetched.ok) {
+      throw new Error(`HTTP ${fetched.status} ${fetched.statusText}`)
+    }
+    return latestVersionInPackument(await fetched.json())
   } catch (err) {
-    if (err instanceof DOMException && err.name === 'AbortError') {
+    // once the deadline elapses the abort says nothing; the transport error that triggered the retry does
+    if (controller.signal.aborted && transportError === undefined) {
       logger.debug(
         `NPM registry fetch timed out after ${NPM_REGISTRY_FETCH_TIMEOUT_MS}ms`,
       )
     } else {
+      const failure = controller.signal.aborted ? transportError : err
+      // undici reports transport errors as a bare "fetch failed"; the cause names the real one
+      const cause =
+        failure instanceof Error && failure.cause instanceof Error
+          ? ` (cause: ${failure.cause.name}: ${failure.cause.message})`
+          : ''
       logger.debug(
-        `Failed to fetch latest version from NPM registry ${npmRegistryUrl}: ${String(err)}`,
+        `Failed to fetch latest version from NPM registry ${npmRegistryUrl}: ${String(failure)}${cause}`,
       )
     }
     return FALLBACK_PACKAGE


### PR DESCRIPTION
Not dropping network errors but displaying them to not displaying misguiding null type error. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving package metadata by retrying recoverable network failures.
  * Prevented unnecessary retries for HTTP errors, timeouts, and aborted requests.
  * Improved error reporting by including underlying transport details when available.
  * Validates malformed registry responses and falls back to the default package name when needed.
  * More accurately selects the latest stable version, with a fallback to the latest available version.
  * Recommends installing the exact detected version when an update is required.

* **Tests**
  * Added coverage for retries, error handling, timeouts, malformed responses, and version selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->