### PR TITLE
[GEN-8654] stake rule for /protected working properly

### DIFF
--- a/.buildkite/collect-bonds.yml
+++ b/.buildkite/collect-bonds.yml
@@ -128,6 +128,53 @@ steps:
 
   - wait: ~
 
+  # Marinade stake per validator is the same for both bond configs, so it is collected on the bidding
+  # run only. `/v1/validators/protected` sizes each bond against it.
+  - label: ":coin: Collect Marinade Stake"
+    key: "collect-stake"
+    commands:
+    - bond_type=$(buildkite-agent meta-data get bond_type)
+    - |
+      if [ "$$bond_type" != "bidding" ]; then
+        echo "Bond type '$$bond_type': stake is collected on the bidding run only"
+        exit 0
+      fi
+    - buildkite-agent artifact download --include-retried-jobs target/release/bonds-collector .
+    - chmod +x target/release/bonds-collector
+    - |
+      ./target/release/bonds-collector collect-stake \
+        --config ./collector-config.yaml > collected-stake.yaml
+    artifact_paths:
+      - collected-stake.yaml
+    retry:
+      automatic:
+        - exit_status: 100
+          limit: 5
+
+  - wait: ~
+
+  - label: ":coin: Store Marinade Stake"
+    commands:
+    - bond_type=$(buildkite-agent meta-data get bond_type)
+    - |
+      if [ "$$bond_type" != "bidding" ]; then
+        echo "Bond type '$$bond_type': stake is stored on the bidding run only"
+        exit 0
+      fi
+    - buildkite-agent artifact download --include-retried-jobs target/release/validator-bonds-api-cli .
+    - buildkite-agent artifact download collected-stake.yaml .
+    - chmod +x target/release/validator-bonds-api-cli
+    - curl https://truststore.pki.rds.amazonaws.com/eu-west-1/eu-west-1-bundle.pem -o ./eu-west-1-bundle.pem
+    - |
+      ./target/release/validator-bonds-api-cli \
+        store-collected-stake --postgres-url "$$POSTGRES_URL" --postgres-ssl-root-cert ./eu-west-1-bundle.pem --input-file collected-stake.yaml
+    retry:
+      automatic:
+        - exit_status: 100
+          limit: 5
+
+  - wait: ~
+
   - label: ":bell: Emit Bond Events"
     key: "emit-bond-events"
     commands:

--- a/.buildkite/collect-bonds.yml
+++ b/.buildkite/collect-bonds.yml
@@ -128,8 +128,34 @@ steps:
 
   - wait: ~
 
+  - label: ":bell: Emit Bond Events"
+    key: "emit-bond-events"
+    commands:
+    - bond_type=$(buildkite-agent meta-data get bond_type)
+    - retry_max_attempts=$(buildkite-agent meta-data get retry_max_attempts)
+    - retry_base_delay_ms=$(buildkite-agent meta-data get retry_base_delay_ms)
+    - emit_concurrency=$(buildkite-agent meta-data get emit_concurrency)
+    - notifications_api_url=$(buildkite-agent meta-data get notifications_api_url)
+    - echo "--- Emitting bond events for $$bond_type"
+    - curl https://truststore.pki.rds.amazonaws.com/eu-west-1/eu-west-1-bundle.pem -o ./eu-west-1-bundle.pem
+    - pnpm install
+    - pnpm -r build
+    - |
+      pnpm ts-node packages/bonds-eventing/src/index.ts \
+        "$$bond_type" \
+        --retry-max-attempts "$$retry_max_attempts" \
+        --retry-base-delay-ms "$$retry_base_delay_ms" \
+        --emit-concurrency "$$emit_concurrency" \
+        --notifications-api-url "$$notifications_api_url" \
+        --postgres-ssl-root-cert ./eu-west-1-bundle.pem
+    soft_fail:
+      - exit_status: "*"
+
+  - wait: ~
+
   # Marinade stake per validator is the same for both bond configs, so it is collected on the bidding
-  # run only. `/v1/validators/protected` sizes each bond against it.
+  # run only. `/v1/validators/protected` sizes each bond against it. Placed after bond eventing so a
+  # failure here cannot keep validator notifications from being emitted.
   - label: ":coin: Collect Marinade Stake"
     key: "collect-stake"
     commands:
@@ -137,6 +163,8 @@ steps:
     - |
       if [ "$$bond_type" != "bidding" ]; then
         echo "Bond type '$$bond_type': stake is collected on the bidding run only"
+        # placeholder so the declared artifact always exists; the store step exits before reading it
+        touch collected-stake.yaml
         exit 0
       fi
     - buildkite-agent artifact download --include-retried-jobs target/release/bonds-collector .
@@ -172,31 +200,6 @@ steps:
       automatic:
         - exit_status: 100
           limit: 5
-
-  - wait: ~
-
-  - label: ":bell: Emit Bond Events"
-    key: "emit-bond-events"
-    commands:
-    - bond_type=$(buildkite-agent meta-data get bond_type)
-    - retry_max_attempts=$(buildkite-agent meta-data get retry_max_attempts)
-    - retry_base_delay_ms=$(buildkite-agent meta-data get retry_base_delay_ms)
-    - emit_concurrency=$(buildkite-agent meta-data get emit_concurrency)
-    - notifications_api_url=$(buildkite-agent meta-data get notifications_api_url)
-    - echo "--- Emitting bond events for $$bond_type"
-    - curl https://truststore.pki.rds.amazonaws.com/eu-west-1/eu-west-1-bundle.pem -o ./eu-west-1-bundle.pem
-    - pnpm install
-    - pnpm -r build
-    - |
-      pnpm ts-node packages/bonds-eventing/src/index.ts \
-        "$$bond_type" \
-        --retry-max-attempts "$$retry_max_attempts" \
-        --retry-base-delay-ms "$$retry_base_delay_ms" \
-        --emit-concurrency "$$emit_concurrency" \
-        --notifications-api-url "$$notifications_api_url" \
-        --postgres-ssl-root-cert ./eu-west-1-bundle.pem
-    soft_fail:
-      - exit_status: "*"
 
   - wait: ~
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11042,6 +11042,7 @@ dependencies = [
 name = "validator-bonds-common"
 version = "0.0.0"
 dependencies = [
+ "agave-feature-set",
  "anchor-client",
  "anyhow",
  "bincode",
@@ -11051,6 +11052,7 @@ dependencies = [
  "serde",
  "solana-account-decoder",
  "solana-client",
+ "solana-feature-gate-interface",
  "solana-program",
  "solana-sdk",
  "solana-stake-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ incremental = false
 opt-level = 3
 
 [workspace.dependencies]
+agave-feature-set = "2.3.13"
 anchor-client = { version = "0.31.1", features = ["async"] }
 anchor-lang = "0.31.1"
 anchor-spl = { version = "0.31.1" }
@@ -54,6 +55,7 @@ solana-account-decoder = "2.3.13"
 solana-account-info = "2.3.0"
 solana-cli-output = "2.3.13"
 solana-client = "2.3.13"
+solana-feature-gate-interface = "2.2.2"
 solana-instructions-sysvar = "2.2.2"
 solana-program = "2.3.0"
 solana-pubkey = "2.3.0"

--- a/api/README.md
+++ b/api/README.md
@@ -57,8 +57,27 @@ cargo run --bin api -- --postgres-url "$POSTGRES_URL" \
 
 # data is gzipped so we use curl --compressed
 curl -X GET --compressed "http://localhost:8000/bonds/bidding"
+curl -X GET --compressed "http://localhost:8000/v1/validators/protected"
+curl -X GET --compressed "http://localhost:8000/v1/validators/stake"
 ```
 
+### Storing collected stake to the database
+
+`/v1/validators/protected` sizes each bond against the stake routed to the validator through the
+Marinade products listed in `collector-config.yaml`, so it needs `collected_stake` populated:
+
+```bash
+cargo run --bin bonds-collector -- collect-stake \
+    --config ./collector-config.yaml > collected-stake.yaml
+cargo run --bin validator-bonds-api-cli -- store-collected-stake \
+    --input-file collected-stake.yaml \
+    --postgres-ssl-root-cert "$PG_SSLROOTCERT" \
+    --postgres-url "$POSTGRES_URL"
+```
+
+With no rows stored the endpoint answers 500 rather than an empty list, which would read as "no
+validator is protected".
+
 The integration tests (`api/tests/http_behavior.rs`) cover routing/middleware only; the
-DB-backed routes (`/bonds/*`, `/protected-events`) and `readyz` are smoke-tested manually
-against the steps above.
+DB-backed routes (`/bonds/*`, `/protected-events`, `/v1/validators/*`) and `readyz` are smoke-tested
+manually against the steps above.

--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -70,8 +70,20 @@ mod tests {
     use super::ApiDoc;
     use utoipa::OpenApi;
 
-    // `/docs` claiming a path that 404s — or omitting one that serves — is what burns consumers, and
-    // the `#[utoipa::path]` attribute drifting from `routes.rs` is not a compile error.
+    // `/docs` claiming a path that 404s is what burns consumers, and the `#[utoipa::path]` attribute
+    // drifting from `routes.rs` is not a compile error. Source text rather than the axum `Router`,
+    // which exposes no way to enumerate what it serves.
+    #[test]
+    fn every_documented_path_is_routed() {
+        let routes = include_str!("routes.rs");
+        for path in ApiDoc::openapi().paths.paths.keys() {
+            assert!(
+                routes.contains(&format!("\"{path}\"")),
+                "{path} is documented but not routed",
+            );
+        }
+    }
+
     #[test]
     fn the_validators_family_is_documented_under_v1() {
         let docs = serde_json::to_value(ApiDoc::openapi()).unwrap();

--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -84,6 +84,25 @@ mod tests {
         }
     }
 
+    // A generated client with no error branch is worse than none: for the two /v1/validators paths
+    // the 500 is a chosen state, not a failure.
+    #[test]
+    fn every_fallible_endpoint_documents_its_error() {
+        let docs = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        for path in [
+            "/bonds",
+            "/bonds/bidding",
+            "/bonds/institutional",
+            "/v1/validators/protected",
+            "/v1/validators/stake",
+        ] {
+            assert!(
+                docs["paths"][path]["get"]["responses"]["500"].is_object(),
+                "{path} can answer 500 and must document it",
+            );
+        }
+    }
+
     #[test]
     fn the_validators_family_is_documented_under_v1() {
         let docs = serde_json::to_value(ApiDoc::openapi()).unwrap();

--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -1,7 +1,9 @@
 use crate::dto::{SettlementMetaSchema, ValidatorBondRecordSchema};
 use crate::{
     dto::ProtectedEventRecord,
-    handlers::{bonds, docs, protected_events, protected_validators, verified_validators},
+    handlers::{
+        bonds, collected_stake, docs, protected_events, protected_validators, verified_validators,
+    },
 };
 use settlement_common::{
     protected_events::ProtectedEvent,
@@ -35,8 +37,12 @@ use utoipa::{
         schemas(protected_events::ProtectedEventsResponse),
         schemas(verified_validators::VerifiedValidatorsResponse),
         schemas(protected_validators::ProtectedValidatorsResponse),
+        schemas(collected_stake::CollectedStakeResponse),
+        schemas(collected_stake::AuthorityTotal),
+        schemas(collected_stake::ValidatorStake),
+        schemas(collected_stake::AuthorityStake),
     ),
-    paths(docs::handler, bonds::handler, bonds::handler_institutional, bonds::handler_bidding, bonds::handler_bidding_auction, protected_events::handler, verified_validators::handler, protected_validators::handler),
+    paths(docs::handler, bonds::handler, bonds::handler_institutional, bonds::handler_bidding, bonds::handler_bidding_auction, protected_events::handler, verified_validators::handler, protected_validators::handler, collected_stake::handler),
     modifiers(&PubkeyScheme),
 )]
 pub struct ApiDoc;
@@ -56,5 +62,33 @@ impl Modify for PubkeyScheme {
             )
             .into(),
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ApiDoc;
+    use utoipa::OpenApi;
+
+    // `/docs` claiming a path that 404s — or omitting one that serves — is what burns consumers, and
+    // the `#[utoipa::path]` attribute drifting from `routes.rs` is not a compile error.
+    #[test]
+    fn the_validators_family_is_documented_under_v1() {
+        let docs = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        let documented = docs["paths"].as_object().unwrap();
+
+        for path in [
+            "/v1/validators/verified",
+            "/v1/validators/protected",
+            "/v1/validators/stake",
+        ] {
+            assert!(documented.contains_key(path), "{path} must be documented");
+        }
+        for removed in ["/validators/verified", "/validators/protected"] {
+            assert!(
+                !documented.contains_key(removed),
+                "{removed} was moved under /v1 and must no longer be documented",
+            );
+        }
     }
 }

--- a/api/src/bin/cli.rs
+++ b/api/src/bin/cli.rs
@@ -1,4 +1,6 @@
-use api::repositories::{bond::store_bonds, common::CommonStoreOptions};
+use api::repositories::{
+    bond::store_bonds, collected_stake::store_collected_stake, common::CommonStoreOptions,
+};
 use clap::{Args, Parser, Subcommand};
 use tracing_log::LogTracer;
 use validator_bonds_common::cli_result::CliResult;
@@ -21,6 +23,7 @@ struct Params {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     StoreBonds(CommonStoreOptions),
+    StoreCollectedStake(CommonStoreOptions),
 }
 
 #[tokio::main]
@@ -53,6 +56,7 @@ async fn real_main() -> anyhow::Result<()> {
 
     match params.command {
         Command::StoreBonds(options) => store_bonds(options).await?,
+        Command::StoreCollectedStake(options) => store_collected_stake(options).await?,
     };
     Ok(())
 }

--- a/api/src/handlers/bonds.rs
+++ b/api/src/handlers/bonds.rs
@@ -32,6 +32,7 @@ pub struct QueryParams {}
     path = "/bonds",
     responses(
         (status = 200, description = "DEPRECATED: Please use /bonds/bidding instead", body = BondsResponse),
+        (status = 500, description = "Bonds could not be read from the database."),
     )
 )]
 #[deprecated]
@@ -50,6 +51,7 @@ pub async fn handler(
     path = "/bonds/institutional",
     responses(
         (status = 200, body = BondsResponse),
+        (status = 500, description = "Bonds could not be read from the database."),
     )
 )]
 pub async fn handler_institutional(
@@ -98,6 +100,7 @@ pub async fn handler_bidding_auction(
     path = "/bonds/bidding",
     responses(
         (status = 200, body = BondsResponse),
+        (status = 500, description = "Bonds could not be read from the database."),
     )
 )]
 pub async fn handler_bidding(

--- a/api/src/handlers/collected_stake.rs
+++ b/api/src/handlers/collected_stake.rs
@@ -114,6 +114,7 @@ fn build_response(snapshot: CollectedStakeSnapshot) -> CollectedStakeResponse {
     path = "/v1/validators/stake",
     responses(
         (status = 200, description = "Stake routed to each validator through the Marinade products the collector tracks, at the latest collected epoch.", body = CollectedStakeResponse),
+        (status = 500, description = "No stake has been collected yet, or it could not be read. Deliberately not an empty list, which would read as 'no validator has stake'."),
     )
 )]
 pub async fn handler(

--- a/api/src/handlers/collected_stake.rs
+++ b/api/src/handlers/collected_stake.rs
@@ -1,0 +1,200 @@
+use crate::context::WrappedContext;
+use crate::error::AppError;
+use crate::repositories::collected_stake::{get_collected_stake, CollectedStakeSnapshot};
+use axum::extract::{Query, State};
+use axum::Json;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+#[allow(unused_imports)] // referenced only in the `value_type` schema attribute below
+use solana_sdk::pubkey::Pubkey;
+use std::collections::BTreeMap;
+
+/// Per-authority amounts, named rather than a `authority -> lamports` map, so a further amount stays
+/// an additive change. `deactivating` is a subset of `effective`, not an addend.
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct AuthorityStake {
+    label: String,
+    #[schema(value_type = Pubkey)]
+    stake_authority: String,
+    effective: u64,
+    activating: u64,
+    deactivating: u64,
+    stake_accounts: u32,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct ValidatorStake {
+    #[schema(value_type = Pubkey)]
+    vote_account: String,
+    /// Sum of `effective` over every authority — the amount the validator's bond has to cover.
+    effective: u64,
+    stake: Vec<AuthorityStake>,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct AuthorityTotal {
+    label: String,
+    #[schema(value_type = Pubkey)]
+    stake_authority: String,
+    effective: u64,
+    activating: u64,
+    deactivating: u64,
+    validators: u32,
+    stake_accounts: u32,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct CollectedStakeResponse {
+    epoch: u64,
+    slot: u64,
+    updated_at: DateTime<Utc>,
+    totals: Vec<AuthorityTotal>,
+    validators: Vec<ValidatorStake>,
+}
+
+#[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct QueryParams {}
+
+fn build_response(snapshot: CollectedStakeSnapshot) -> CollectedStakeResponse {
+    let mut per_validator: BTreeMap<String, Vec<AuthorityStake>> = BTreeMap::new();
+    let mut per_authority: BTreeMap<String, AuthorityTotal> = BTreeMap::new();
+
+    for record in snapshot.records {
+        let total = per_authority
+            .entry(record.stake_authority.clone())
+            .or_insert_with(|| AuthorityTotal {
+                label: record.label.clone(),
+                stake_authority: record.stake_authority.clone(),
+                effective: 0,
+                activating: 0,
+                deactivating: 0,
+                validators: 0,
+                stake_accounts: 0,
+            });
+        total.effective += record.effective;
+        total.activating += record.activating;
+        total.deactivating += record.deactivating;
+        total.validators += 1;
+        total.stake_accounts += record.stake_accounts;
+
+        per_validator
+            .entry(record.vote_account)
+            .or_default()
+            .push(AuthorityStake {
+                label: record.label,
+                stake_authority: record.stake_authority,
+                effective: record.effective,
+                activating: record.activating,
+                deactivating: record.deactivating,
+                stake_accounts: record.stake_accounts,
+            });
+    }
+
+    CollectedStakeResponse {
+        epoch: snapshot.epoch,
+        slot: snapshot.slot,
+        updated_at: snapshot.updated_at,
+        totals: per_authority.into_values().collect(),
+        validators: per_validator
+            .into_iter()
+            .map(|(vote_account, stake)| ValidatorStake {
+                vote_account,
+                effective: stake.iter().map(|authority| authority.effective).sum(),
+                stake,
+            })
+            .collect(),
+    }
+}
+
+#[utoipa::path(
+    get,
+    tag = "Validators",
+    operation_id = "Marinade stake per validator, per staker authority",
+    path = "/v1/validators/stake",
+    responses(
+        (status = 200, description = "Stake routed to each validator through the Marinade products the collector tracks, at the latest collected epoch.", body = CollectedStakeResponse),
+    )
+)]
+pub async fn handler(
+    State(context): State<WrappedContext>,
+    Query(_query_params): Query<QueryParams>,
+) -> Result<Json<CollectedStakeResponse>, AppError> {
+    let context = context.read().await;
+
+    let snapshot = get_collected_stake(&context.psql_client)
+        .await
+        .map_err(|error| AppError {
+            message: format!("Failed to fetch collected stake. Error: {error:?}"),
+        })?
+        .ok_or_else(|| AppError {
+            message: "No collected stake stored yet".to_string(),
+        })?;
+
+    Ok(Json(build_response(snapshot)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use validator_bonds_common::dto::CollectedStakeRecord;
+
+    fn record(label: &str, vote_account: &str, effective: u64) -> CollectedStakeRecord {
+        CollectedStakeRecord {
+            epoch: 1014,
+            slot: 438413520,
+            label: label.to_string(),
+            stake_authority: format!("{label}-authority"),
+            vote_account: vote_account.to_string(),
+            effective,
+            activating: 1,
+            deactivating: 2,
+            stake_accounts: 3,
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn response(records: Vec<CollectedStakeRecord>) -> CollectedStakeResponse {
+        build_response(CollectedStakeSnapshot {
+            epoch: 1014,
+            slot: 438413520,
+            updated_at: Utc::now(),
+            records,
+        })
+    }
+
+    #[test]
+    fn a_validator_sums_its_authorities() {
+        let built = response(vec![
+            record("native", "voteA", 10),
+            record("liquid", "voteA", 30),
+        ]);
+        assert_eq!(built.validators.len(), 1);
+        assert_eq!(built.validators[0].effective, 40);
+        assert_eq!(built.validators[0].stake.len(), 2);
+    }
+
+    #[test]
+    fn totals_count_validators_and_accounts_per_authority() {
+        let built = response(vec![
+            record("native", "voteA", 10),
+            record("native", "voteB", 5),
+            record("liquid", "voteA", 30),
+        ]);
+        let native = built
+            .totals
+            .iter()
+            .find(|total| total.label == "native")
+            .unwrap();
+        assert_eq!(
+            (
+                native.effective,
+                native.validators,
+                native.stake_accounts,
+                native.activating,
+                native.deactivating
+            ),
+            (15, 2, 6, 2, 4)
+        );
+    }
+}

--- a/api/src/handlers/mod.rs
+++ b/api/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod bonds;
+pub mod collected_stake;
 pub mod docs;
 pub mod protected_events;
 pub mod protected_validators;

--- a/api/src/handlers/protected_validators.rs
+++ b/api/src/handlers/protected_validators.rs
@@ -92,10 +92,9 @@ pub async fn handler(
             message: format!("Failed to fetch bonds. Error: {error:?}"),
         })?;
 
-    // The two are collected by separate pipeline steps, so a stale stake snapshot is possible and
-    // must be visible in the logs rather than silently changing who is protected.
+    // Separate pipeline steps write these, so a skew either way must surface rather than move the list.
     if let Some(bonds_epoch) = bonds.iter().map(|bond| bond.epoch).max() {
-        if snapshot.epoch < bonds_epoch {
+        if snapshot.epoch != bonds_epoch {
             tracing::warn!(
                 "Collected stake is from epoch {} while bonds are from epoch {bonds_epoch}",
                 snapshot.epoch

--- a/api/src/handlers/protected_validators.rs
+++ b/api/src/handlers/protected_validators.rs
@@ -1,6 +1,6 @@
 use crate::context::WrappedContext;
 use crate::error::AppError;
-use crate::repositories::bond::get_bonds_by_type;
+use crate::repositories::bond::get_summable_bonds;
 use crate::repositories::collected_stake::{get_collected_stake, MarinadeStakeByVoteAccount};
 use axum::extract::{Query, State};
 use axum::Json;
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[allow(unused_imports)] // referenced only in the `value_type` schema attribute below
 use solana_sdk::pubkey::Pubkey;
 use std::collections::{BTreeSet, HashMap};
-use validator_bonds_common::dto::{BondType, ValidatorBondRecord};
+use validator_bonds_common::dto::ValidatorBondRecord;
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct ProtectedValidatorsResponse {
@@ -28,7 +28,9 @@ const ALLOWED_STAKE_PER_BOND_RATIO: u64 = 2000;
 
 fn required_bond_lamports(marinade_stake_lamports: u64) -> Decimal {
     Decimal::from(
-        (marinade_stake_lamports / ALLOWED_STAKE_PER_BOND_RATIO).max(MIN_PROTECTED_BOND_LAMPORTS),
+        marinade_stake_lamports
+            .div_ceil(ALLOWED_STAKE_PER_BOND_RATIO)
+            .max(MIN_PROTECTED_BOND_LAMPORTS),
     )
 }
 
@@ -84,16 +86,11 @@ pub async fn handler(
             message: "No collected stake stored yet".to_string(),
         })?;
 
-    let mut bonds = vec![];
-    for bond_type in [BondType::Bidding, BondType::Institutional] {
-        bonds.extend(
-            get_bonds_by_type(&context.psql_client, bond_type)
-                .await
-                .map_err(|error| AppError {
-                    message: format!("Failed to fetch bonds. Error: {error:?}"),
-                })?,
-        );
-    }
+    let bonds = get_summable_bonds(&context.psql_client)
+        .await
+        .map_err(|error| AppError {
+            message: format!("Failed to fetch bonds. Error: {error:?}"),
+        })?;
 
     // The two are collected by separate pipeline steps, so a stale stake snapshot is possible and
     // must be visible in the logs rather than silently changing who is protected.
@@ -120,6 +117,7 @@ pub async fn handler(
 mod tests {
     use super::*;
     use chrono::Utc;
+    use validator_bonds_common::dto::BondType;
 
     fn sol(amount: u64) -> u64 {
         amount * 1_000_000_000

--- a/api/src/handlers/protected_validators.rs
+++ b/api/src/handlers/protected_validators.rs
@@ -68,6 +68,7 @@ fn protected_vote_accounts(
     path = "/v1/validators/protected",
     responses(
         (status = 200, description = "Effective bond under the bidding and the institutional config, summed, covers at least 1/2000 of the validator's Marinade stake, and is at least 1 SOL.", body = ProtectedValidatorsResponse),
+        (status = 500, description = "No stake has been collected yet, or bonds could not be read. Deliberately not an empty list, which would read as 'no validator is protected'."),
     )
 )]
 pub async fn handler(

--- a/api/src/handlers/protected_validators.rs
+++ b/api/src/handlers/protected_validators.rs
@@ -1,13 +1,14 @@
 use crate::context::WrappedContext;
 use crate::error::AppError;
 use crate::repositories::bond::get_bonds_by_type;
+use crate::repositories::collected_stake::{get_collected_stake, MarinadeStakeByVoteAccount};
 use axum::extract::{Query, State};
 use axum::Json;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)] // referenced only in the `value_type` schema attribute below
 use solana_sdk::pubkey::Pubkey;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use validator_bonds_common::dto::{BondType, ValidatorBondRecord};
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]
@@ -22,12 +23,39 @@ pub struct QueryParams {}
 
 const MIN_PROTECTED_BOND_LAMPORTS: u64 = 1_000_000_000;
 
-/// Effective, not funded: a settlement reservation or a filed withdraw request forfeits protection.
-fn protected_vote_accounts(bonds: &[ValidatorBondRecord]) -> BTreeSet<String> {
-    bonds
-        .iter()
-        .filter(|bond| bond.effective_amount >= Decimal::from(MIN_PROTECTED_BOND_LAMPORTS))
-        .map(|bond| bond.vote_account.clone())
+/// Select's ratio, applied to SAM stake too, so one rule replaces SAM's per-epoch PMPE sizing.
+const ALLOWED_STAKE_PER_BOND_RATIO: u64 = 2000;
+
+fn required_bond_lamports(marinade_stake_lamports: u64) -> Decimal {
+    Decimal::from(
+        (marinade_stake_lamports / ALLOWED_STAKE_PER_BOND_RATIO).max(MIN_PROTECTED_BOND_LAMPORTS),
+    )
+}
+
+/// Both configs' bonds are summed against the whole Marinade stake: the badge is per validator,
+/// while collateral and stake each split per product.
+fn protected_vote_accounts(
+    bonds: &[ValidatorBondRecord],
+    marinade_stake: &MarinadeStakeByVoteAccount,
+) -> BTreeSet<String> {
+    let mut effective_amounts: HashMap<&str, Decimal> = HashMap::new();
+    for bond in bonds {
+        // Effective, not funded: a settlement reservation or a withdraw request cannot pay a claim.
+        *effective_amounts
+            .entry(bond.vote_account.as_str())
+            .or_default() += bond.effective_amount;
+    }
+
+    effective_amounts
+        .into_iter()
+        .filter(|(vote_account, effective_amount)| {
+            // Zero stake — or a vote account no configured authority stakes to — has nothing to protect.
+            match marinade_stake.get(*vote_account).copied().unwrap_or(0) {
+                0 => false,
+                stake => *effective_amount >= required_bond_lamports(stake),
+            }
+        })
+        .map(|(vote_account, _)| vote_account.to_string())
         .collect()
 }
 
@@ -35,29 +63,56 @@ fn protected_vote_accounts(bonds: &[ValidatorBondRecord]) -> BTreeSet<String> {
     get,
     tag = "Validators",
     operation_id = "List validators whose stakers are PSR protected",
-    path = "/validators/protected",
+    path = "/v1/validators/protected",
     responses(
-        (status = 200, description = "At least 1 SOL of effective bond under the bidding or the institutional config.", body = ProtectedValidatorsResponse),
+        (status = 200, description = "Effective bond under the bidding and the institutional config, summed, covers at least 1/2000 of the validator's Marinade stake, and is at least 1 SOL.", body = ProtectedValidatorsResponse),
     )
 )]
 pub async fn handler(
     State(context): State<WrappedContext>,
     Query(_query_params): Query<QueryParams>,
 ) -> Result<Json<ProtectedValidatorsResponse>, AppError> {
-    let psql_client = &context.read().await.psql_client;
+    let context = context.read().await;
 
-    let mut protected = BTreeSet::new();
+    // Serving the list without stake data would silently un-protect every validator.
+    let snapshot = get_collected_stake(&context.psql_client)
+        .await
+        .map_err(|error| AppError {
+            message: format!("Failed to fetch collected stake. Error: {error:?}"),
+        })?
+        .ok_or_else(|| AppError {
+            message: "No collected stake stored yet".to_string(),
+        })?;
+
+    let mut bonds = vec![];
     for bond_type in [BondType::Bidding, BondType::Institutional] {
-        let bonds = get_bonds_by_type(psql_client, bond_type)
-            .await
-            .map_err(|error| AppError {
-                message: format!("Failed to fetch bonds. Error: {error:?}"),
-            })?;
-        protected.extend(protected_vote_accounts(&bonds));
+        bonds.extend(
+            get_bonds_by_type(&context.psql_client, bond_type)
+                .await
+                .map_err(|error| AppError {
+                    message: format!("Failed to fetch bonds. Error: {error:?}"),
+                })?,
+        );
+    }
+
+    // The two are collected by separate pipeline steps, so a stale stake snapshot is possible and
+    // must be visible in the logs rather than silently changing who is protected.
+    if let Some(bonds_epoch) = bonds.iter().map(|bond| bond.epoch).max() {
+        if snapshot.epoch < bonds_epoch {
+            tracing::warn!(
+                "Collected stake is from epoch {} while bonds are from epoch {bonds_epoch}",
+                snapshot.epoch
+            );
+        }
     }
 
     Ok(Json(ProtectedValidatorsResponse {
-        protected_validators: protected.into_iter().collect(),
+        protected_validators: protected_vote_accounts(
+            &bonds,
+            &snapshot.effective_by_vote_account(),
+        )
+        .into_iter()
+        .collect(),
     }))
 }
 
@@ -66,7 +121,15 @@ mod tests {
     use super::*;
     use chrono::Utc;
 
-    fn bond(vote_account: &str, effective_amount: Decimal) -> ValidatorBondRecord {
+    fn sol(amount: u64) -> u64 {
+        amount * 1_000_000_000
+    }
+
+    fn bond(
+        vote_account: &str,
+        effective_lamports: u64,
+        bond_type: BondType,
+    ) -> ValidatorBondRecord {
         ValidatorBondRecord {
             pubkey: format!("{vote_account}-bond"),
             vote_account: vote_account.to_string(),
@@ -74,42 +137,110 @@ mod tests {
             cpmpe: Decimal::ZERO,
             max_stake_wanted: Decimal::ZERO,
             epoch: 980,
-            // Max on every fixture: a bond excluded below the floor must be excluded despite it.
+            // Max on every fixture: an excluded bond must stay excluded despite it.
             funded_amount: Decimal::from(u64::MAX),
-            effective_amount,
+            effective_amount: Decimal::from(effective_lamports),
             remaining_witdraw_request_amount: Decimal::ZERO,
             remainining_settlement_claim_amount: Decimal::ZERO,
             updated_at: Utc::now(),
-            bond_type: BondType::Bidding,
+            bond_type,
             inflation_commission_bps: None,
             mev_commission_bps: None,
             block_commission_bps: None,
         }
     }
 
-    fn protected(bonds: Vec<ValidatorBondRecord>) -> Vec<String> {
-        protected_vote_accounts(&bonds).into_iter().collect()
+    fn bidding(vote_account: &str, effective_lamports: u64) -> ValidatorBondRecord {
+        bond(vote_account, effective_lamports, BondType::Bidding)
+    }
+
+    fn stake(entries: &[(&str, u64)]) -> MarinadeStakeByVoteAccount {
+        entries
+            .iter()
+            .map(|(vote_account, stake_lamports)| (vote_account.to_string(), *stake_lamports))
+            .collect()
+    }
+
+    fn protected(
+        bonds: Vec<ValidatorBondRecord>,
+        marinade_stake: &MarinadeStakeByVoteAccount,
+    ) -> Vec<String> {
+        protected_vote_accounts(&bonds, marinade_stake)
+            .into_iter()
+            .collect()
+    }
+
+    #[test]
+    fn the_bond_must_cover_one_two_thousandth_of_the_marinade_stake() {
+        let listed = protected(
+            vec![
+                bidding("voteAtRatio", sol(25)),
+                bidding("voteBelowRatio", sol(25) - 1),
+                bidding("voteAboveRatio", sol(25) + 1),
+            ],
+            &stake(&[
+                ("voteAtRatio", sol(50_000)),
+                ("voteBelowRatio", sol(50_000)),
+                ("voteAboveRatio", sol(50_000)),
+            ]),
+        );
+        assert_eq!(
+            listed,
+            vec!["voteAboveRatio".to_string(), "voteAtRatio".to_string()]
+        );
     }
 
     #[test]
     fn a_bond_below_the_floor_is_not_protected() {
-        let listed = protected(vec![
-            bond("voteAtFloor", Decimal::from(MIN_PROTECTED_BOND_LAMPORTS)),
-            bond(
-                "voteBelowFloor",
-                Decimal::from(MIN_PROTECTED_BOND_LAMPORTS - 1),
-            ),
-            bond("voteZero", Decimal::ZERO),
-        ]);
+        // Without the floor the ratio alone would protect a dust bond of a small stake.
+        let listed = protected(
+            vec![
+                bidding("voteAtFloor", MIN_PROTECTED_BOND_LAMPORTS),
+                bidding("voteBelowFloor", MIN_PROTECTED_BOND_LAMPORTS - 1),
+                bidding("voteZero", 0),
+            ],
+            &stake(&[
+                ("voteAtFloor", sol(100)),
+                ("voteBelowFloor", sol(100)),
+                ("voteZero", sol(100)),
+            ]),
+        );
         assert_eq!(listed, vec!["voteAtFloor".to_string()]);
     }
 
     #[test]
+    fn a_validator_without_marinade_stake_is_not_protected() {
+        let listed = protected(
+            vec![
+                bidding("voteNoStake", sol(50)),
+                bidding("voteWithoutCollectedStake", sol(50)),
+            ],
+            &stake(&[("voteNoStake", 0)]),
+        );
+        assert!(listed.is_empty());
+    }
+
+    #[test]
+    fn bonds_of_both_configs_are_summed() {
+        let listed = protected(
+            vec![
+                bidding("voteBoth", sol(13)),
+                bond("voteBoth", sol(12), BondType::Institutional),
+            ],
+            &stake(&[("voteBoth", sol(50_000))]),
+        );
+        assert_eq!(listed, vec!["voteBoth".to_string()]);
+    }
+
+    #[test]
     fn a_vote_account_appearing_twice_is_listed_once() {
-        let listed = protected(vec![
-            bond("voteTwice", Decimal::from(MIN_PROTECTED_BOND_LAMPORTS)),
-            bond("voteTwice", Decimal::from(MIN_PROTECTED_BOND_LAMPORTS * 20)),
-        ]);
+        let listed = protected(
+            vec![
+                bidding("voteTwice", sol(25)),
+                bidding("voteTwice", sol(500)),
+            ],
+            &stake(&[("voteTwice", sol(50_000))]),
+        );
         assert_eq!(listed, vec!["voteTwice".to_string()]);
     }
 }

--- a/api/src/handlers/verified_validators.rs
+++ b/api/src/handlers/verified_validators.rs
@@ -19,7 +19,7 @@ pub struct QueryParams {}
     get,
     tag = "Validators",
     operation_id = "List verified validators",
-    path = "/validators/verified",
+    path = "/v1/validators/verified",
     responses(
         (status = 200, body = VerifiedValidatorsResponse),
     )

--- a/api/src/repositories/bond.rs
+++ b/api/src/repositories/bond.rs
@@ -1,4 +1,4 @@
-use super::common::CommonStoreOptions;
+use super::common::{pg_transient, CommonStoreOptions};
 use crate::dto::SqlSerializableBondType;
 
 use openssl::ssl::{SslConnector, SslMethod};
@@ -7,7 +7,6 @@ use rust_decimal::Decimal;
 use serde_json::Value;
 use std::collections::HashMap;
 use tokio_postgres::{types::ToSql, Client};
-use validator_bonds_common::cli_result::CliError;
 use validator_bonds_common::dto::{BondType, ValidatorBondRecord};
 
 /// ds-sam-calc relay from bonds-eventing: per-validator calc blobs (keyed by vote
@@ -54,35 +53,6 @@ pub async fn get_auction_context(
     Ok(AuctionContext { meta, validators })
 }
 
-fn pg_transient(err: tokio_postgres::Error) -> CliError {
-    let is_transient = err.is_closed()
-        || std::error::Error::source(&err)
-            .and_then(|s| s.downcast_ref::<std::io::Error>())
-            .map(is_transient_io_kind)
-            .unwrap_or(false);
-
-    if is_transient {
-        CliError::retry_able(err)
-    } else {
-        CliError::critical(err)
-    }
-}
-
-fn is_transient_io_kind(io: &std::io::Error) -> bool {
-    use std::io::ErrorKind::*;
-    matches!(
-        io.kind(),
-        ConnectionRefused
-            | ConnectionReset
-            | ConnectionAborted
-            | NotConnected
-            | TimedOut
-            | UnexpectedEof
-            | Interrupted
-            | WouldBlock
-    )
-}
-
 pub async fn get_bonds_by_type(
     psql_client: &Client,
     bond_type: BondType,
@@ -122,32 +92,54 @@ async fn get_bonds_query(
     };
 
     let rows = psql_client.query(&query_string, &params).await?;
+    rows.into_iter().map(map_bond_row).collect()
+}
 
-    let mut bonds: Vec<ValidatorBondRecord> = vec![];
-    for row in rows {
-        let bond_type: SqlSerializableBondType = row.get("bond_type");
-        bonds.push(ValidatorBondRecord {
-            pubkey: row.get("pubkey"),
-            vote_account: row.get("vote_account"),
-            authority: row.get("authority"),
-            epoch: row.get::<_, i32>("epoch").try_into()?,
-            cpmpe: row.get::<_, Decimal>("cpmpe"),
-            max_stake_wanted: row.get::<_, Decimal>("max_stake_wanted"),
-            updated_at: row.get("updated_at"),
-            funded_amount: row.get::<_, Decimal>("funded_amount"),
-            effective_amount: row.get::<_, Decimal>("effective_amount"),
-            remaining_witdraw_request_amount: row
-                .get::<_, Decimal>("remaining_witdraw_request_amount"),
-            remainining_settlement_claim_amount: row
-                .get::<_, Decimal>("remainining_settlement_claim_amount"),
-            bond_type: bond_type.into(),
-            inflation_commission_bps: row.get("inflation_commission_bps"),
-            mev_commission_bps: row.get("mev_commission_bps"),
-            block_commission_bps: row.get("block_commission_bps"),
-        })
-    }
+/// Both configs at one epoch. `/v1/validators/protected` sums their collateral, and each type is
+/// stored by its own pipeline run, so a per-type `MAX(epoch)` could sum two different epochs.
+pub async fn get_summable_bonds(psql_client: &Client) -> anyhow::Result<Vec<ValidatorBondRecord>> {
+    let bidding: SqlSerializableBondType = BondType::Bidding.into();
+    let institutional: SqlSerializableBondType = BondType::Institutional.into();
 
-    Ok(bonds)
+    let rows = psql_client
+        .query(
+            "SELECT *
+             FROM bonds
+             WHERE bond_type IN ($1, $2)
+               AND epoch = (
+                   SELECT MIN(newest) FROM (
+                       SELECT MAX(epoch) AS newest
+                       FROM bonds
+                       WHERE bond_type IN ($1, $2)
+                       GROUP BY bond_type
+                   ) newest_per_type
+               )",
+            &[&bidding, &institutional],
+        )
+        .await?;
+    rows.into_iter().map(map_bond_row).collect()
+}
+
+fn map_bond_row(row: tokio_postgres::Row) -> anyhow::Result<ValidatorBondRecord> {
+    let bond_type: SqlSerializableBondType = row.get("bond_type");
+    Ok(ValidatorBondRecord {
+        pubkey: row.get("pubkey"),
+        vote_account: row.get("vote_account"),
+        authority: row.get("authority"),
+        epoch: row.get::<_, i32>("epoch").try_into()?,
+        cpmpe: row.get::<_, Decimal>("cpmpe"),
+        max_stake_wanted: row.get::<_, Decimal>("max_stake_wanted"),
+        updated_at: row.get("updated_at"),
+        funded_amount: row.get::<_, Decimal>("funded_amount"),
+        effective_amount: row.get::<_, Decimal>("effective_amount"),
+        remaining_witdraw_request_amount: row.get::<_, Decimal>("remaining_witdraw_request_amount"),
+        remainining_settlement_claim_amount: row
+            .get::<_, Decimal>("remainining_settlement_claim_amount"),
+        bond_type: bond_type.into(),
+        inflation_commission_bps: row.get("inflation_commission_bps"),
+        mev_commission_bps: row.get("mev_commission_bps"),
+        block_commission_bps: row.get("block_commission_bps"),
+    })
 }
 
 pub async fn store_bonds(options: CommonStoreOptions) -> anyhow::Result<()> {

--- a/api/src/repositories/collected_stake.rs
+++ b/api/src/repositories/collected_stake.rs
@@ -1,9 +1,77 @@
 use super::common::CommonStoreOptions;
 
+use chrono::{DateTime, Utc};
 use openssl::ssl::{SslConnector, SslMethod};
 use postgres_openssl::MakeTlsConnector;
-use tokio_postgres::types::ToSql;
+use std::collections::HashMap;
+use tokio_postgres::{types::ToSql, Client};
 use validator_bonds_common::dto::CollectedStakeRecord;
+
+/// Marinade stake in lamports, keyed by vote account.
+pub type MarinadeStakeByVoteAccount = HashMap<String, u64>;
+
+/// One collection run: every record shares the epoch, slot and timestamp the collector stamped, since
+/// the store replaces a whole epoch at once.
+pub struct CollectedStakeSnapshot {
+    pub epoch: u64,
+    pub slot: u64,
+    pub updated_at: DateTime<Utc>,
+    pub records: Vec<CollectedStakeRecord>,
+}
+
+impl CollectedStakeSnapshot {
+    /// Summed across every configured authority: the bond has to cover the validator's whole
+    /// Marinade stake, whichever product routed it.
+    pub fn effective_by_vote_account(&self) -> MarinadeStakeByVoteAccount {
+        let mut effective = MarinadeStakeByVoteAccount::new();
+        for record in &self.records {
+            *effective.entry(record.vote_account.clone()).or_default() += record.effective;
+        }
+        effective
+    }
+}
+
+/// `None` when nothing has ever been collected. Callers must fail loudly rather than treat that as
+/// "no validator has stake", which would un-protect every validator at once.
+pub async fn get_collected_stake(
+    psql_client: &Client,
+) -> anyhow::Result<Option<CollectedStakeSnapshot>> {
+    let rows = psql_client
+        .query(
+            "SELECT epoch, slot, label, stake_authority, vote_account, effective, activating,
+                    deactivating, stake_accounts, updated_at
+             FROM collected_stake
+             WHERE epoch = (SELECT MAX(epoch) FROM collected_stake)",
+            &[],
+        )
+        .await?;
+
+    let mut records: Vec<CollectedStakeRecord> = vec![];
+    for row in rows {
+        records.push(CollectedStakeRecord {
+            epoch: row.get::<_, i32>("epoch").try_into()?,
+            slot: row.get::<_, i64>("slot").try_into()?,
+            label: row.get("label"),
+            stake_authority: row.get("stake_authority"),
+            vote_account: row.get("vote_account"),
+            effective: row.get::<_, i64>("effective").try_into()?,
+            activating: row.get::<_, i64>("activating").try_into()?,
+            deactivating: row.get::<_, i64>("deactivating").try_into()?,
+            stake_accounts: row.get::<_, i32>("stake_accounts").try_into()?,
+            updated_at: row.get("updated_at"),
+        })
+    }
+
+    let Some(first) = records.first() else {
+        return Ok(None);
+    };
+    Ok(Some(CollectedStakeSnapshot {
+        epoch: first.epoch,
+        slot: first.slot,
+        updated_at: first.updated_at,
+        records,
+    }))
+}
 
 /// One epoch per collection run: the collector stamps every record from a single `Clock`, and the
 /// store replaces that whole epoch. Mixed epochs would make the `DELETE` drop rows it never rewrites.

--- a/api/src/repositories/collected_stake.rs
+++ b/api/src/repositories/collected_stake.rs
@@ -1,4 +1,4 @@
-use super::common::CommonStoreOptions;
+use super::common::{pg_transient, CommonStoreOptions};
 
 use chrono::{DateTime, Utc};
 use openssl::ssl::{SslConnector, SslMethod};
@@ -75,6 +75,8 @@ pub async fn get_collected_stake(
 
 /// One epoch per collection run: the collector stamps every record from a single `Clock`, and the
 /// store replaces that whole epoch. Mixed epochs would make the `DELETE` drop rows it never rewrites.
+/// `slot` and `updated_at` are checked too because `get_collected_stake` reads them off an arbitrary
+/// row of the epoch.
 fn collection_epoch(records: &[CollectedStakeRecord]) -> anyhow::Result<i32> {
     let Some(first) = records.first() else {
         // An empty file must not be allowed to empty the table — the endpoint would silently
@@ -85,6 +87,18 @@ fn collection_epoch(records: &[CollectedStakeRecord]) -> anyhow::Result<i32> {
         records.iter().all(|record| record.epoch == first.epoch),
         "Collected stake records span multiple epochs, expected only {}",
         first.epoch
+    );
+    anyhow::ensure!(
+        records.iter().all(|record| record.slot == first.slot),
+        "Collected stake records span multiple slots, expected only {}",
+        first.slot
+    );
+    anyhow::ensure!(
+        records
+            .iter()
+            .all(|record| record.updated_at == first.updated_at),
+        "Collected stake records span multiple timestamps, expected only {}",
+        first.updated_at
     );
     Ok(first.epoch.try_into()?)
 }
@@ -101,20 +115,22 @@ pub async fn store_collected_stake(options: CommonStoreOptions) -> anyhow::Resul
     builder.set_ca_file(&options.postgres_ssl_root_cert)?;
     let connector = MakeTlsConnector::new(builder.build());
 
-    let (mut psql_client, psql_conn) =
-        tokio_postgres::connect(&options.postgres_url, connector).await?;
+    let (mut psql_client, psql_conn) = tokio_postgres::connect(&options.postgres_url, connector)
+        .await
+        .map_err(pg_transient)?;
     tokio::spawn(async move {
         if let Err(err) = psql_conn.await {
             log::error!("PSQL connection terminated: {err}");
         }
     });
 
-    let tx = psql_client.transaction().await?;
+    let tx = psql_client.transaction().await.map_err(pg_transient)?;
 
     // Replace rather than upsert: a validator that fully unstaked has no record in this run, and a
     // left-behind row would keep reporting stake it no longer has.
     tx.execute("DELETE FROM collected_stake WHERE epoch = $1", &[&epoch])
-        .await?;
+        .await
+        .map_err(pg_transient)?;
 
     for chunk in records.chunks(CHUNK_SIZE) {
         let mut param_index = 1;
@@ -154,10 +170,10 @@ pub async fn store_collected_stake(options: CommonStoreOptions) -> anyhow::Resul
             .iter()
             .map(|param| param.as_ref() as &(dyn ToSql + Sync))
             .collect::<Vec<_>>();
-        tx.query(&query, &params).await?;
+        tx.query(&query, &params).await.map_err(pg_transient)?;
     }
 
-    tx.commit().await?;
+    tx.commit().await.map_err(pg_transient)?;
     log::info!(
         "Stored {} collected stake records for epoch {epoch}",
         records.len()
@@ -169,7 +185,13 @@ pub async fn store_collected_stake(options: CommonStoreOptions) -> anyhow::Resul
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
+    use chrono::TimeZone;
+
+    // Fixed, not `Utc::now()`: two records of one run carry the very same stamp, and the check
+    // under test is what rejects them when they do not.
+    fn stamp(seconds: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 10, 12, 0, seconds).unwrap()
+    }
 
     fn record(epoch: u64) -> CollectedStakeRecord {
         CollectedStakeRecord {
@@ -182,7 +204,7 @@ mod tests {
             activating: 0,
             deactivating: 0,
             stake_accounts: 1,
-            updated_at: Utc::now(),
+            updated_at: stamp(0),
         }
     }
 
@@ -203,5 +225,21 @@ mod tests {
     fn mixed_epochs_are_rejected() {
         let err = collection_epoch(&[record(1014), record(1013)]).unwrap_err();
         assert!(err.to_string().contains("multiple epochs"));
+    }
+
+    #[test]
+    fn mixed_slots_are_rejected() {
+        let mut second = record(1014);
+        second.slot += 1;
+        let err = collection_epoch(&[record(1014), second]).unwrap_err();
+        assert!(err.to_string().contains("multiple slots"));
+    }
+
+    #[test]
+    fn mixed_timestamps_are_rejected() {
+        let mut second = record(1014);
+        second.updated_at = stamp(1);
+        let err = collection_epoch(&[record(1014), second]).unwrap_err();
+        assert!(err.to_string().contains("multiple timestamps"));
     }
 }

--- a/api/src/repositories/collected_stake.rs
+++ b/api/src/repositories/collected_stake.rs
@@ -1,0 +1,139 @@
+use super::common::CommonStoreOptions;
+
+use openssl::ssl::{SslConnector, SslMethod};
+use postgres_openssl::MakeTlsConnector;
+use tokio_postgres::types::ToSql;
+use validator_bonds_common::dto::CollectedStakeRecord;
+
+/// One epoch per collection run: the collector stamps every record from a single `Clock`, and the
+/// store replaces that whole epoch. Mixed epochs would make the `DELETE` drop rows it never rewrites.
+fn collection_epoch(records: &[CollectedStakeRecord]) -> anyhow::Result<i32> {
+    let Some(first) = records.first() else {
+        // An empty file must not be allowed to empty the table — the endpoint would silently
+        // un-protect every validator.
+        anyhow::bail!("No collected stake records to store");
+    };
+    anyhow::ensure!(
+        records.iter().all(|record| record.epoch == first.epoch),
+        "Collected stake records span multiple epochs, expected only {}",
+        first.epoch
+    );
+    Ok(first.epoch.try_into()?)
+}
+
+pub async fn store_collected_stake(options: CommonStoreOptions) -> anyhow::Result<()> {
+    const CHUNK_SIZE: usize = 512;
+    const PARAMS_PER_INSERT: usize = 10;
+
+    let input = std::fs::File::open(options.input_path)?;
+    let records: Vec<CollectedStakeRecord> = serde_yaml::from_reader(input)?;
+    let epoch = collection_epoch(&records)?;
+
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    builder.set_ca_file(&options.postgres_ssl_root_cert)?;
+    let connector = MakeTlsConnector::new(builder.build());
+
+    let (mut psql_client, psql_conn) =
+        tokio_postgres::connect(&options.postgres_url, connector).await?;
+    tokio::spawn(async move {
+        if let Err(err) = psql_conn.await {
+            log::error!("PSQL connection terminated: {err}");
+        }
+    });
+
+    let tx = psql_client.transaction().await?;
+
+    // Replace rather than upsert: a validator that fully unstaked has no record in this run, and a
+    // left-behind row would keep reporting stake it no longer has.
+    tx.execute("DELETE FROM collected_stake WHERE epoch = $1", &[&epoch])
+        .await?;
+
+    for chunk in records.chunks(CHUNK_SIZE) {
+        let mut param_index = 1;
+        let mut params: Vec<Box<dyn ToSql + Sync + Send>> = Vec::new();
+        let mut insert_values = String::new();
+
+        for record in chunk {
+            let placeholders = (param_index..param_index + PARAMS_PER_INSERT)
+                .map(|index| format!("${index}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            insert_values.push_str(&format!("({placeholders}),"));
+            param_index += PARAMS_PER_INSERT;
+
+            params.push(Box::new(epoch));
+            params.push(Box::new(i64::try_from(record.slot)?));
+            params.push(Box::new(record.label.clone()));
+            params.push(Box::new(record.stake_authority.clone()));
+            params.push(Box::new(record.vote_account.clone()));
+            params.push(Box::new(i64::try_from(record.effective)?));
+            params.push(Box::new(i64::try_from(record.activating)?));
+            params.push(Box::new(i64::try_from(record.deactivating)?));
+            params.push(Box::new(i32::try_from(record.stake_accounts)?));
+            params.push(Box::new(record.updated_at));
+        }
+
+        insert_values.pop();
+
+        let query = format!(
+            "
+            INSERT INTO collected_stake (epoch, slot, label, stake_authority, vote_account, effective, activating, deactivating, stake_accounts, updated_at)
+            VALUES {insert_values}
+            "
+        );
+
+        let params = params
+            .iter()
+            .map(|param| param.as_ref() as &(dyn ToSql + Sync))
+            .collect::<Vec<_>>();
+        tx.query(&query, &params).await?;
+    }
+
+    tx.commit().await?;
+    log::info!(
+        "Stored {} collected stake records for epoch {epoch}",
+        records.len()
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn record(epoch: u64) -> CollectedStakeRecord {
+        CollectedStakeRecord {
+            epoch,
+            slot: 438413520,
+            label: "native".to_string(),
+            stake_authority: "stWirqFCf2Uts1JBL1Jsd3r6VBWhgnpdPxCTe1MFjrq".to_string(),
+            vote_account: "We11J5D4iXcNbdMwCZX2o9RRkwaWBo1AGLADfubmeTb".to_string(),
+            effective: 1,
+            activating: 0,
+            deactivating: 0,
+            stake_accounts: 1,
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn one_epoch_is_accepted() {
+        assert_eq!(
+            collection_epoch(&[record(1014), record(1014)]).unwrap(),
+            1014
+        );
+    }
+
+    #[test]
+    fn an_empty_collection_is_rejected() {
+        collection_epoch(&[]).unwrap_err();
+    }
+
+    #[test]
+    fn mixed_epochs_are_rejected() {
+        let err = collection_epoch(&[record(1014), record(1013)]).unwrap_err();
+        assert!(err.to_string().contains("multiple epochs"));
+    }
+}

--- a/api/src/repositories/common.rs
+++ b/api/src/repositories/common.rs
@@ -1,4 +1,34 @@
 use clap::Args;
+use validator_bonds_common::cli_result::CliError;
+
+pub fn pg_transient(err: tokio_postgres::Error) -> CliError {
+    let is_transient = err.is_closed()
+        || std::error::Error::source(&err)
+            .and_then(|s| s.downcast_ref::<std::io::Error>())
+            .map(is_transient_io_kind)
+            .unwrap_or(false);
+
+    if is_transient {
+        CliError::retry_able(err)
+    } else {
+        CliError::critical(err)
+    }
+}
+
+fn is_transient_io_kind(io: &std::io::Error) -> bool {
+    use std::io::ErrorKind::*;
+    matches!(
+        io.kind(),
+        ConnectionRefused
+            | ConnectionReset
+            | ConnectionAborted
+            | NotConnected
+            | TimedOut
+            | UnexpectedEof
+            | Interrupted
+            | WouldBlock
+    )
+}
 
 #[derive(Debug, Args)]
 pub struct CommonStoreOptions {

--- a/api/src/repositories/common.rs
+++ b/api/src/repositories/common.rs
@@ -1,8 +1,10 @@
 use clap::Args;
+use tokio_postgres::error::SqlState;
 use validator_bonds_common::cli_result::CliError;
 
 pub fn pg_transient(err: tokio_postgres::Error) -> CliError {
     let is_transient = err.is_closed()
+        || err.code().is_some_and(is_transient_sql_state)
         || std::error::Error::source(&err)
             .and_then(|s| s.downcast_ref::<std::io::Error>())
             .map(is_transient_io_kind)
@@ -13,6 +15,18 @@ pub fn pg_transient(err: tokio_postgres::Error) -> CliError {
     } else {
         CliError::critical(err)
     }
+}
+
+// A server answer carries no IO error, yet a lost transaction race or an RDS failover must retry.
+fn is_transient_sql_state(code: &SqlState) -> bool {
+    matches!(
+        *code,
+        SqlState::T_R_SERIALIZATION_FAILURE
+            | SqlState::T_R_DEADLOCK_DETECTED
+            | SqlState::ADMIN_SHUTDOWN
+            | SqlState::CRASH_SHUTDOWN
+            | SqlState::CANNOT_CONNECT_NOW
+    )
 }
 
 fn is_transient_io_kind(io: &std::io::Error) -> bool {

--- a/api/src/repositories/mod.rs
+++ b/api/src/repositories/mod.rs
@@ -1,4 +1,5 @@
 pub mod bond;
+pub mod collected_stake;
 pub mod common;
 pub mod protected_events;
 pub mod verified_validators;

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -19,7 +19,9 @@ use tower_http::normalize_path::NormalizePath;
 
 use crate::api_docs::ApiDoc;
 use crate::context::WrappedContext;
-use crate::handlers::{bonds, docs, protected_events, protected_validators, verified_validators};
+use crate::handlers::{
+    bonds, collected_stake, docs, protected_events, protected_validators, verified_validators,
+};
 use crate::metrics::{healthz, metrics_handler, readyz, track_metrics};
 use crate::rate_limit::CfConnectingIpKeyExtractor;
 
@@ -55,8 +57,13 @@ pub fn public_data_routes(context: WrappedContext) -> Router {
         )
         .route("/bonds/institutional", get(bonds::handler_institutional))
         .route("/protected-events", get(protected_events::handler))
-        .route("/validators/verified", get(verified_validators::handler))
-        .route("/validators/protected", get(protected_validators::handler))
+        // The /validators family is versioned; the unversioned paths were removed, not aliased.
+        .route("/v1/validators/verified", get(verified_validators::handler))
+        .route(
+            "/v1/validators/protected",
+            get(protected_validators::handler),
+        )
+        .route("/v1/validators/stake", get(collected_stake::handler))
         .with_state(context)
 }
 

--- a/bonds-collector/src/bin/cli.rs
+++ b/bonds-collector/src/bin/cli.rs
@@ -1,5 +1,6 @@
 use bonds_collector::commands::bonds::collect_bonds;
-use bonds_collector::commands::common::CommonCollectOptions;
+use bonds_collector::commands::common::{CollectStakeOptions, CommonCollectOptions};
+use bonds_collector::commands::stake::collect_stake;
 use clap::{Args, Parser, Subcommand};
 use tracing_log::LogTracer;
 use validator_bonds_common::cli_result::CliResult;
@@ -22,6 +23,7 @@ struct Params {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     CollectBonds(CommonCollectOptions),
+    CollectStake(CollectStakeOptions),
 }
 
 #[tokio::main]
@@ -54,6 +56,7 @@ async fn real_main() -> anyhow::Result<()> {
 
     match params.command {
         Command::CollectBonds(options) => collect_bonds(options).await?,
+        Command::CollectStake(options) => collect_stake(options).await?,
     };
     Ok(())
 }

--- a/bonds-collector/src/commands/bonds.rs
+++ b/bonds-collector/src/commands/bonds.rs
@@ -9,8 +9,8 @@ use validator_bonds_common::funded_bonds::collect_validator_bonds_with_funds;
 
 pub async fn collect_bonds(options: CommonCollectOptions) -> anyhow::Result<()> {
     let rpc_client = Arc::new(get_rpc_client(
-        options.rpc_url,
-        options.commitment.to_string(),
+        options.rpc.rpc_url,
+        options.rpc.commitment.to_string(),
     ));
 
     let config_address = options.bond_type.config_address();

--- a/bonds-collector/src/commands/common.rs
+++ b/bonds-collector/src/commands/common.rs
@@ -10,12 +10,18 @@ fn parse_bond_type(s: &str) -> Result<BondType, String> {
 }
 
 #[derive(Debug, Args)]
-pub struct CommonCollectOptions {
+pub struct CommonRpcOptions {
     #[arg(short = 'u', env = "RPC_URL")]
     pub rpc_url: String,
 
     #[arg(long = "commitment", default_value = "confirmed")]
     pub commitment: CommitmentLevel,
+}
+
+#[derive(Debug, Args)]
+pub struct CommonCollectOptions {
+    #[command(flatten)]
+    pub rpc: CommonRpcOptions,
 
     #[arg(
         short = 't',
@@ -24,4 +30,13 @@ pub struct CommonCollectOptions {
         help = "Type of bond to collect (bidding or institutional)"
     )]
     pub bond_type: BondType,
+}
+
+#[derive(Debug, Args)]
+pub struct CollectStakeOptions {
+    #[command(flatten)]
+    pub rpc: CommonRpcOptions,
+
+    #[arg(long = "config", help = "Path to the collector YAML configuration")]
+    pub config: String,
 }

--- a/bonds-collector/src/commands/common.rs
+++ b/bonds-collector/src/commands/common.rs
@@ -39,4 +39,10 @@ pub struct CollectStakeOptions {
 
     #[arg(long = "config", help = "Path to the collector YAML configuration")]
     pub config: String,
+
+    #[arg(
+        long = "skip-locked",
+        help = "Exclude locked stake accounts from the collected amounts. Off by default: a lockup blocks withdrawing, not delegating or earning, so locked stake still needs bond coverage."
+    )]
+    pub skip_locked: bool,
 }

--- a/bonds-collector/src/commands/mod.rs
+++ b/bonds-collector/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod bonds;
 pub mod common;
+pub mod stake;

--- a/bonds-collector/src/commands/stake.rs
+++ b/bonds-collector/src/commands/stake.rs
@@ -29,6 +29,7 @@ pub async fn collect_stake(options: CollectStakeOptions) -> anyhow::Result<()> {
             .iter()
             .map(|authority| authority.stake_authority)
             .collect::<Vec<_>>(),
+        options.skip_locked,
     )
     .await?;
     let updated_at = chrono::Utc::now();

--- a/bonds-collector/src/commands/stake.rs
+++ b/bonds-collector/src/commands/stake.rs
@@ -1,0 +1,76 @@
+use crate::commands::common::CollectStakeOptions;
+use crate::config::load_collector_config;
+use crate::utils::rpc::get_rpc_client;
+use log::{log, Level};
+use serde_yaml;
+use std::sync::Arc;
+use validator_bonds_common::dto::CollectedStakeRecord;
+use validator_bonds_common::stake_accounts::collect_stake_by_authority;
+
+pub async fn collect_stake(options: CollectStakeOptions) -> anyhow::Result<()> {
+    let stake_authorities = load_collector_config(&options.config)?;
+    let rpc_client = Arc::new(get_rpc_client(
+        options.rpc.rpc_url,
+        options.rpc.commitment.to_string(),
+    ));
+
+    log!(
+        Level::Info,
+        "Collecting stake of {} authorities: {:?}",
+        stake_authorities.len(),
+        stake_authorities
+            .iter()
+            .map(|authority| authority.label.as_str())
+            .collect::<Vec<_>>()
+    );
+
+    let collected = collect_stake_by_authority(
+        rpc_client,
+        &stake_authorities
+            .iter()
+            .map(|authority| authority.stake_authority)
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+    let updated_at = chrono::Utc::now();
+
+    let mut records: Vec<CollectedStakeRecord> = vec![];
+    for authority in &stake_authorities {
+        let per_vote_account = collected
+            .authorities
+            .get(&authority.stake_authority)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Stake of '{}' ({}) was not collected",
+                    authority.label,
+                    authority.stake_authority
+                )
+            })?;
+        for (vote_account, aggregate) in per_vote_account {
+            records.push(CollectedStakeRecord {
+                epoch: collected.epoch,
+                slot: collected.slot,
+                label: authority.label.clone(),
+                stake_authority: authority.stake_authority.to_string(),
+                vote_account: vote_account.to_string(),
+                effective: aggregate.effective,
+                activating: aggregate.activating,
+                deactivating: aggregate.deactivating,
+                stake_accounts: aggregate.stake_accounts,
+                updated_at,
+            })
+        }
+    }
+
+    log!(
+        Level::Info,
+        "Collected {} stake records, epoch {}, slot {}",
+        records.len(),
+        collected.epoch,
+        collected.slot
+    );
+
+    serde_yaml::to_writer(std::io::stdout(), &records)?;
+
+    Ok(())
+}

--- a/bonds-collector/src/commands/stake.rs
+++ b/bonds-collector/src/commands/stake.rs
@@ -2,7 +2,6 @@ use crate::commands::common::CollectStakeOptions;
 use crate::config::load_collector_config;
 use crate::utils::rpc::get_rpc_client;
 use log::{log, Level};
-use serde_yaml;
 use std::sync::Arc;
 use validator_bonds_common::dto::CollectedStakeRecord;
 use validator_bonds_common::stake_accounts::collect_stake_by_authority;

--- a/bonds-collector/src/config.rs
+++ b/bonds-collector/src/config.rs
@@ -1,0 +1,127 @@
+use anyhow::Context;
+use serde::Deserialize;
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashSet;
+use std::str::FromStr;
+
+#[derive(Debug, Deserialize)]
+pub struct CollectorConfig {
+    pub collect_stake_authorities: Vec<StakeAuthorityEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StakeAuthorityEntry {
+    pub label: String,
+    pub stake_authority: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct StakeAuthority {
+    pub label: String,
+    pub stake_authority: Pubkey,
+}
+
+pub fn load_collector_config(path: &str) -> anyhow::Result<Vec<StakeAuthority>> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("Failed to open collector config '{path}'"))?;
+    let config: CollectorConfig = serde_yaml::from_reader(file)
+        .with_context(|| format!("Failed to parse collector config '{path}'"))?;
+    validate(config)
+}
+
+// Everything fails at load rather than mid-run: a dropped authority silently understates the stake
+// routed through Marinade, which would over-report bond coverage downstream.
+fn validate(config: CollectorConfig) -> anyhow::Result<Vec<StakeAuthority>> {
+    anyhow::ensure!(
+        !config.collect_stake_authorities.is_empty(),
+        "collect_stake_authorities must not be empty"
+    );
+
+    let mut labels = HashSet::new();
+    let mut authorities = HashSet::new();
+    let mut collected = vec![];
+    for entry in config.collect_stake_authorities {
+        let stake_authority = Pubkey::from_str(&entry.stake_authority).with_context(|| {
+            format!(
+                "Invalid stake authority '{}' of '{}'",
+                entry.stake_authority, entry.label
+            )
+        })?;
+        anyhow::ensure!(
+            labels.insert(entry.label.clone()),
+            "Duplicate label '{}'",
+            entry.label
+        );
+        anyhow::ensure!(
+            authorities.insert(stake_authority),
+            "Duplicate stake authority '{stake_authority}'"
+        );
+        collected.push(StakeAuthority {
+            label: entry.label,
+            stake_authority,
+        });
+    }
+
+    Ok(collected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A: &str = "stWirqFCf2Uts1JBL1Jsd3r6VBWhgnpdPxCTe1MFjrq";
+    const B: &str = "4bZ6o3eUUNXhKuqjdCnCoPAoLgWiuLYixKaxoa8PpiKk";
+
+    fn config(entries: &[(&str, &str)]) -> CollectorConfig {
+        CollectorConfig {
+            collect_stake_authorities: entries
+                .iter()
+                .map(|(label, stake_authority)| StakeAuthorityEntry {
+                    label: label.to_string(),
+                    stake_authority: stake_authority.to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn entries_keep_their_order_and_labels() {
+        let loaded = validate(config(&[("native", A), ("liquid", B)])).unwrap();
+        assert_eq!(
+            loaded
+                .iter()
+                .map(|entry| (entry.label.as_str(), entry.stake_authority.to_string()))
+                .collect::<Vec<_>>(),
+            vec![("native", A.to_string()), ("liquid", B.to_string())]
+        );
+    }
+
+    #[test]
+    fn an_invalid_pubkey_errors_with_its_label() {
+        let err = validate(config(&[("native", "not-a-pubkey")])).unwrap_err();
+        assert!(err.to_string().contains("not-a-pubkey"));
+        assert!(err.to_string().contains("native"));
+    }
+
+    #[test]
+    fn an_empty_list_errors() {
+        validate(config(&[])).unwrap_err();
+    }
+
+    #[test]
+    fn a_duplicate_label_errors() {
+        let err = validate(config(&[("native", A), ("native", B)])).unwrap_err();
+        assert!(err.to_string().contains("Duplicate label"));
+    }
+
+    #[test]
+    fn a_duplicate_stake_authority_errors() {
+        let err = validate(config(&[("native", A), ("native-again", A)])).unwrap_err();
+        assert!(err.to_string().contains("Duplicate stake authority"));
+    }
+
+    #[test]
+    fn a_missing_key_errors() {
+        serde_yaml::from_str::<CollectorConfig>("other: value").unwrap_err();
+    }
+}

--- a/bonds-collector/src/lib.rs
+++ b/bonds-collector/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod commands;
+pub mod config;
 pub mod utils;

--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -1,0 +1,26 @@
+---
+# Staker authorities of the Marinade products whose stake a validator bond has to cover.
+# Upstream registry: portfolio-api/packages/data/src/stake-groups.ts (native, select, direct);
+# liquid (mSOL) is not in that registry, so it lives only here.
+#
+# Deliberately excluded:
+#   - the native reward-token recipe authorities (stRcP4…/stR2tj…/stR3WD…/stR11we…/stR4sF…/stR5Et…/
+#     stR6sP…/stR7SJ…/stR8PF…/stR9fP…) — they delegate only to Marinade's own validator, which holds
+#     no bond. Add an entry here if a recipe is ever pointed at a bonded validator.
+#   - 9eG63CdHjsfhHmobHgLtESGC8GabbmRcaSpHAZrtmhco — that is liquid's stake *withdrawer*, paired with
+#     the staker 4bZ6o3eU… below, so it matches no stake account as a staker authority.
+collect_stake_authorities:
+  - label: liquid
+    stake_authority: 4bZ6o3eUUNXhKuqjdCnCoPAoLgWiuLYixKaxoa8PpiKk
+  - label: native
+    stake_authority: stWirqFCf2Uts1JBL1Jsd3r6VBWhgnpdPxCTe1MFjrq
+  - label: native-exit
+    stake_authority: ex9CfkBZZd6Nv9XdnoDmmB45ymbu4arXVk7g5pWnt3N
+  - label: select
+    stake_authority: STNi1NHDUi6Hvibvonawgze8fM83PFLeJhuGMEXyGps
+  - label: select-exit
+    stake_authority: EX1Fs34ajye3BTMSjTkMdZ8P4hb99vQFWzmueqhKGpH6
+  - label: direct
+    stake_authority: psrStL2hNx4c7hLUUks8SmDngeYriB8pF7uyHFhM8ir
+  - label: direct-exit
+    stake_authority: ExPsrC88dVCUozsuHFXYYpVGytsvwB9vWhwicuaFiypb

--- a/common-rs/Cargo.toml
+++ b/common-rs/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+agave-feature-set = { workspace = true }
 anchor-client = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
@@ -16,6 +17,7 @@ solana-stake-interface = { workspace = true }
 rust_decimal = { workspace = true, features = ["serde-float"] }
 solana-client = { workspace = true }
 solana-account-decoder = { workspace = true }
+solana-feature-gate-interface = { workspace = true }
 solana-program = { workspace = true }
 tokio = { workspace = true }
 validator-bonds = { workspace = true }

--- a/common-rs/src/dto.rs
+++ b/common-rs/src/dto.rs
@@ -55,6 +55,22 @@ impl fmt::Display for BondType {
     }
 }
 
+/// Stake routed to a validator through one Marinade product, identified by its staker authority.
+/// `deactivating` is a subset of `effective`, not an addend — see `stake_accounts::StakeAggregate`.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CollectedStakeRecord {
+    pub epoch: u64,
+    pub slot: u64,
+    pub label: String,
+    pub stake_authority: String,
+    pub vote_account: String,
+    pub effective: u64,
+    pub activating: u64,
+    pub deactivating: u64,
+    pub stake_accounts: u32,
+    pub updated_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ValidatorBondRecord {
     pub pubkey: String,

--- a/common-rs/src/stake_accounts.rs
+++ b/common-rs/src/stake_accounts.rs
@@ -1,4 +1,5 @@
 use crate::cli_result::CliError;
+use agave_feature_set::reduce_stake_warmup_cooldown;
 use log::{info, warn};
 use solana_account_decoder::UiAccountEncoding;
 use solana_client::{
@@ -6,10 +7,10 @@ use solana_client::{
     rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
     rpc_filter::{Memcmp, RpcFilterType},
 };
-use solana_program::stake::state::StakeStateV2;
+use solana_program::stake::state::{Delegation, StakeStateV2};
 use solana_program::stake_history::StakeHistoryEntry;
 use solana_sdk::{
-    clock::Clock,
+    clock::{Clock, Epoch},
     pubkey::Pubkey,
     stake_history::StakeHistory,
     sysvar::{clock, stake_history},
@@ -31,6 +32,59 @@ pub async fn get_clock(rpc_client: Arc<RpcClient>) -> anyhow::Result<Clock> {
     Ok(bincode::deserialize(
         &rpc_client.get_account_data(&clock::id()).await?,
     )?)
+}
+
+/// The epoch `reduce_stake_warmup_cooldown` activated on this cluster, mirroring Agave's
+/// `Bank::new_warmup_cooldown_rate_epoch`. `None` only when the cluster has not activated it.
+/// Never hardcode the epoch: the value decides between the pre-2024 25% and the current 9% rate.
+pub async fn get_new_rate_activation_epoch(
+    rpc_client: Arc<RpcClient>,
+) -> anyhow::Result<Option<Epoch>> {
+    let Some(account) = rpc_client
+        .get_account_with_commitment(&reduce_stake_warmup_cooldown::id(), rpc_client.commitment())
+        .await?
+        .value
+    else {
+        return Ok(None);
+    };
+    let feature = solana_feature_gate_interface::from_account(&account)
+        .ok_or_else(|| anyhow::anyhow!("Account {} is not a feature account", account.owner))?;
+    let epoch_schedule = rpc_client.get_epoch_schedule().await?;
+    Ok(feature
+        .activated_at
+        .map(|slot| epoch_schedule.get_epoch(slot)))
+}
+
+/// The three cluster values Agave's warmup/cooldown math needs, fetched together so they cannot be
+/// paired from different reads. Call `status` rather than `stake_activating_and_deactivating`
+/// directly — passing `None` as the activation epoch silently selects the legacy 25% rate.
+#[derive(Clone, Debug)]
+pub struct StakeActivation {
+    pub clock: Clock,
+    pub stake_history: StakeHistory,
+    pub new_rate_activation_epoch: Option<Epoch>,
+}
+
+impl StakeActivation {
+    pub async fn fetch(rpc_client: Arc<RpcClient>) -> anyhow::Result<Self> {
+        Ok(Self {
+            clock: get_clock(rpc_client.clone()).await?,
+            stake_history: get_stake_history(rpc_client.clone()).await?,
+            new_rate_activation_epoch: get_new_rate_activation_epoch(rpc_client).await?,
+        })
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.clock.epoch
+    }
+
+    pub fn status(&self, delegation: &Delegation) -> StakeHistoryEntry {
+        delegation.stake_activating_and_deactivating(
+            self.clock.epoch,
+            &self.stake_history,
+            self.new_rate_activation_epoch,
+        )
+    }
 }
 
 /// stake account pubkey, lamports in account, stake state
@@ -124,12 +178,11 @@ pub async fn obtain_claimable_stake_accounts_for_settlement(
     settlement_addresses: Vec<Pubkey>,
     rpc_client: Arc<RpcClient>,
 ) -> anyhow::Result<HashMap<Pubkey, (u64, CollectedStakeAccounts)>> {
-    let clock = get_clock(rpc_client.clone()).await?;
-    let stake_history = get_stake_history(rpc_client.clone()).await?;
+    let stake_activation = StakeActivation::fetch(rpc_client).await?;
     let filtered_deactivated_stake_accounts: CollectedStakeAccounts = stake_accounts
         .into_iter()
         .filter(|(pubkey, _, stake)| {
-            if is_locked(stake, &clock) {
+            if is_locked(stake, &stake_activation.clock) {
                 // cannot use locked stake account
                 warn!(
                     "Locked stake account {} found (withdrawer {}/staker {})",
@@ -145,10 +198,7 @@ pub async fn obtain_claimable_stake_accounts_for_settlement(
             } else if let Some(delegation) = stake.delegation() {
                 // stake has got delegation but is fully deactivated
                 // https://github.com/marinade-finance/native-staking/blob/master/bot/src/utils/stakes.rs#L64C1-L64C113
-                delegation
-                    .stake_activating_and_deactivating(clock.epoch, &stake_history, None)
-                    .effective
-                    == 0
+                stake_activation.status(&delegation).effective == 0
             } else {
                 // non-locked, non-delegated, maybe initialized (initialized has got authorities but not delegation)
                 // (more filtering under map_stake_accounts_to_settlement)
@@ -170,13 +220,12 @@ pub async fn obtain_funded_stake_accounts_for_settlement(
     stake_accounts: CollectedStakeAccounts,
     config_address: &Pubkey,
     settlement_addresses: Vec<Pubkey>,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
 ) -> anyhow::Result<HashMap<Pubkey, (u64, CollectedStakeAccounts)>> {
     let filtered_to_be_deactivated_stake_accounts: CollectedStakeAccounts = stake_accounts
         .into_iter()
         .filter(|(_, _, stake)| {
-            if is_locked(stake, clock) {
+            if is_locked(stake, &stake_activation.clock) {
                 // cannot use locked stake account
                 false
             } else if let Some(delegation) = stake.delegation() {
@@ -185,7 +234,7 @@ pub async fn obtain_funded_stake_accounts_for_settlement(
                     effective,
                     deactivating,
                     activating: _,
-                } = delegation.stake_activating_and_deactivating(clock.epoch, stake_history, None);
+                } = stake_activation.status(&delegation);
                 effective == 0 || deactivating > 0
             } else {
                 // non-locked, non-delegated, maybe initialized (more filtering under map_stake_accounts_to_settlement)
@@ -243,15 +292,20 @@ pub struct StakeAggregate {
 
 /// `deactivating` is a subset of `effective`, never additive: Agave's `with_deactivating` reports the
 /// cooling-down stake as effective for that epoch too. Active-only is `effective - deactivating`.
+///
+/// `skip_locked` defaults to off for measurement: a lockup gates only withdraw, merge and
+/// authorize-withdrawer, never delegation or rewards, so locked stake still earns and still needs
+/// bond coverage. The settlement paths keep their unconditional filter — there the account really
+/// cannot pay a claim.
 fn aggregate_stake_by_vote_account(
     stake_accounts: &CollectedStakeAccounts,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
+    skip_locked: bool,
 ) -> HashMap<Pubkey, StakeAggregate> {
     let mut per_vote_account: HashMap<Pubkey, StakeAggregate> = HashMap::new();
 
     for (_, _, stake) in stake_accounts {
-        if is_locked(stake, clock) {
+        if skip_locked && is_locked(stake, &stake_activation.clock) {
             continue;
         }
         let Some(delegation) = stake.delegation() else {
@@ -261,7 +315,7 @@ fn aggregate_stake_by_vote_account(
             effective,
             activating,
             deactivating,
-        } = delegation.stake_activating_and_deactivating(clock.epoch, stake_history, None);
+        } = stake_activation.status(&delegation);
 
         let aggregate = per_vote_account.entry(delegation.voter_pubkey).or_default();
         aggregate.effective += effective;
@@ -291,11 +345,9 @@ pub struct StakeByAuthority {
 pub async fn collect_stake_by_authority(
     rpc_client: Arc<RpcClient>,
     stake_authorities: &[Pubkey],
+    skip_locked: bool,
 ) -> Result<StakeByAuthority, CliError> {
-    let clock = get_clock(rpc_client.clone())
-        .await
-        .map_err(CliError::retry_able)?;
-    let stake_history = get_stake_history(rpc_client.clone())
+    let stake_activation = StakeActivation::fetch(rpc_client.clone())
         .await
         .map_err(CliError::retry_able)?;
 
@@ -306,7 +358,7 @@ pub async fn collect_stake_by_authority(
                 .await
                 .map_err(CliError::retry_able)?;
         let per_vote_account =
-            aggregate_stake_by_vote_account(&stake_accounts, &clock, &stake_history);
+            aggregate_stake_by_vote_account(&stake_accounts, &stake_activation, skip_locked);
 
         let effective: u64 = per_vote_account
             .values()
@@ -323,8 +375,8 @@ pub async fn collect_stake_by_authority(
     }
 
     Ok(StakeByAuthority {
-        epoch: clock.epoch,
-        slot: clock.slot,
+        epoch: stake_activation.clock.epoch,
+        slot: stake_activation.clock.slot,
         authorities,
     })
 }
@@ -367,16 +419,37 @@ mod tests {
         Pubkey::from_str_const("We11J5D4iXcNbdMwCZX2o9RRkwaWBo1AGLADfubmeTb")
     }
 
-    fn aggregate(states: Vec<StakeStateV2>) -> HashMap<Pubkey, StakeAggregate> {
+    fn activation(
+        new_rate_activation_epoch: Option<Epoch>,
+        stake_history: StakeHistory,
+    ) -> StakeActivation {
+        StakeActivation {
+            clock: Clock {
+                epoch: EPOCH,
+                ..Default::default()
+            },
+            stake_history,
+            new_rate_activation_epoch,
+        }
+    }
+
+    fn aggregate_with(
+        states: Vec<StakeStateV2>,
+        skip_locked: bool,
+    ) -> HashMap<Pubkey, StakeAggregate> {
         let accounts: CollectedStakeAccounts = states
             .into_iter()
             .map(|state| (Pubkey::new_unique(), STAKE, state))
             .collect();
-        let clock = Clock {
-            epoch: EPOCH,
-            ..Default::default()
-        };
-        aggregate_stake_by_vote_account(&accounts, &clock, &StakeHistory::default())
+        aggregate_stake_by_vote_account(
+            &accounts,
+            &activation(Some(EPOCH - 1), StakeHistory::default()),
+            skip_locked,
+        )
+    }
+
+    fn aggregate(states: Vec<StakeStateV2>) -> HashMap<Pubkey, StakeAggregate> {
+        aggregate_with(states, false)
     }
 
     fn only(states: Vec<StakeStateV2>) -> StakeAggregate {
@@ -430,9 +503,31 @@ mod tests {
         assert!(aggregate(vec![stake_state(EPOCH - 2, EPOCH - 1, 0)]).is_empty());
     }
 
+    // A lockup gates withdraw, merge and authorize-withdrawer — never delegation or rewards. The
+    // stake still earns for its owner, so the measurement counts it unless explicitly asked not to.
     #[test]
-    fn a_locked_stake_account_is_skipped() {
-        assert!(aggregate(vec![stake_state(EPOCH - 1, u64::MAX, EPOCH + 1)]).is_empty());
+    fn a_locked_stake_account_is_counted_by_default() {
+        assert_eq!(
+            only(vec![stake_state(EPOCH - 1, u64::MAX, EPOCH + 1)]),
+            StakeAggregate {
+                effective: STAKE,
+                activating: 0,
+                deactivating: 0,
+                stake_accounts: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn a_locked_stake_account_is_skipped_when_asked() {
+        assert!(aggregate_with(vec![stake_state(EPOCH - 1, u64::MAX, EPOCH + 1)], true).is_empty());
+    }
+
+    #[test]
+    fn an_expired_lockup_is_counted_even_when_skipping() {
+        assert!(
+            !aggregate_with(vec![stake_state(EPOCH - 1, u64::MAX, EPOCH - 1)], true).is_empty()
+        );
     }
 
     #[test]
@@ -454,6 +549,49 @@ mod tests {
                 deactivating: 0,
                 stake_accounts: 3,
             }
+        );
+    }
+
+    // Guards the activation epoch itself: `None` selects the pre-2024 25% rate and cools the account
+    // down almost three times too fast. Needs a cooldown queue larger than the 9% cap, or the rate
+    // never binds and both values agree.
+    #[test]
+    fn the_activation_epoch_selects_the_cooldown_rate() {
+        const CLUSTER: u64 = 1_000_000;
+
+        let cooled_down_to = |new_rate_activation_epoch| {
+            let mut stake_history = StakeHistory::default();
+            stake_history.add(
+                EPOCH - 1,
+                StakeHistoryEntry {
+                    effective: CLUSTER,
+                    activating: 0,
+                    deactivating: CLUSTER,
+                },
+            );
+            let accounts: CollectedStakeAccounts = vec![(
+                Pubkey::new_unique(),
+                STAKE,
+                stake_state(EPOCH - 3, EPOCH - 1, 0),
+            )];
+            aggregate_stake_by_vote_account(
+                &accounts,
+                &activation(new_rate_activation_epoch, stake_history),
+                false,
+            )
+            .get(&vote_account())
+            .unwrap()
+            .effective
+        };
+
+        let share = STAKE as f64 / CLUSTER as f64;
+        assert_eq!(
+            cooled_down_to(Some(EPOCH - 1)),
+            STAKE - (share * CLUSTER as f64 * 0.09) as u64
+        );
+        assert_eq!(
+            cooled_down_to(None),
+            STAKE - (share * CLUSTER as f64 * 0.25) as u64
         );
     }
 }

--- a/common-rs/src/stake_accounts.rs
+++ b/common-rs/src/stake_accounts.rs
@@ -1,5 +1,6 @@
+use crate::cli_result::CliError;
 use log::{info, warn};
-use solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig};
+use solana_account_decoder::UiAccountEncoding;
 use solana_client::{
     nonblocking::rpc_client::RpcClient,
     rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
@@ -232,79 +233,215 @@ fn map_stake_accounts_to_settlement(
         .collect::<HashMap<_, _>>()
 }
 
-pub async fn get_stake_account_slices(
-    rpc_client: Arc<RpcClient>,
-    stake_authority: Option<Pubkey>,
-    slice: Option<(usize, usize)>,
-    fetch_pause_millis: Option<u64>,
-) -> (Vec<(Pubkey, StakeStateV2)>, Option<anyhow::Error>) {
-    info!("Fetching stake account slices {slice:?} with stake authority: {stake_authority:?}");
-    let mut stake_accounts_count = 0;
-    let data_slice = slice.map(|(offset, length)| UiDataSliceConfig { offset, length });
-    let mut stake_accounts: Vec<(Pubkey, StakeStateV2)> = vec![];
-    let mut errors: Vec<String> = vec![];
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct StakeAggregate {
+    pub effective: u64,
+    pub activating: u64,
+    pub deactivating: u64,
+    pub stake_accounts: u32,
+}
 
-    for page in 0..=u8::MAX {
-        let mut filters: Vec<RpcFilterType> = vec![RpcFilterType::DataSize(200)];
-        if let Some(stake_authority) = stake_authority {
-            filters.push(RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
-                4 + 8,
-                stake_authority.to_bytes().to_vec(),
-            )));
+/// `deactivating` is a subset of `effective`, never additive: Agave's `with_deactivating` reports the
+/// cooling-down stake as effective for that epoch too. Active-only is `effective - deactivating`.
+fn aggregate_stake_by_vote_account(
+    stake_accounts: &CollectedStakeAccounts,
+    clock: &Clock,
+    stake_history: &StakeHistory,
+) -> HashMap<Pubkey, StakeAggregate> {
+    let mut per_vote_account: HashMap<Pubkey, StakeAggregate> = HashMap::new();
+
+    for (_, _, stake) in stake_accounts {
+        if is_locked(stake, clock) {
+            continue;
         }
-        filters.push(RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
-            4 + 8 + 32,
-            vec![page],
-        )));
-        let result = rpc_client
-            .get_program_accounts_with_config(
-                &stake_program_id,
-                RpcProgramAccountsConfig {
-                    filters: Some(filters.clone()),
-                    account_config: RpcAccountInfoConfig {
-                        encoding: Some(UiAccountEncoding::Base64),
-                        commitment: Some(rpc_client.commitment()),
-                        data_slice,
-                        min_context_slot: None,
-                    },
-                    with_context: None,
-                    sort_results: None,
-                },
-            )
-            .await;
-        match result {
-            Ok(accounts) => {
-                stake_accounts_count += accounts.len();
-                for (pubkey, account) in accounts {
-                    let stake_state = bincode::deserialize(&account.data).unwrap_or_else(|_| {
-                        panic!("Failed to deserialize stake account data for {pubkey}")
-                    });
-                    stake_accounts.push((pubkey, stake_state));
-                }
-            }
-            Err(err) => {
-                errors.push(format!("Failed to fetch stake accounts slice: {err:?}"));
-            }
+        let Some(delegation) = stake.delegation() else {
+            continue;
         };
+        let StakeHistoryEntry {
+            effective,
+            activating,
+            deactivating,
+        } = delegation.stake_activating_and_deactivating(clock.epoch, stake_history, None);
 
-        // pause between fetches to not overwhelming the RPC with many requests
-        if let Some(fetch_pause) = fetch_pause_millis {
-            tokio::time::sleep(tokio::time::Duration::from_millis(fetch_pause)).await;
-        }
+        let aggregate = per_vote_account.entry(delegation.voter_pubkey).or_default();
+        aggregate.effective += effective;
+        aggregate.activating += activating;
+        aggregate.deactivating += deactivating;
+        aggregate.stake_accounts += 1;
     }
 
-    info!(
-        "Loaded {} stake accounts with filter: {:?}",
-        stake_accounts_count,
-        (stake_authority, slice)
-    );
-    let result_error = if errors.is_empty() {
-        None
-    } else {
-        Some(anyhow::anyhow!(
-            "Failed to fetch stake accounts: {errors:?}"
-        ))
-    };
+    // Fully cooled-down accounts keep their delegation, so they would otherwise contribute rows
+    // carrying no stake at all — 878 of them on the native exit authority for 14 SOL.
+    per_vote_account.retain(|_, aggregate| {
+        aggregate.effective + aggregate.activating + aggregate.deactivating > 0
+    });
+    per_vote_account
+}
 
-    (stake_accounts, result_error)
+/// Marinade-routed stake per staker authority, per vote account. Errors are never partial: a missing
+/// authority understates the stake and would over-report bond coverage downstream.
+pub async fn collect_stake_by_authority(
+    rpc_client: Arc<RpcClient>,
+    stake_authorities: &[Pubkey],
+) -> Result<HashMap<Pubkey, HashMap<Pubkey, StakeAggregate>>, CliError> {
+    let clock = get_clock(rpc_client.clone())
+        .await
+        .map_err(CliError::retry_able)?;
+    let stake_history = get_stake_history(rpc_client.clone())
+        .await
+        .map_err(CliError::retry_able)?;
+
+    let mut collected = HashMap::new();
+    for stake_authority in stake_authorities {
+        let stake_accounts =
+            collect_stake_accounts(rpc_client.clone(), None, Some(stake_authority))
+                .await
+                .map_err(CliError::retry_able)?;
+        let per_vote_account =
+            aggregate_stake_by_vote_account(&stake_accounts, &clock, &stake_history);
+
+        let effective: u64 = per_vote_account
+            .values()
+            .map(|aggregate| aggregate.effective)
+            .sum();
+        info!(
+            "Stake authority {stake_authority}: {} accounts, {} vote accounts, {} lamports effective",
+            stake_accounts.len(),
+            per_vote_account.len(),
+            effective
+        );
+
+        collected.insert(*stake_authority, per_vote_account);
+    }
+
+    Ok(collected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_program::stake::state::{Delegation, Meta, Stake};
+    use solana_stake_interface::stake_flags::StakeFlags;
+
+    const EPOCH: u64 = 1014;
+    const STAKE: u64 = 100_000;
+
+    // An empty StakeHistory makes the Agave warmup/cooldown math deterministic: outside the
+    // activation and deactivation epochs it reports the delegation verbatim or nothing at all.
+    fn stake_state(
+        activation_epoch: u64,
+        deactivation_epoch: u64,
+        lockup_epoch: u64,
+    ) -> StakeStateV2 {
+        let mut meta = Meta::default();
+        meta.lockup.epoch = lockup_epoch;
+        StakeStateV2::Stake(
+            meta,
+            Stake {
+                delegation: Delegation {
+                    voter_pubkey: vote_account(),
+                    stake: STAKE,
+                    activation_epoch,
+                    deactivation_epoch,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            StakeFlags::empty(),
+        )
+    }
+
+    fn vote_account() -> Pubkey {
+        Pubkey::from_str_const("We11J5D4iXcNbdMwCZX2o9RRkwaWBo1AGLADfubmeTb")
+    }
+
+    fn aggregate(states: Vec<StakeStateV2>) -> HashMap<Pubkey, StakeAggregate> {
+        let accounts: CollectedStakeAccounts = states
+            .into_iter()
+            .map(|state| (Pubkey::new_unique(), STAKE, state))
+            .collect();
+        let clock = Clock {
+            epoch: EPOCH,
+            ..Default::default()
+        };
+        aggregate_stake_by_vote_account(&accounts, &clock, &StakeHistory::default())
+    }
+
+    fn only(states: Vec<StakeStateV2>) -> StakeAggregate {
+        let aggregated = aggregate(states);
+        assert_eq!(aggregated.len(), 1, "expected one vote account");
+        aggregated.get(&vote_account()).unwrap().clone()
+    }
+
+    #[test]
+    fn activated_stake_is_effective() {
+        assert_eq!(
+            only(vec![stake_state(EPOCH - 1, u64::MAX, 0)]),
+            StakeAggregate {
+                effective: STAKE,
+                activating: 0,
+                deactivating: 0,
+                stake_accounts: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn stake_activating_this_epoch_is_not_effective_yet() {
+        assert_eq!(
+            only(vec![stake_state(EPOCH, u64::MAX, 0)]),
+            StakeAggregate {
+                effective: 0,
+                activating: STAKE,
+                deactivating: 0,
+                stake_accounts: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn deactivating_stake_is_still_reported_as_effective() {
+        // The subset invariant: summing effective + deactivating would double-count this stake.
+        assert_eq!(
+            only(vec![stake_state(EPOCH - 1, EPOCH, 0)]),
+            StakeAggregate {
+                effective: STAKE,
+                activating: 0,
+                deactivating: STAKE,
+                stake_accounts: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn a_fully_deactivated_vote_account_is_dropped() {
+        assert!(aggregate(vec![stake_state(EPOCH - 2, EPOCH - 1, 0)]).is_empty());
+    }
+
+    #[test]
+    fn a_locked_stake_account_is_skipped() {
+        assert!(aggregate(vec![stake_state(EPOCH - 1, u64::MAX, EPOCH + 1)]).is_empty());
+    }
+
+    #[test]
+    fn a_stake_account_without_delegation_is_skipped() {
+        assert!(aggregate(vec![StakeStateV2::Initialized(Meta::default())]).is_empty());
+    }
+
+    #[test]
+    fn accounts_of_one_vote_account_are_summed() {
+        assert_eq!(
+            only(vec![
+                stake_state(EPOCH - 1, u64::MAX, 0),
+                stake_state(EPOCH - 1, u64::MAX, 0),
+                stake_state(EPOCH, u64::MAX, 0),
+            ]),
+            StakeAggregate {
+                effective: 2 * STAKE,
+                activating: STAKE,
+                deactivating: 0,
+                stake_accounts: 3,
+            }
+        );
+    }
 }

--- a/common-rs/src/stake_accounts.rs
+++ b/common-rs/src/stake_accounts.rs
@@ -278,12 +278,20 @@ fn aggregate_stake_by_vote_account(
     per_vote_account
 }
 
+/// `epoch`/`slot` are the ones the amounts were computed against, so a caller stamping a snapshot
+/// cannot pair them with a different clock than the warmup/cooldown math used.
+pub struct StakeByAuthority {
+    pub epoch: u64,
+    pub slot: u64,
+    pub authorities: HashMap<Pubkey, HashMap<Pubkey, StakeAggregate>>,
+}
+
 /// Marinade-routed stake per staker authority, per vote account. Errors are never partial: a missing
 /// authority understates the stake and would over-report bond coverage downstream.
 pub async fn collect_stake_by_authority(
     rpc_client: Arc<RpcClient>,
     stake_authorities: &[Pubkey],
-) -> Result<HashMap<Pubkey, HashMap<Pubkey, StakeAggregate>>, CliError> {
+) -> Result<StakeByAuthority, CliError> {
     let clock = get_clock(rpc_client.clone())
         .await
         .map_err(CliError::retry_able)?;
@@ -291,7 +299,7 @@ pub async fn collect_stake_by_authority(
         .await
         .map_err(CliError::retry_able)?;
 
-    let mut collected = HashMap::new();
+    let mut authorities = HashMap::new();
     for stake_authority in stake_authorities {
         let stake_accounts =
             collect_stake_accounts(rpc_client.clone(), None, Some(stake_authority))
@@ -311,10 +319,14 @@ pub async fn collect_stake_by_authority(
             effective
         );
 
-        collected.insert(*stake_authority, per_vote_account);
+        authorities.insert(*stake_authority, per_vote_account);
     }
 
-    Ok(collected)
+    Ok(StakeByAuthority {
+        epoch: clock.epoch,
+        slot: clock.slot,
+        authorities,
+    })
 }
 
 #[cfg(test)]

--- a/common-rs/src/stake_accounts.rs
+++ b/common-rs/src/stake_accounts.rs
@@ -40,15 +40,16 @@ pub async fn get_clock(rpc_client: Arc<RpcClient>) -> anyhow::Result<Clock> {
 pub async fn get_new_rate_activation_epoch(
     rpc_client: Arc<RpcClient>,
 ) -> anyhow::Result<Option<Epoch>> {
+    let feature_id = reduce_stake_warmup_cooldown::id();
     let Some(account) = rpc_client
-        .get_account_with_commitment(&reduce_stake_warmup_cooldown::id(), rpc_client.commitment())
+        .get_account_with_commitment(&feature_id, rpc_client.commitment())
         .await?
         .value
     else {
         return Ok(None);
     };
     let feature = solana_feature_gate_interface::from_account(&account)
-        .ok_or_else(|| anyhow::anyhow!("Account {} is not a feature account", account.owner))?;
+        .ok_or_else(|| anyhow::anyhow!("Account {feature_id} is not a feature account"))?;
     let epoch_schedule = rpc_client.get_epoch_schedule().await?;
     Ok(feature
         .activated_at
@@ -324,8 +325,7 @@ fn aggregate_stake_by_vote_account(
         aggregate.stake_accounts += 1;
     }
 
-    // Fully cooled-down accounts keep their delegation, so they would otherwise contribute rows
-    // carrying no stake at all — 878 of them on the native exit authority for 14 SOL.
+    // Fully cooled-down accounts keep their delegation: 878 such rows on native-exit, for 14 SOL.
     per_vote_account.retain(|_, aggregate| {
         aggregate.effective + aggregate.activating + aggregate.deactivating > 0
     });
@@ -374,6 +374,18 @@ pub async fn collect_stake_by_authority(
         authorities.insert(*stake_authority, per_vote_account);
     }
 
+    // A rollover mid-run would stamp the starting epoch onto accounts scanned after it.
+    let end_epoch = get_clock(rpc_client)
+        .await
+        .map_err(CliError::retry_able)?
+        .epoch;
+    if end_epoch != stake_activation.clock.epoch {
+        return Err(CliError::retry_able(anyhow::anyhow!(
+            "Epoch changed during stake collection: {} -> {end_epoch}",
+            stake_activation.clock.epoch
+        )));
+    }
+
     Ok(StakeByAuthority {
         epoch: stake_activation.clock.epoch,
         slot: stake_activation.clock.slot,
@@ -390,8 +402,7 @@ mod tests {
     const EPOCH: u64 = 1014;
     const STAKE: u64 = 100_000;
 
-    // An empty StakeHistory makes the Agave warmup/cooldown math deterministic: outside the
-    // activation and deactivation epochs it reports the delegation verbatim or nothing at all.
+    // An empty StakeHistory makes Agave report the delegation verbatim, so the epochs alone drive it.
     fn stake_state(
         activation_epoch: u64,
         deactivation_epoch: u64,
@@ -503,8 +514,7 @@ mod tests {
         assert!(aggregate(vec![stake_state(EPOCH - 2, EPOCH - 1, 0)]).is_empty());
     }
 
-    // A lockup gates withdraw, merge and authorize-withdrawer — never delegation or rewards. The
-    // stake still earns for its owner, so the measurement counts it unless explicitly asked not to.
+    // A lockup gates withdraw, merge and authorize-withdrawer — never delegation, so it still earns.
     #[test]
     fn a_locked_stake_account_is_counted_by_default() {
         assert_eq!(
@@ -552,9 +562,7 @@ mod tests {
         );
     }
 
-    // Guards the activation epoch itself: `None` selects the pre-2024 25% rate and cools the account
-    // down almost three times too fast. Needs a cooldown queue larger than the 9% cap, or the rate
-    // never binds and both values agree.
+    // Needs a cooldown queue above the 9% cap, or the rate never binds and both values agree.
     #[test]
     fn the_activation_epoch_selects_the_cooldown_rate() {
         const CLUSTER: u64 = 1_000_000;

--- a/migrations/0012-add-collected-stake.sql
+++ b/migrations/0012-add-collected-stake.sql
@@ -1,0 +1,19 @@
+-- Marinade-routed stake per validator per configured staker authority, written by
+-- `bonds-collector collect-stake`. Readers pin epoch = MAX(epoch), the same contract as `bonds`.
+-- `deactivating` is a SUBSET of `effective`, never an addend: Agave keeps stake in its deactivation
+-- epoch effective for that epoch, so active-only is `effective - deactivating`.
+-- The UNIQUE index leads on epoch, so it also serves the MAX(epoch) lookup; no extra index needed.
+CREATE TABLE collected_stake (
+    id              BIGSERIAL PRIMARY KEY,
+    epoch           INTEGER     NOT NULL,
+    slot            BIGINT      NOT NULL,
+    label           TEXT        NOT NULL,
+    stake_authority TEXT        NOT NULL,
+    vote_account    TEXT        NOT NULL,
+    effective       BIGINT      NOT NULL,
+    activating      BIGINT      NOT NULL,
+    deactivating    BIGINT      NOT NULL,
+    stake_accounts  INTEGER     NOT NULL,
+    updated_at      TIMESTAMPTZ NOT NULL,
+    UNIQUE (epoch, stake_authority, vote_account)
+);

--- a/programs/validator-bonds/src/checks.rs
+++ b/programs/validator-bonds/src/checks.rs
@@ -199,6 +199,8 @@ pub fn check_stake_exist_and_activating_or_activated(
             deactivating,
         } = stake
             .delegation
+            // `None` selects the legacy 25% rate, but the verdict below is the same under either:
+            // warmup keeps `effective + activating` whole, cooldown rejects on one clause or the other.
             .stake_activating_and_deactivating(epoch, stake_history, None);
         if (effective == 0 && activating == 0) || deactivating > 0 {
             msg!(

--- a/settlement-pipelines/src/bin/claim_settlement.rs
+++ b/settlement-pipelines/src/bin/claim_settlement.rs
@@ -25,10 +25,8 @@ use settlement_pipelines::stake_accounts_cache::StakeAccountsCache;
 use settlement_pipelines::FINALIZATION_WAIT_TIMEOUT;
 use solana_cli_output::display::build_balance_message;
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::clock::Clock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::stake::program::ID as stake_program_id;
-use solana_sdk::stake_history::StakeHistory;
 use solana_sdk::sysvar::{clock::ID as clock_id, stake_history::ID as stake_history_id};
 use solana_transaction_builder::TransactionBuilder;
 use solana_transaction_executor::{PriorityFeePolicy, TransactionExecutor};
@@ -52,7 +50,7 @@ use validator_bonds_common::settlements::{
     get_settlement_claims_for_settlement_pubkeys, get_settlements_for_pubkeys,
 };
 use validator_bonds_common::stake_accounts::{
-    collect_stake_accounts, get_clock, get_stake_history, CollectedStakeAccounts,
+    collect_stake_accounts, CollectedStakeAccounts, StakeActivation,
 };
 
 #[derive(Parser, Debug)]
@@ -169,10 +167,7 @@ async fn real_main(
     let mut transaction_builder = TransactionBuilder::limited(fee_payer.clone());
     let transaction_executor = get_executor(rpc_client.clone(), tip_policy);
 
-    let clock = get_clock(rpc_client.clone())
-        .await
-        .map_err(CliError::retry_able)?;
-    let stake_history = get_stake_history(rpc_client.clone())
+    let stake_activation = StakeActivation::fetch(rpc_client.clone())
         .await
         .map_err(CliError::retry_able)?;
 
@@ -181,8 +176,7 @@ async fn real_main(
         &program,
         &config_address,
         &mut transaction_builder,
-        &clock,
-        &stake_history,
+        &stake_activation,
         rpc_client.clone(),
         transaction_executor.clone(),
         &priority_fee_policy,
@@ -228,8 +222,7 @@ async fn real_main(
             &mut settlement_claimed_amounts,
             &mut stake_accounts_to_cache,
             minimal_stake_lamports,
-            &clock,
-            &stake_history,
+            &stake_activation,
         )
         .await?;
     }
@@ -244,8 +237,7 @@ async fn merge_stake_accounts(
     program: &Program<Arc<DynSigner>>,
     config_address: &Pubkey,
     transaction_builder: &mut TransactionBuilder,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
     rpc_client: Arc<RpcClient>,
     transaction_executor: Arc<TransactionExecutor>,
     priority_fee_policy: &PriorityFeePolicy,
@@ -255,7 +247,7 @@ async fn merge_stake_accounts(
     for claimable_settlement in claimable_settlements.iter() {
         let mergeable_stake_accounts = if claimable_settlement.stake_accounts.len() > 1 {
             let destination_stake = claimable_settlement.stake_accounts[0];
-            let destination_type = get_stake_state_type(&destination_stake.2, clock, stake_history);
+            let destination_type = get_stake_state_type(&destination_stake.2, stake_activation);
             let possible_to_merge = claimable_settlement.stake_accounts.iter().skip(1).collect();
             settlements_with_merge_operation.insert(claimable_settlement.settlement_address);
             Some((destination_stake.0, destination_type, possible_to_merge))
@@ -275,8 +267,7 @@ async fn merge_stake_accounts(
                 config_address,
                 &find_settlement_staker_authority(&claimable_settlement.settlement_address).0,
                 transaction_builder,
-                clock,
-                stake_history,
+                stake_activation,
             )
             .await?;
         }
@@ -323,8 +314,7 @@ async fn claim_settlement<'a>(
     settlement_claimed_amounts: &mut HashMap<Pubkey, u64>,
     stake_accounts_to_cache: &mut StakeAccountsCache<'a>,
     minimal_stake_lamports: u64,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
 ) -> anyhow::Result<()> {
     let (bonds_withdrawer_authority, _) = find_bonds_withdrawer_authority(config_address);
     let empty_stake_accounts: CollectedStakeAccounts = vec![];
@@ -420,8 +410,7 @@ async fn claim_settlement<'a>(
             });
         let stake_account_to = prioritize_for_claiming(
             stake_accounts_to,
-            clock,
-            stake_history,
+            stake_activation,
         ).map_or_else(|e| {
             reporting.warning().with_msg(format!(
                 "No available stake account found where to claim into of staker/withdraw authorities {}/{} (epoch: {}, settlement: {}, claim: {}, index: {}): {:?}",

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -56,8 +56,8 @@ use validator_bonds_common::cli_result::{CliError, CliResult};
 use validator_bonds_common::config::get_config;
 use validator_bonds_common::constants::find_event_authority;
 use validator_bonds_common::stake_accounts::{
-    collect_stake_accounts, get_clock, get_stake_history, obtain_delegated_stake_accounts,
-    CollectedStakeAccount, CollectedStakeAccounts,
+    collect_stake_accounts, obtain_delegated_stake_accounts, CollectedStakeAccount,
+    CollectedStakeAccounts, StakeActivation,
 };
 
 #[derive(Parser, Debug)]
@@ -215,17 +215,17 @@ async fn prepare_funding(
             .await
             .map_err(CliError::retry_able)?;
 
-    let clock = get_clock(rpc_client.clone())
-        .await
-        .map_err(CliError::retry_able)?;
-    let stake_history = get_stake_history(rpc_client.clone())
+    let stake_activation = StakeActivation::fetch(rpc_client.clone())
         .await
         .map_err(CliError::retry_able)?;
     let minimal_stake_lamports = config.minimum_stake_lamports + STAKE_ACCOUNT_RENT_EXEMPTION;
 
-    let mut fund_bond_stake_accounts =
-        get_on_chain_bond_stake_accounts(&all_stake_accounts, &withdrawer_authority, &clock)
-            .await?;
+    let mut fund_bond_stake_accounts = get_on_chain_bond_stake_accounts(
+        &all_stake_accounts,
+        &withdrawer_authority,
+        &stake_activation.clock,
+    )
+    .await?;
 
     let epochs_pending_init = epochs_pending_on_chain_init(settlement_records);
 
@@ -264,7 +264,7 @@ async fn prepare_funding(
             }
             continue;
         }
-        if epoch + config.epochs_to_claim_settlement < clock.epoch {
+        if epoch + config.epochs_to_claim_settlement < stake_activation.clock.epoch {
             reporting.warning().with_msg(format!(
                 "Settlement {} (vote account {}, bond {}, epoch {}, reason {}) is too old to be funded, skipping funding",
                 settlement_record.settlement_address,
@@ -385,8 +385,7 @@ async fn prepare_funding(
                 }
                 // prioritize the biggest undelegated (inactive) amounts first
                 funding_stake_accounts.sort_by_cached_key(|account| {
-                    let delegated_amount =
-                        get_delegated_amount(&account.state, &clock, &stake_history);
+                    let delegated_amount = get_delegated_amount(&account.state, &stake_activation);
                     account.lamports.saturating_sub(delegated_amount)
                 });
                 funding_stake_accounts.reverse();
@@ -432,8 +431,7 @@ async fn prepare_funding(
                         None
                     } else {
                         let account = stake_accounts_to_fund.remove(0);
-                        let stake_type =
-                            get_stake_state_type(&account.state, &clock, &stake_history);
+                        let stake_type = get_stake_state_type(&account.state, &stake_activation);
                         Some((account, stake_type))
                     };
                 if let Some((
@@ -462,8 +460,7 @@ async fn prepare_funding(
                         config_address,
                         &withdrawer_authority,
                         &mut transaction_builder,
-                        &clock,
-                        &stake_history,
+                        &stake_activation,
                     )
                     .await?;
 

--- a/settlement-pipelines/src/bin/merge_stakes.rs
+++ b/settlement-pipelines/src/bin/merge_stakes.rs
@@ -1,5 +1,3 @@
-use anchor_client::anchor_lang::prelude::StakeHistory;
-
 use anchor_client::anchor_lang::solana_program::stake::state::StakeStateV2;
 
 use anchor_client::{DynSigner, Program};
@@ -23,7 +21,6 @@ use settlement_pipelines::stake_accounts::{
     get_stake_state_type, prepare_merge_instructions, StakeAccountStateType,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::clock::Clock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 
@@ -41,7 +38,7 @@ use validator_bonds::state::config::find_bonds_withdrawer_authority;
 use validator_bonds_common::config::get_config;
 
 use validator_bonds_common::stake_accounts::{
-    collect_stake_accounts, get_clock, get_stake_history, CollectedStakeAccount,
+    collect_stake_accounts, CollectedStakeAccount, StakeActivation,
 };
 
 #[derive(Parser, Debug)]
@@ -98,18 +95,14 @@ async fn real_main(
 
     reporting.reportable.init(&config_address).await;
 
-    let clock = get_clock(rpc_client.clone())
-        .await
-        .map_err(CliError::retry_able)?;
-    let stake_history = get_stake_history(rpc_client.clone())
+    let stake_activation = StakeActivation::fetch(rpc_client.clone())
         .await
         .map_err(CliError::retry_able)?;
 
     let loaded_stake = get_merge_stake_accounts(
         rpc_client.clone(),
         &config_address,
-        &clock,
-        &stake_history,
+        &stake_activation,
         reporting,
     )
     .await?;
@@ -122,8 +115,7 @@ async fn real_main(
         &config_address,
         fee_payer.clone(),
         &priority_fee_policy,
-        &clock,
-        &stake_history,
+        &stake_activation,
         reporting,
     )
     .await?;
@@ -146,8 +138,7 @@ fn is_transient_stake(inner_stake: &Stake, state_type: StakeAccountStateType) ->
 async fn get_merge_stake_accounts(
     rpc_client: Arc<RpcClient>,
     config_address: &Pubkey,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
     report_handler: &mut ReportHandler<MergeConfigReport>,
 ) -> anyhow::Result<GetMergeType> {
     let (withdrawer_authority, _) = find_bonds_withdrawer_authority(config_address);
@@ -163,7 +154,7 @@ async fn get_merge_stake_accounts(
     let mut delegation_stake_accounts: GetMergeType = HashMap::new();
     for stake in non_funded_stake_accounts.into_iter() {
         if let StakeStateV2::Stake(_, inner_stake, _) = stake.2 {
-            let state_type = get_stake_state_type(&stake.2, clock, stake_history);
+            let state_type = get_stake_state_type(&stake.2, stake_activation);
             let key = (inner_stake.delegation.voter_pubkey, state_type);
 
             if is_transient_stake(&inner_stake, state_type) {
@@ -198,8 +189,7 @@ async fn merge_stake(
     config_address: &Pubkey,
     fee_payer: Arc<Keypair>,
     priority_fee_policy: &PriorityFeePolicy,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
     reporting: &mut ReportHandler<MergeConfigReport>,
 ) -> anyhow::Result<()> {
     let mut transaction_builder = TransactionBuilder::limited(fee_payer.clone());
@@ -228,8 +218,7 @@ async fn merge_stake(
             config_address,
             &withdrawer_authority,
             &mut transaction_builder,
-            clock,
-            stake_history,
+            stake_activation,
         )
         .await?;
         if !non_mergeable.is_empty() {

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -7,7 +7,6 @@ use solana_sdk::clock::Clock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::stake::program::ID as stake_program_id;
 use solana_sdk::stake::state::StakeStateV2;
-use solana_sdk::stake_history::StakeHistory;
 use solana_sdk::sysvar::{
     clock::ID as clock_sysvar_id, stake_history::ID as stake_history_sysvar_id,
 };
@@ -19,7 +18,7 @@ use validator_bonds::instructions::MergeStakeArgs;
 use validator_bonds::ID as validator_bonds_id;
 use validator_bonds_common::constants::find_event_authority;
 use validator_bonds_common::stake_accounts::{
-    is_locked, CollectedStakeAccount, CollectedStakeAccounts,
+    is_locked, CollectedStakeAccount, CollectedStakeAccounts, StakeActivation,
 };
 
 // TODO: better to be loaded from chain
@@ -41,15 +40,14 @@ pub const IGNORE_DANGLING_NOT_CLOSABLE_STAKE_ACCOUNTS_LIST: [&str; 2] = [
 // - error if all are locked or no stake accounts
 pub fn prioritize_for_claiming(
     stake_accounts: &CollectedStakeAccounts,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
 ) -> anyhow::Result<Pubkey> {
     let mut non_locked_stake_accounts = stake_accounts
         .iter()
-        .filter(|(_, _, stake)| !is_locked(stake, clock))
+        .filter(|(_, _, stake)| !is_locked(stake, &stake_activation.clock))
         .collect::<Vec<_>>();
     non_locked_stake_accounts.sort_by_cached_key(|(_, lamports, stake_account)| {
-        get_claiming_priority_key(stake_account, *lamports, clock, stake_history)
+        get_claiming_priority_key(stake_account, *lamports, stake_activation)
     });
     if let Some((pubkey, _, _)) = non_locked_stake_accounts.first() {
         Ok(*pubkey)
@@ -76,8 +74,7 @@ pub enum StakeAccountStateType {
 
 pub fn get_stake_state_type(
     stake_account_state: &StakeStateV2,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
 ) -> StakeAccountStateType {
     if let StakeStateV2::Initialized(_) = stake_account_state {
         // stake account is initialized and not delegated, it can be delegated just now
@@ -88,7 +85,7 @@ pub fn get_stake_state_type(
             effective,
             deactivating,
             activating,
-        } = delegation.stake_activating_and_deactivating(clock.epoch, stake_history, None);
+        } = stake_activation.status(&delegation);
         if effective == 0 && activating == 0 {
             // all available for immediate delegation
             StakeAccountStateType::DelegatedAndDeactivated
@@ -109,15 +106,14 @@ pub fn get_stake_state_type(
 
 pub fn get_delegated_amount(
     stake_account_state: &StakeStateV2,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
 ) -> u64 {
     if let Some(delegation) = stake_account_state.delegation() {
         let StakeHistoryEntry {
             effective,
             deactivating,
             activating,
-        } = delegation.stake_activating_and_deactivating(clock.epoch, stake_history, None);
+        } = stake_activation.status(&delegation);
         effective + deactivating + activating
     } else {
         0
@@ -186,8 +182,7 @@ impl Ord for ClaimingPriorityKey {
 fn get_claiming_priority_key(
     stake_account: &StakeStateV2,
     lamports: u64,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
 ) -> ClaimingPriorityKey {
     let staker = if let Some(authorized) = stake_account.authorized() {
         authorized.staker
@@ -196,7 +191,7 @@ fn get_claiming_priority_key(
     };
     // Marinade liquid and institutional stake accounts need a different priority to other types
     if staker == Pubkey::from_str(MARINADE_LIQUID_STAKER_AUTHORITY).unwrap() {
-        match get_stake_state_type(stake_account, clock, stake_history) {
+        match get_stake_state_type(stake_account, stake_activation) {
             StakeAccountStateType::DelegatedAndActive => ClaimingPriorityKey::simple(0),
             StakeAccountStateType::DelegatedAndActivating => ClaimingPriorityKey::simple(1),
             StakeAccountStateType::DelegatedAndDeactivating => ClaimingPriorityKey::simple(2),
@@ -205,7 +200,7 @@ fn get_claiming_priority_key(
             StakeAccountStateType::NonAuthorized => ClaimingPriorityKey::simple(255),
         }
     } else if staker == Pubkey::from_str(MARINADE_INSTITUTIONAL_STAKER_AUTHORITY).unwrap() {
-        match get_stake_state_type(stake_account, clock, stake_history) {
+        match get_stake_state_type(stake_account, stake_activation) {
             StakeAccountStateType::DelegatedAndDeactivated => {
                 ClaimingPriorityKey::full(0, lamports)
             }
@@ -218,7 +213,7 @@ fn get_claiming_priority_key(
             StakeAccountStateType::NonAuthorized => ClaimingPriorityKey::full(255, lamports),
         }
     } else {
-        match get_stake_state_type(stake_account, clock, stake_history) {
+        match get_stake_state_type(stake_account, stake_activation) {
             StakeAccountStateType::Initialized => ClaimingPriorityKey::simple(0),
             StakeAccountStateType::DelegatedAndDeactivated => ClaimingPriorityKey::simple(1),
             StakeAccountStateType::DelegatedAndDeactivating => ClaimingPriorityKey::simple(2),
@@ -282,14 +277,13 @@ pub async fn prepare_merge_instructions(
     config_address: &Pubkey,
     staker_authority: &Pubkey,
     transaction_builder: &mut TransactionBuilder,
-    clock: &Clock,
-    stake_history: &StakeHistory,
+    stake_activation: &StakeActivation,
 ) -> anyhow::Result<Vec<Pubkey>> {
     let mut non_mergeable_stake_accounts: Vec<Pubkey> = vec![];
     // can we merge stake accounts? (stake accounts can be merged only when both in the same state)
     for (stake_account_address, _, stake_account_state) in stake_accounts_to_merge {
         let stake_account_to_merge_state_type =
-            get_stake_state_type(stake_account_state, clock, stake_history);
+            get_stake_state_type(stake_account_state, stake_activation);
         if stake_account_to_merge_state_type != destination_stake_state_type {
             // will be funded each separately
             warn!(

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -111,10 +111,11 @@ pub fn get_delegated_amount(
     if let Some(delegation) = stake_account_state.delegation() {
         let StakeHistoryEntry {
             effective,
-            deactivating,
+            deactivating: _,
             activating,
         } = stake_activation.status(&delegation);
-        effective + deactivating + activating
+        // Not an addend: Agave's `with_deactivating` sets `effective` to that same amount.
+        effective + activating
     } else {
         0
     }
@@ -481,5 +482,60 @@ mod tests {
                 "{label}"
             );
         }
+    }
+
+    const EPOCH: u64 = 1014;
+
+    fn delegated_between(activation_epoch: u64, deactivation_epoch: u64) -> StakeStateV2 {
+        StakeStateV2::Stake(
+            Meta::default(),
+            Stake {
+                delegation: Delegation {
+                    stake: 10 * SOL,
+                    activation_epoch,
+                    deactivation_epoch,
+                    ..Delegation::default()
+                },
+                ..Stake::default()
+            },
+            StakeFlags::empty(),
+        )
+    }
+
+    // An empty StakeHistory makes Agave report the delegation verbatim, so the epochs alone drive it.
+    fn at_epoch() -> StakeActivation {
+        StakeActivation {
+            clock: solana_sdk::clock::Clock {
+                epoch: EPOCH,
+                ..Default::default()
+            },
+            stake_history: solana_sdk::stake_history::StakeHistory::default(),
+            new_rate_activation_epoch: Some(EPOCH - 1),
+        }
+    }
+
+    #[test]
+    fn delegated_amount_of_an_active_account_is_the_delegation() {
+        let state = delegated_between(EPOCH - 1, u64::MAX);
+        assert_eq!(get_delegated_amount(&state, &at_epoch()), 10 * SOL);
+    }
+
+    #[test]
+    fn delegated_amount_of_an_activating_account_is_the_delegation() {
+        let state = delegated_between(EPOCH, u64::MAX);
+        assert_eq!(get_delegated_amount(&state, &at_epoch()), 10 * SOL);
+    }
+
+    // Adding `deactivating` reported 20 SOL for this 10 SOL account, hiding its free lamports.
+    #[test]
+    fn delegated_amount_of_a_cooling_account_is_not_doubled() {
+        let state = delegated_between(EPOCH - 1, EPOCH);
+        assert_eq!(get_delegated_amount(&state, &at_epoch()), 10 * SOL);
+    }
+
+    #[test]
+    fn delegated_amount_of_a_non_delegated_account_is_zero() {
+        let state = initialized_stake(Pubkey::new_unique(), Pubkey::new_unique());
+        assert_eq!(get_delegated_amount(&state, &at_epoch()), 0);
     }
 }


### PR DESCRIPTION
Per discussion at https://marinade-group.slack.com/archives/C0BJZAZC66S/p1786171658277399?thread_ts=1786007411.934379&cid=C0BJZAZC66S
this PR adds a way to correctly resolve the protected validators based on their bonds funding that needs to be compared to the staked SOL. We need to add logic to find the staked SOL, then we can compare. Adding an API that also provides the collected data externally.

Dependent PR: https://github.com/marinade-finance/delegation-strategy-2/pull/246

----

`/v1/validators/protected` sizes each validator's bond against the Marinade stake it actually receives, collected on chain rather than from another Marinade service.

- Protect a validator only when its bidding and institutional effective bonds together cover 1/2000 of its Marinade stake and at least 1 SOL — 111 validators at epoch 1014, a strict subset of the 269 tagged before
- Add a `collect-stake` collector subcommand over the seven staker authorities in `collector-config.yaml`, since validators-api omits Select stake entirely
- Store each sweep in a new `collected_stake` table, replacing the epoch's rows in one transaction so an unstaked validator cannot keep a stale row
- Serve the snapshot at `/v1/validators/stake` so the rule can be audited without database access
- Move the `/validators` family under `/v1` and drop the unversioned paths, matching the convention across Marinade services; old callers get 404
- Collect stake on the bidding build only and after bond eventing, so a stake failure cannot block validator notifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Marinade stake collection and storage workflows with retry handling.
  * Added CLI commands for collecting and storing stake data.
  * Added `/v1/validators/stake` with aggregated stake information.
  * Protected-validator detection now considers collected stake, bond totals, minimum thresholds, and snapshot freshness.
* **API Changes**
  * Versioned validator endpoints under `/v1`; removed legacy unversioned paths.
* **Documentation**
  * Added API examples and setup guidance for stake collection and protected-validator checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->