### PR TITLE
[tests] making cli tests more stable [trivial]

### DIFF
--- a/packages/validator-bonds-cli-institutional/__tests__/test-validator/fundBondInstitutional.spec.ts
+++ b/packages/validator-bonds-cli-institutional/__tests__/test-validator/fundBondInstitutional.spec.ts
@@ -9,6 +9,7 @@ import { initTest } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/
 import {
   createVoteAccount,
   delegatedStakeAccount,
+  retryOnEpochRewardsPeriod,
 } from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/staking'
 import { executeInitBondInstruction } from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/testTransactions'
 import { createTempFileKeypair } from '@marinade.finance/web3js-1x'
@@ -83,26 +84,28 @@ describe('Fund bond account using CLI (institutional)', () => {
       stakeAccount: stakeAccount1,
       connection: provider.connection,
     })
-    await expect([
-      'pnpm',
-      [
-        'cli:institutional',
-        '-u',
-        provider.connection.rpcEndpoint,
-        'fund-bond',
-        bondAccount.toBase58(),
-        '--stake-account',
-        stakeAccount1.toBase58(),
-        '--stake-authority',
-        stakeWithdrawerPath,
-        '--confirmation-finality',
-        'confirmed',
-      ],
-    ]).toHaveMatchingSpawnOutput({
-      code: 0,
-      // stderr: '',
-      stdout: /successfully funded/,
-    })
+    await retryOnEpochRewardsPeriod(() =>
+      expect([
+        'pnpm',
+        [
+          'cli:institutional',
+          '-u',
+          provider.connection.rpcEndpoint,
+          'fund-bond',
+          bondAccount.toBase58(),
+          '--stake-account',
+          stakeAccount1.toBase58(),
+          '--stake-authority',
+          stakeWithdrawerPath,
+          '--confirmation-finality',
+          'confirmed',
+        ],
+      ]).toHaveMatchingSpawnOutput({
+        code: 0,
+        // stderr: '',
+        stdout: /successfully funded/,
+      }),
+    )
 
     const stakeAccountData1 = await getStakeAccount(provider, stakeAccount1)
     expect(stakeAccountData1.staker).toEqual(bondWithdrawer)

--- a/packages/validator-bonds-cli-institutional/__tests__/test-validator/fundBondWithSolInstitutional.spec.ts
+++ b/packages/validator-bonds-cli-institutional/__tests__/test-validator/fundBondWithSolInstitutional.spec.ts
@@ -9,7 +9,10 @@ import {
   getRentExemptStake,
 } from '@marinade.finance/validator-bonds-sdk'
 import { initTest } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/testValidator'
-import { createVoteAccount } from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/staking'
+import {
+  createVoteAccount,
+  retryOnEpochRewardsPeriod,
+} from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/staking'
 import { executeInitBondInstruction } from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/testTransactions'
 import {
   createTempFileKeypair,
@@ -75,24 +78,26 @@ describe('Fund bond account with SOL using CLI (institutional)', () => {
       lamports: baseLamports,
     })
     await waitForNextEpoch(program.provider, 15)
-    await expect([
-      'pnpm',
-      [
-        'cli:institutional',
-        '-u',
-        provider.connection.rpcEndpoint,
-        'fund-bond-sol',
-        bondAccount.toBase58(),
-        '--amount',
-        fundBondSols,
-        '--from',
-        fromPath,
-        '--verbose',
-      ],
-    ]).toHaveMatchingSpawnOutput({
-      code: 0,
-      stdout: /successfully funded with amount/,
-    })
+    await retryOnEpochRewardsPeriod(() =>
+      expect([
+        'pnpm',
+        [
+          'cli:institutional',
+          '-u',
+          provider.connection.rpcEndpoint,
+          'fund-bond-sol',
+          bondAccount.toBase58(),
+          '--amount',
+          fundBondSols,
+          '--from',
+          fromPath,
+          '--verbose',
+        ],
+      ]).toHaveMatchingSpawnOutput({
+        code: 0,
+        stdout: /successfully funded with amount/,
+      }),
+    )
 
     const userAccount = await provider.connection.getAccountInfo(
       fromKeypair.publicKey,

--- a/packages/validator-bonds-cli/__tests__/test-validator/claimWithdrawRequest.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/claimWithdrawRequest.spec.ts
@@ -14,6 +14,7 @@ import { initTest } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/
 import {
   createBondsFundedStakeAccount,
   createVoteAccount,
+  retryOnEpochRewardsPeriod,
 } from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/staking'
 import {
   executeCancelWithdrawRequestInstruction,
@@ -284,30 +285,32 @@ describe('Claim withdraw request using CLI', () => {
     // + needed to wait 1 epoch for the withdraw request to be claimable (config set 'withdrawLockupEpochs' to 0)
     await waitForNextEpoch(provider.connection, 15)
 
-    await expect([
-      'pnpm',
-      [
-        'cli',
-        '-u',
-        provider.connection.rpcEndpoint,
-        '--program-id',
-        program.programId.toBase58(),
-        'claim-withdraw-request',
-        voteAccount.toBase58(),
-        '--config',
-        configAccount.toBase58(),
-        '--authority',
-        validatorIdentityPath,
-        '--withdrawer',
-        pubkey(user).toBase58(),
-        '--stake-account',
-        stakeAccount.toBase58(),
-      ],
-    ]).toHaveMatchingSpawnOutput({
-      code: 0,
-      // stderr: '',
-      stdout: /successfully claimed/,
-    })
+    await retryOnEpochRewardsPeriod(() =>
+      expect([
+        'pnpm',
+        [
+          'cli',
+          '-u',
+          provider.connection.rpcEndpoint,
+          '--program-id',
+          program.programId.toBase58(),
+          'claim-withdraw-request',
+          voteAccount.toBase58(),
+          '--config',
+          configAccount.toBase58(),
+          '--authority',
+          validatorIdentityPath,
+          '--withdrawer',
+          pubkey(user).toBase58(),
+          '--stake-account',
+          stakeAccount.toBase58(),
+        ],
+      ]).toHaveMatchingSpawnOutput({
+        code: 0,
+        // stderr: '',
+        stdout: /successfully claimed/,
+      }),
+    )
   })
 
   it('claim withdraw request in print-only mode', async () => {

--- a/packages/validator-bonds-cli/__tests__/test-validator/fundBond.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/fundBond.spec.ts
@@ -10,6 +10,7 @@ import { initTest } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/
 import {
   createVoteAccount,
   delegatedStakeAccount,
+  retryOnEpochRewardsPeriod,
 } from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/staking'
 import {
   executeInitBondInstruction,
@@ -103,86 +104,92 @@ describe('Fund bond account using CLI', () => {
       stakeAccount: stakeAccount1,
       connection: provider.connection,
     })
-    await expect([
-      'pnpm',
-      [
-        'cli',
-        '-u',
-        provider.connection.rpcEndpoint,
-        '--program-id',
-        program.programId.toBase58(),
-        'fund-bond',
-        bondAccount.toBase58(),
-        '--stake-account',
-        stakeAccount1.toBase58(),
-        '--stake-authority',
-        stakeWithdrawerPath,
-        '--confirmation-finality',
-        'confirmed',
-        '--verbose',
-      ],
-    ]).toHaveMatchingSpawnOutput({
-      code: 0,
-      // stderr: '',
-      stdout: /successfully funded/,
-    })
+    await retryOnEpochRewardsPeriod(() =>
+      expect([
+        'pnpm',
+        [
+          'cli',
+          '-u',
+          provider.connection.rpcEndpoint,
+          '--program-id',
+          program.programId.toBase58(),
+          'fund-bond',
+          bondAccount.toBase58(),
+          '--stake-account',
+          stakeAccount1.toBase58(),
+          '--stake-authority',
+          stakeWithdrawerPath,
+          '--confirmation-finality',
+          'confirmed',
+          '--verbose',
+        ],
+      ]).toHaveMatchingSpawnOutput({
+        code: 0,
+        // stderr: '',
+        stdout: /successfully funded/,
+      }),
+    )
 
     const stakeAccountData1 = await getStakeAccount(provider, stakeAccount1)
     expect(stakeAccountData1.staker).toEqual(bondWithdrawer)
     expect(stakeAccountData1.withdrawer).toEqual(bondWithdrawer)
 
-    await expect([
-      'pnpm',
-      [
-        'cli',
-        '-u',
-        provider.connection.rpcEndpoint,
-        '--program-id',
-        program.programId.toBase58(),
-        'fund-bond',
-        bondAccount.toBase58(),
-        '--stake-account',
-        stakeAccount1.toBase58(),
-        '--stake-authority',
-        stakeWithdrawerPath,
-        '--confirmation-finality',
-        'confirmed',
-        '--verbose',
-      ],
-    ]).toHaveMatchingSpawnOutput({
-      code: 0,
-      // stderr: '',
-      stdout: /is ALREADY funded to bond account/,
-    })
+    await retryOnEpochRewardsPeriod(() =>
+      expect([
+        'pnpm',
+        [
+          'cli',
+          '-u',
+          provider.connection.rpcEndpoint,
+          '--program-id',
+          program.programId.toBase58(),
+          'fund-bond',
+          bondAccount.toBase58(),
+          '--stake-account',
+          stakeAccount1.toBase58(),
+          '--stake-authority',
+          stakeWithdrawerPath,
+          '--confirmation-finality',
+          'confirmed',
+          '--verbose',
+        ],
+      ]).toHaveMatchingSpawnOutput({
+        code: 0,
+        // stderr: '',
+        stdout: /is ALREADY funded to bond account/,
+      }),
+    )
 
     await waitForStakeAccountActivation({
       stakeAccount: stakeAccount2,
       connection: provider.connection,
     })
-    await expect([
-      'pnpm',
-      [
-        'cli',
-        'fund-bond',
-        '-u',
-        provider.connection.rpcEndpoint,
-        '--program-id',
-        program.programId.toBase58(),
-        '--config',
-        configAccount.toBase58(),
-        voteAccount.toBase58(),
-        '--stake-account',
-        stakeAccount2.toBase58(),
-        '--stake-authority',
-        stakeWithdrawerPath,
-        '--confirmation-finality',
-        'confirmed',
-      ],
-    ]).toHaveMatchingSpawnOutput({
-      code: 0,
-      // stderr: '',
-      stdout: /successfully funded/,
-    })
+    await retryOnEpochRewardsPeriod(() =>
+      expect([
+        'pnpm',
+        [
+          'cli',
+          'fund-bond',
+          '-u',
+          provider.connection.rpcEndpoint,
+          '--program-id',
+          program.programId.toBase58(),
+          '--config',
+          configAccount.toBase58(),
+          voteAccount.toBase58(),
+          '--stake-account',
+          stakeAccount2.toBase58(),
+          '--stake-authority',
+          stakeWithdrawerPath,
+          '--confirmation-finality',
+          'confirmed',
+        ],
+      ]).toHaveMatchingSpawnOutput({
+        code: 0,
+        // stderr: '',
+        stdout: /successfully funded/,
+      }),
+    )
 
     const stakeAccountData2 = await getStakeAccount(provider, stakeAccount2)
     expect(stakeAccountData2.staker).toEqual(bondWithdrawer)

--- a/packages/validator-bonds-cli/__tests__/test-validator/fundBondWithSol.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/fundBondWithSol.spec.ts
@@ -8,7 +8,10 @@ import {
   getRentExemptStake,
 } from '@marinade.finance/validator-bonds-sdk'
 import { initTest } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/testValidator'
-import { createVoteAccount } from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/staking'
+import {
+  createVoteAccount,
+  retryOnEpochRewardsPeriod,
+} from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/staking'
 import {
   executeInitBondInstruction,
   executeInitConfigInstruction,
@@ -79,26 +82,28 @@ describe('Fund bond account with SOL using CLI', () => {
       user: fromKeypair.publicKey,
       lamports: baseLamports,
     })
-    await expect([
-      'pnpm',
-      [
-        'cli',
-        '-u',
-        provider.connection.rpcEndpoint,
-        '--program-id',
-        program.programId.toBase58(),
-        'fund-bond-sol',
-        bondAccount.toBase58(),
-        '--amount',
-        fundBondSols,
-        '--from',
-        fromPath,
-        '--verbose',
-      ],
-    ]).toHaveMatchingSpawnOutput({
-      code: 0,
-      stdout: /successfully funded with amount/,
-    })
+    await retryOnEpochRewardsPeriod(() =>
+      expect([
+        'pnpm',
+        [
+          'cli',
+          '-u',
+          provider.connection.rpcEndpoint,
+          '--program-id',
+          program.programId.toBase58(),
+          'fund-bond-sol',
+          bondAccount.toBase58(),
+          '--amount',
+          fundBondSols,
+          '--from',
+          fromPath,
+          '--verbose',
+        ],
+      ]).toHaveMatchingSpawnOutput({
+        code: 0,
+        stdout: /successfully funded with amount/,
+      }),
+    )
     const userAccount = await provider.connection.getAccountInfo(
       fromKeypair.publicKey,
     )
@@ -135,28 +140,30 @@ describe('Fund bond account with SOL using CLI', () => {
     await waitForNextEpoch(program.provider, 15)
 
     const fundBondSolsSecond = 2.22
-    await expect([
-      'pnpm',
-      [
-        'cli',
-        '-u',
-        provider.connection.rpcEndpoint,
-        '--program-id',
-        program.programId.toBase58(),
-        'fund-bond-sol',
-        bondAccountData.voteAccount.toBase58(),
-        '--config',
-        configAccount.toBase58(),
-        '--amount',
-        fundBondSolsSecond,
-        '--from',
-        fromPath,
-        '--verbose',
-      ],
-    ]).toHaveMatchingSpawnOutput({
-      code: 0,
-      stdout: /successfully funded with amount/,
-    })
+    await retryOnEpochRewardsPeriod(() =>
+      expect([
+        'pnpm',
+        [
+          'cli',
+          '-u',
+          provider.connection.rpcEndpoint,
+          '--program-id',
+          program.programId.toBase58(),
+          'fund-bond-sol',
+          bondAccountData.voteAccount.toBase58(),
+          '--config',
+          configAccount.toBase58(),
+          '--amount',
+          fundBondSolsSecond,
+          '--from',
+          fromPath,
+          '--verbose',
+        ],
+      ]).toHaveMatchingSpawnOutput({
+        code: 0,
+        stdout: /successfully funded with amount/,
+      }),
+    )
 
     const userAccountAfter = await provider.connection.getAccountInfo(
       fromKeypair.publicKey,

--- a/packages/validator-bonds-cli/__tests__/test-validator/mergeStake.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/mergeStake.spec.ts
@@ -6,6 +6,7 @@ import { initTest } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/
 import {
   authorizeStakeAccount,
   delegatedStakeAccount,
+  retryOnEpochRewardsPeriod,
 } from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/staking'
 import { executeInitConfigInstruction } from '@marinade.finance/validator-bonds-sdk/dist/__tests__/utils/testTransactions'
 import { waitForNextEpoch } from '@marinade.finance/web3js-1x'
@@ -53,30 +54,32 @@ describe('Merge stake accounts using CLI', () => {
       lamports2: LAMPORTS_PER_SOL * 3,
     })
 
-    await expect([
-      'pnpm',
-      [
-        'cli',
-        '-u',
-        provider.connection.rpcEndpoint,
-        '--program-id',
-        program.programId.toBase58(),
-        'merge-stake',
-        '--source',
-        stakeAccount1.toBase58(),
-        '--destination',
-        stakeAccount2.toBase58(),
-        '--config',
-        configAccount.toBase58(),
-        '--confirmation-finality',
-        'confirmed',
-        '-v',
-      ],
-    ]).toHaveMatchingSpawnOutput({
-      code: 0,
-      // stderr: '',
-      stdout: /successfully merged/,
-    })
+    await retryOnEpochRewardsPeriod(() =>
+      expect([
+        'pnpm',
+        [
+          'cli',
+          '-u',
+          provider.connection.rpcEndpoint,
+          '--program-id',
+          program.programId.toBase58(),
+          'merge-stake',
+          '--source',
+          stakeAccount1.toBase58(),
+          '--destination',
+          stakeAccount2.toBase58(),
+          '--config',
+          configAccount.toBase58(),
+          '--confirmation-finality',
+          'confirmed',
+          '-v',
+        ],
+      ]).toHaveMatchingSpawnOutput({
+        code: 0,
+        // stderr: '',
+        stdout: /successfully merged/,
+      }),
+    )
 
     const stakeAccount1Info =
       await provider.connection.getAccountInfo(stakeAccount1)


### PR DESCRIPTION
CLI tests to be more stable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CLI test reliability by retrying bond funding, stake merging, and withdrawal-claim checks during epoch reward periods.
  * Preserved existing command arguments, success validations, and expected output checks across standard and institutional workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->