### PR TITLE
[GEN-8245] [api][direct-staking] add GET /validators/protected

### DIFF
--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -1,7 +1,7 @@
 use crate::dto::{SettlementMetaSchema, ValidatorBondRecordSchema};
 use crate::{
     dto::ProtectedEventRecord,
-    handlers::{bonds, docs, protected_events, verified_validators},
+    handlers::{bonds, docs, protected_events, protected_validators, verified_validators},
 };
 use settlement_common::{
     protected_events::ProtectedEvent,
@@ -34,8 +34,9 @@ use utoipa::{
         schemas(bonds::AuctionContextResponse),
         schemas(protected_events::ProtectedEventsResponse),
         schemas(verified_validators::VerifiedValidatorsResponse),
+        schemas(protected_validators::ProtectedValidatorsResponse),
     ),
-    paths(docs::handler, bonds::handler, bonds::handler_institutional, bonds::handler_bidding, bonds::handler_bidding_auction, protected_events::handler, verified_validators::handler),
+    paths(docs::handler, bonds::handler, bonds::handler_institutional, bonds::handler_bidding, bonds::handler_bidding_auction, protected_events::handler, verified_validators::handler, protected_validators::handler),
     modifiers(&PubkeyScheme),
 )]
 pub struct ApiDoc;

--- a/api/src/handlers/mod.rs
+++ b/api/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod bonds;
 pub mod docs;
 pub mod protected_events;
+pub mod protected_validators;
 pub mod verified_validators;

--- a/api/src/handlers/protected_validators.rs
+++ b/api/src/handlers/protected_validators.rs
@@ -1,0 +1,115 @@
+use crate::context::WrappedContext;
+use crate::error::AppError;
+use crate::repositories::bond::get_bonds_by_type;
+use axum::extract::{Query, State};
+use axum::Json;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+#[allow(unused_imports)] // referenced only in the `value_type` schema attribute below
+use solana_sdk::pubkey::Pubkey;
+use std::collections::BTreeSet;
+use validator_bonds_common::dto::{BondType, ValidatorBondRecord};
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct ProtectedValidatorsResponse {
+    #[schema(value_type = Vec<Pubkey>)]
+    protected_validators: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct QueryParams {}
+
+const MIN_PROTECTED_BOND_LAMPORTS: u64 = 1_000_000_000;
+
+/// Effective, not funded: a settlement reservation or a filed withdraw request forfeits protection.
+fn protected_vote_accounts(bonds: &[ValidatorBondRecord]) -> BTreeSet<String> {
+    bonds
+        .iter()
+        .filter(|bond| bond.effective_amount >= Decimal::from(MIN_PROTECTED_BOND_LAMPORTS))
+        .map(|bond| bond.vote_account.clone())
+        .collect()
+}
+
+#[utoipa::path(
+    get,
+    tag = "Validators",
+    operation_id = "List validators whose stakers are PSR protected",
+    path = "/validators/protected",
+    responses(
+        (status = 200, description = "At least 1 SOL of effective bond under the bidding or the institutional config.", body = ProtectedValidatorsResponse),
+    )
+)]
+pub async fn handler(
+    State(context): State<WrappedContext>,
+    Query(_query_params): Query<QueryParams>,
+) -> Result<Json<ProtectedValidatorsResponse>, AppError> {
+    let psql_client = &context.read().await.psql_client;
+
+    let mut protected = BTreeSet::new();
+    for bond_type in [BondType::Bidding, BondType::Institutional] {
+        let bonds = get_bonds_by_type(psql_client, bond_type)
+            .await
+            .map_err(|error| AppError {
+                message: format!("Failed to fetch bonds. Error: {error:?}"),
+            })?;
+        protected.extend(protected_vote_accounts(&bonds));
+    }
+
+    Ok(Json(ProtectedValidatorsResponse {
+        protected_validators: protected.into_iter().collect(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn bond(vote_account: &str, effective_amount: Decimal) -> ValidatorBondRecord {
+        ValidatorBondRecord {
+            pubkey: format!("{vote_account}-bond"),
+            vote_account: vote_account.to_string(),
+            authority: format!("{vote_account}-authority"),
+            cpmpe: Decimal::ZERO,
+            max_stake_wanted: Decimal::ZERO,
+            epoch: 980,
+            // Max on every fixture: a bond excluded below the floor must be excluded despite it.
+            funded_amount: Decimal::from(u64::MAX),
+            effective_amount,
+            remaining_witdraw_request_amount: Decimal::ZERO,
+            remainining_settlement_claim_amount: Decimal::ZERO,
+            updated_at: Utc::now(),
+            bond_type: BondType::Bidding,
+            inflation_commission_bps: None,
+            mev_commission_bps: None,
+            block_commission_bps: None,
+        }
+    }
+
+    fn protected(bonds: Vec<ValidatorBondRecord>) -> Vec<String> {
+        protected_vote_accounts(&bonds).into_iter().collect()
+    }
+
+    #[test]
+    fn a_bond_below_the_floor_is_not_protected() {
+        let listed = protected(vec![
+            bond("voteAtFloor", Decimal::from(MIN_PROTECTED_BOND_LAMPORTS)),
+            bond(
+                "voteBelowFloor",
+                Decimal::from(MIN_PROTECTED_BOND_LAMPORTS - 1),
+            ),
+            bond("voteZero", Decimal::ZERO),
+        ]);
+        assert_eq!(listed, vec!["voteAtFloor".to_string()]);
+    }
+
+    #[test]
+    fn a_vote_account_appearing_twice_is_listed_once() {
+        let listed = protected(vec![
+            bond("voteTwice", Decimal::from(MIN_PROTECTED_BOND_LAMPORTS)),
+            bond("voteTwice", Decimal::from(MIN_PROTECTED_BOND_LAMPORTS * 20)),
+        ]);
+        assert_eq!(listed, vec!["voteTwice".to_string()]);
+    }
+}

--- a/api/src/repositories/bond.rs
+++ b/api/src/repositories/bond.rs
@@ -158,7 +158,7 @@ pub async fn store_bonds(options: CommonStoreOptions) -> anyhow::Result<()> {
     builder.set_ca_file(&options.postgres_ssl_root_cert)?;
     let connector = MakeTlsConnector::new(builder.build());
 
-    let (psql_client, psql_conn) = tokio_postgres::connect(&options.postgres_url, connector)
+    let (mut psql_client, psql_conn) = tokio_postgres::connect(&options.postgres_url, connector)
         .await
         .map_err(pg_transient)?;
 
@@ -175,6 +175,9 @@ pub async fn store_bonds(options: CommonStoreOptions) -> anyhow::Result<()> {
         .map(|record| (record.pubkey.clone(), record))
         .collect();
     let epoch = bonds[0].epoch as i32;
+
+    // Readers pin epoch = MAX(epoch), so a half-written epoch hides the previous complete one.
+    let tx = psql_client.transaction().await.map_err(pg_transient)?;
 
     for chunk in bonds_records
         .into_iter()
@@ -239,11 +242,10 @@ pub async fn store_bonds(options: CommonStoreOptions) -> anyhow::Result<()> {
             .iter()
             .map(|param| param.as_ref() as &(dyn ToSql + Sync))
             .collect::<Vec<_>>();
-        psql_client
-            .query(&query, &params)
-            .await
-            .map_err(pg_transient)?;
+        tx.query(&query, &params).await.map_err(pg_transient)?;
     }
+
+    tx.commit().await.map_err(pg_transient)?;
 
     Ok(())
 }

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -19,7 +19,7 @@ use tower_http::normalize_path::NormalizePath;
 
 use crate::api_docs::ApiDoc;
 use crate::context::WrappedContext;
-use crate::handlers::{bonds, docs, protected_events, verified_validators};
+use crate::handlers::{bonds, docs, protected_events, protected_validators, verified_validators};
 use crate::metrics::{healthz, metrics_handler, readyz, track_metrics};
 use crate::rate_limit::CfConnectingIpKeyExtractor;
 
@@ -56,6 +56,7 @@ pub fn public_data_routes(context: WrappedContext) -> Router {
         .route("/bonds/institutional", get(bonds::handler_institutional))
         .route("/protected-events", get(protected_events::handler))
         .route("/validators/verified", get(verified_validators::handler))
+        .route("/validators/protected", get(protected_validators::handler))
         .with_state(context)
 }
 

--- a/migrations/0011-index-bonds-type-epoch.sql
+++ b/migrations/0011-index-bonds-type-epoch.sql
@@ -1,0 +1,2 @@
+-- get_bonds_by_type filters on (bond_type, epoch); the only other index leads on pubkey.
+CREATE INDEX IF NOT EXISTS idx_bonds_type_epoch ON bonds(bond_type, epoch);

--- a/migrations/0011-index-bonds-type-epoch.sql
+++ b/migrations/0011-index-bonds-type-epoch.sql
@@ -1,2 +1,2 @@
 -- get_bonds_by_type filters on (bond_type, epoch); the only other index leads on pubkey.
-CREATE INDEX IF NOT EXISTS idx_bonds_type_epoch ON bonds(bond_type, epoch);
+CREATE INDEX IF NOT EXISTS idx_bond_type_epoch ON bonds(bond_type, epoch);


### PR DESCRIPTION
Lists validators whose bond can back a PSR downtime claim, as a flat list of vote accounts in the same shape as `/validators/verified` — the front end matches it client-side across the whole Explore table, so one cached list beats a per-validator flag.

This is part of the work on direct-staking; a follow-up PR is: https://github.com/marinade-finance/validator-bonds/pull/485

Rule: a validator is listed when it has a bond under either config — bidding `vbMaRfmTCg92HWGzmd53APkMNpPnGVGZTUHwUJQkXAU` or institutional `VbinSTyUEC8JXtzFteC4ruKSfs6dkQUUcY6wB1oJyjE` — whose effective_amount is at least 1 SOL. Effective rather than funded, because pending settlement claims and outstanding withdraw requests are already committed elsewhere and cannot pay a new claim. The two lists are unioned and deduplicated, so a validator bonded under both appears once.

At epoch 1012 that is 264 distinct vote accounts (220 bidding, 70 institutional, 26 in both). The front end currently derives the same badge from /bonds/bidding with effective_amount > 0, which yields 318 and ignores institutional bonds entirely, so it both over-reports dust bonds and misses institutional-only validators.

Deliberately not part of the rule for this first version: any check that the bond is sufficient relative to the stake routed to the validator, and any exclusion of validators that cannot currently produce a downtime event. Both need data the API does not hold today.

Split out of the direct-staking-route branch so it can land and be consumed independently of the settlement-generation work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public API endpoint for retrieving protected validator vote accounts.
  - Includes validators backed by eligible bidding and institutional bonds with at least 1 SOL in effective value.
  - Results are deduplicated and returned in a structured JSON response.
  - Added API documentation for the new endpoint.

- **Bug Fixes**
  - Improved bond storage reliability by ensuring batch updates complete atomically.
  - Improved performance when querying bonds by type and epoch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->