### PR TITLE
[GEN-8245] [api] stakes etl direct staking route

### DIFF
--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -1,6 +1,6 @@
 use crate::dto::{SettlementMetaSchema, ValidatorBondRecordSchema};
 use crate::{
-    dto::ProtectedEventRecord,
+    dto::{LegacyProtectedEventRecord, ProtectedEventRecord},
     handlers::{
         bonds, collected_stake, docs, protected_events, protected_validators, verified_validators,
     },
@@ -28,6 +28,7 @@ use utoipa::{
     components(
         schemas(ValidatorBondRecordSchema),
         schemas(ProtectedEventRecord),
+        schemas(LegacyProtectedEventRecord),
         schemas(SettlementMetaSchema),
         schemas(SettlementReason),
         schemas(SettlementFunder),
@@ -35,6 +36,7 @@ use utoipa::{
         schemas(bonds::BondsResponse),
         schemas(bonds::AuctionContextResponse),
         schemas(protected_events::ProtectedEventsResponse),
+        schemas(protected_events::LegacyProtectedEventsResponse),
         schemas(verified_validators::VerifiedValidatorsResponse),
         schemas(protected_validators::ProtectedValidatorsResponse),
         schemas(collected_stake::CollectedStakeResponse),
@@ -42,7 +44,7 @@ use utoipa::{
         schemas(collected_stake::ValidatorStake),
         schemas(collected_stake::AuthorityStake),
     ),
-    paths(docs::handler, bonds::handler, bonds::handler_institutional, bonds::handler_bidding, bonds::handler_bidding_auction, protected_events::handler, verified_validators::handler, protected_validators::handler, collected_stake::handler),
+    paths(docs::handler, bonds::handler, bonds::handler_institutional, bonds::handler_bidding, bonds::handler_bidding_auction, protected_events::handler, protected_events::handler_v1, verified_validators::handler, protected_validators::handler, collected_stake::handler),
     modifiers(&PubkeyScheme),
 )]
 pub struct ApiDoc;
@@ -84,8 +86,8 @@ mod tests {
         }
     }
 
-    // A generated client with no error branch is worse than none: for the two /v1/validators paths
-    // the 500 is a chosen state, not a failure.
+    // A generated client with no error branch is worse than none: for the /v1/validators paths and
+    // /protected-events the 500 is a chosen state, not a failure.
     #[test]
     fn every_fallible_endpoint_documents_its_error() {
         let docs = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -93,6 +95,8 @@ mod tests {
             "/bonds",
             "/bonds/bidding",
             "/bonds/institutional",
+            "/protected-events",
+            "/v1/protected-events",
             "/v1/validators/protected",
             "/v1/validators/stake",
         ] {

--- a/api/src/bin/api.rs
+++ b/api/src/bin/api.rs
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let protected_event_records = Arc::new(RwLock::new(vec![]));
+    let protected_event_records = Arc::new(RwLock::new(None));
     let context: WrappedContext = Arc::new(RwLock::new(Context::new(
         psql_client,
         protected_event_records.clone(),
@@ -82,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
             spawn_protected_events_cache(gcp_sa_key, gcp_project_id, protected_event_records).await;
         }
         (None, None) => {
-            error!("GCP parameters not provided, will not populate the protected events.")
+            error!("GCP parameters not provided, /protected-events will answer 500.")
         }
         _ => anyhow::bail!("All GCP parameters must be used together."),
     };

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -4,16 +4,20 @@ use tokio_postgres::Client;
 
 use crate::dto::ProtectedEventRecord;
 
+/// `None` until a BigQuery fetch has succeeded once. Distinguishes "never loaded" from an epoch
+/// that genuinely settled nothing, which the handlers answer as 500 and 200 respectively.
+pub type ProtectedEventsCache = Arc<RwLock<Option<Vec<ProtectedEventRecord>>>>;
+
 pub struct Context {
     pub psql_client: Client,
-    pub protected_events_records: Arc<RwLock<Vec<ProtectedEventRecord>>>,
+    pub protected_events_records: ProtectedEventsCache,
     pub verified_validators: Vec<String>,
 }
 
 impl Context {
     pub fn new(
         psql_client: Client,
-        protected_events_records: Arc<RwLock<Vec<ProtectedEventRecord>>>,
+        protected_events_records: ProtectedEventsCache,
         verified_validators: Vec<String>,
     ) -> anyhow::Result<Self> {
         Ok(Self {

--- a/api/src/dto.rs
+++ b/api/src/dto.rs
@@ -96,6 +96,41 @@ pub struct ProtectedEventRecord {
     pub product: String,
 }
 
+/// The single product `/protected-events` ever reported: SAM bidding PSR. Direct staking now lands
+/// in `psr_settlements` too, so naming it is what keeps the two apart.
+const LEGACY_PRODUCT: &str = "sam";
+
+/// DEPRECATED: the pre-`/v1` shape of `/protected-events`. SAM bidding PSR only.
+#[derive(Debug, Serialize, Deserialize, Clone, utoipa::ToSchema)]
+#[schema(deprecated)]
+pub struct LegacyProtectedEventRecord {
+    pub epoch: u64,
+    pub amount: u64,
+    #[serde(with = "pubkey_string_conversion")]
+    pub vote_account: Pubkey,
+    pub meta: SettlementMeta,
+    pub reason: SettlementReason,
+}
+
+/// Narrows the one BigQuery feed to what the pre-`/v1` endpoint meant. Pinning the product keeps
+/// `(epoch, vote_account, meta, reason)` unique, so this stays a field drop and never re-sums:
+/// folding direct staking into a SAM amount would report a number that is true of neither.
+pub fn legacy_projection(records: &[ProtectedEventRecord]) -> Vec<LegacyProtectedEventRecord> {
+    records
+        .iter()
+        .filter(|record| {
+            matches!(record.bond_type, BondType::Bidding) && record.product == LEGACY_PRODUCT
+        })
+        .map(|record| LegacyProtectedEventRecord {
+            epoch: record.epoch,
+            amount: record.amount,
+            vote_account: record.vote_account,
+            meta: record.meta.clone(),
+            reason: record.reason.clone(),
+        })
+        .collect()
+}
+
 /// DEPRECATED: this `{ "funder": ... }` wrapper is retained only for backward compatibility.
 /// The generated settlement JSON now exposes `funder` directly, and any field carrying this
 /// wrapper will be replaced by a top-level `funder` in a future API version.
@@ -141,7 +176,10 @@ pub struct ValidatorBondRecordSchema {
 
 #[cfg(test)]
 mod tests {
-    use super::{ProtectedEventRecord, SettlementFunder, SettlementMeta, SettlementReason};
+    use super::{
+        legacy_projection, LegacyProtectedEventRecord, ProtectedEventRecord, SettlementFunder,
+        SettlementMeta, SettlementReason,
+    };
     use crate::api_docs::ApiDoc;
     use chrono::{DateTime, Utc};
     use rust_decimal::Decimal;
@@ -532,5 +570,144 @@ mod tests {
                 );
             }
         }
+    }
+
+    fn event(
+        epoch: u64,
+        vote_account: Pubkey,
+        amount: u64,
+        bond_type: BondType,
+        product: &str,
+        reason: SettlementReason,
+    ) -> ProtectedEventRecord {
+        ProtectedEventRecord {
+            epoch,
+            amount,
+            vote_account,
+            meta: SettlementMeta {
+                funder: SettlementFunder::ValidatorBond,
+            },
+            reason,
+            bond_type,
+            product: product.to_owned(),
+        }
+    }
+
+    fn legacy(records: Vec<ProtectedEventRecord>) -> Vec<LegacyProtectedEventRecord> {
+        legacy_projection(&records)
+    }
+
+    // Direct staking loads into `psr_settlements` too. Summing it into the SAM amount would report
+    // a number that is true of neither product.
+    #[test]
+    fn the_legacy_shape_reports_sam_alone_and_never_folds_direct_staking_in() {
+        let vote_account = Pubkey::new_unique();
+        let listed = legacy(vec![
+            event(
+                1013,
+                vote_account,
+                100,
+                BondType::Bidding,
+                "sam",
+                SettlementReason::Bidding,
+            ),
+            event(
+                1013,
+                vote_account,
+                40,
+                BondType::Bidding,
+                "single-validator",
+                SettlementReason::Bidding,
+            ),
+        ]);
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].amount, 100);
+    }
+
+    // The pre-/v1 endpoint read `psr_settlements` alone; the union must not leak into it.
+    #[test]
+    fn the_legacy_shape_drops_the_institutional_bond() {
+        let listed = legacy(vec![event(
+            1013,
+            Pubkey::new_unique(),
+            100,
+            BondType::Institutional,
+            "select",
+            SettlementReason::InstitutionalPayout,
+        )]);
+        assert!(listed.is_empty());
+    }
+
+    // Pinning one product is what keeps the old key unique, so the rows pass through as they came.
+    #[test]
+    fn the_legacy_shape_keeps_the_settlement_key_unique() {
+        let vote_account = Pubkey::new_unique();
+        let listed = legacy(vec![
+            event(
+                1013,
+                vote_account,
+                100,
+                BondType::Bidding,
+                "sam",
+                SettlementReason::Bidding,
+            ),
+            event(
+                1013,
+                vote_account,
+                40,
+                BondType::Bidding,
+                "sam",
+                SettlementReason::BidTooLowPenalty,
+            ),
+            event(
+                1012,
+                vote_account,
+                7,
+                BondType::Bidding,
+                "sam",
+                SettlementReason::Bidding,
+            ),
+        ]);
+        assert_eq!(
+            listed
+                .iter()
+                .map(|record| (record.epoch, record.amount))
+                .collect::<Vec<_>>(),
+            vec![(1013, 100), (1013, 40), (1012, 7)],
+        );
+    }
+
+    // The whole point of keeping the old path: its wire shape must not gain the new discriminators.
+    #[test]
+    fn the_legacy_shape_publishes_neither_bond_type_nor_product() {
+        let listed = legacy(vec![event(
+            1013,
+            Pubkey::new_unique(),
+            100,
+            BondType::Bidding,
+            "sam",
+            SettlementReason::Bidding,
+        )]);
+        let serialized = serde_json::to_value(&listed[0]).unwrap();
+        let keys: BTreeSet<&str> = serialized
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            keys,
+            BTreeSet::from(["epoch", "amount", "vote_account", "meta", "reason"]),
+        );
+
+        let documented = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        let schema = &documented["components"]["schemas"]["LegacyProtectedEventRecord"];
+        let documented: BTreeSet<&str> = schema["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(documented, keys);
     }
 }

--- a/api/src/dto.rs
+++ b/api/src/dto.rs
@@ -90,6 +90,10 @@ pub struct ProtectedEventRecord {
     pub vote_account: Pubkey,
     pub meta: SettlementMeta,
     pub reason: SettlementReason,
+    // Not redundant with `product`: `single-validator` occurs under both bond types.
+    #[schema(value_type = String)]
+    pub bond_type: BondType,
+    pub product: String,
 }
 
 /// DEPRECATED: this `{ "funder": ... }` wrapper is retained only for backward compatibility.
@@ -137,7 +141,7 @@ pub struct ValidatorBondRecordSchema {
 
 #[cfg(test)]
 mod tests {
-    use super::{SettlementFunder, SettlementMeta};
+    use super::{ProtectedEventRecord, SettlementFunder, SettlementMeta, SettlementReason};
     use crate::api_docs::ApiDoc;
     use chrono::{DateTime, Utc};
     use rust_decimal::Decimal;
@@ -305,6 +309,84 @@ mod tests {
         })
         .unwrap();
         assert_shape_matches(&docs, schema, &serialized, "SettlementMetaSchema");
+    }
+
+    fn sample_protected_event_record(
+        bond_type: BondType,
+        product: &str,
+        reason: SettlementReason,
+    ) -> ProtectedEventRecord {
+        ProtectedEventRecord {
+            epoch: 1013,
+            amount: 37316490,
+            vote_account: Pubkey::new_unique(),
+            meta: SettlementMeta {
+                funder: SettlementFunder::ValidatorBond,
+            },
+            reason,
+            bond_type,
+            product: product.to_owned(),
+        }
+    }
+
+    #[test]
+    fn protected_event_record_documents_both_settlement_dimensions() {
+        let docs = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        let schema = &docs["components"]["schemas"]["ProtectedEventRecord"];
+
+        let documented: BTreeSet<&str> = schema["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let serialized = serde_json::to_value(sample_protected_event_record(
+            BondType::Institutional,
+            "select",
+            SettlementReason::InstitutionalPayout,
+        ))
+        .unwrap();
+        let actual: BTreeSet<&str> = serialized
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            documented, actual,
+            "ProtectedEventRecord: documented property set drifted from the serialized keys",
+        );
+
+        // BondType has no registered component; deriving its schema emits a dangling `$ref`.
+        for field in ["bond_type", "product"] {
+            assert!(
+                documented_accepts(&docs, &schema["properties"][field], "string"),
+                "{field}: must document as a plain string; got {}",
+                schema["properties"][field],
+            );
+        }
+
+        for (bond_type, wire) in [
+            (BondType::Bidding, "bidding"),
+            (BondType::Institutional, "institutional"),
+        ] {
+            let serialized = serde_json::to_value(sample_protected_event_record(
+                bond_type,
+                "single-validator",
+                SettlementReason::Bidding,
+            ))
+            .unwrap();
+            assert_eq!(
+                serialized["bond_type"].as_str(),
+                Some(wire),
+                "bond_type must use the /bonds/* wire value so the two join without a mapping",
+            );
+            assert_eq!(
+                serialized["product"].as_str(),
+                Some("single-validator"),
+                "product must reach the wire verbatim; it is the only direct-staking discriminator",
+            );
+        }
     }
 
     #[test]

--- a/api/src/handlers/protected_events.rs
+++ b/api/src/handlers/protected_events.rs
@@ -1,4 +1,8 @@
-use crate::{context::WrappedContext, dto::ProtectedEventRecord};
+use crate::{
+    context::WrappedContext,
+    dto::{legacy_projection, LegacyProtectedEventRecord, ProtectedEventRecord},
+    error::AppError,
+};
 use axum::extract::{Query, State};
 use axum::Json;
 use serde::{Deserialize, Serialize};
@@ -6,6 +10,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct ProtectedEventsResponse {
     protected_events: Vec<ProtectedEventRecord>,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+#[schema(deprecated)]
+pub struct LegacyProtectedEventsResponse {
+    protected_events: Vec<LegacyProtectedEventRecord>,
 }
 
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
@@ -18,19 +28,53 @@ pub struct QueryParams {}
     operation_id = "List Bid PSR (protected events)",
     path = "/protected-events",
     responses(
-        (status = 200, description = "Settlements from both bond configs. Filter on `bond_type` (bidding | institutional) and `product` (sam | select | single-validator) to narrow the set.", body = ProtectedEventsResponse),
+        (status = 200, description = "DEPRECATED: SAM bidding PSR only. Please use /v1/protected-events instead, which also covers the institutional bond and direct staking, split by product.", body = LegacyProtectedEventsResponse),
+        (status = 500, description = "No settlements have been read from BigQuery yet. Deliberately not an empty list, which would read as 'no validator owes a protected event'."),
     )
 )]
+#[deprecated]
 pub async fn handler(
     State(context): State<WrappedContext>,
     Query(_query_params): Query<QueryParams>,
-) -> Json<ProtectedEventsResponse> {
+) -> Result<Json<LegacyProtectedEventsResponse>, AppError> {
+    let protected_events = legacy_projection(
+        context
+            .read()
+            .await
+            .protected_events_records
+            .read()
+            .await
+            .as_deref()
+            .ok_or_else(|| AppError {
+                message: "No protected events loaded from BigQuery yet".to_string(),
+            })?,
+    );
+    Ok(Json(LegacyProtectedEventsResponse { protected_events }))
+}
+
+#[utoipa::path(
+    get,
+    tag = "Protected Events",
+    operation_id = "List PSR (protected events) per bond type and product",
+    path = "/v1/protected-events",
+    responses(
+        (status = 200, description = "Settlements from both bond configs. One row per `bond_type` (bidding | institutional) and `product` (sam | select | single-validator), so `(epoch, vote_account, meta, reason)` is no longer unique.", body = ProtectedEventsResponse),
+        (status = 500, description = "No settlements have been read from BigQuery yet. Deliberately not an empty list, which would read as 'no validator owes a protected event'."),
+    )
+)]
+pub async fn handler_v1(
+    State(context): State<WrappedContext>,
+    Query(_query_params): Query<QueryParams>,
+) -> Result<Json<ProtectedEventsResponse>, AppError> {
     let protected_events = context
         .read()
         .await
         .protected_events_records
         .read()
         .await
-        .clone();
-    Json(ProtectedEventsResponse { protected_events })
+        .clone()
+        .ok_or_else(|| AppError {
+            message: "No protected events loaded from BigQuery yet".to_string(),
+        })?;
+    Ok(Json(ProtectedEventsResponse { protected_events }))
 }

--- a/api/src/handlers/protected_events.rs
+++ b/api/src/handlers/protected_events.rs
@@ -18,7 +18,7 @@ pub struct QueryParams {}
     operation_id = "List Bid PSR (protected events)",
     path = "/protected-events",
     responses(
-        (status = 200, body = ProtectedEventsResponse),
+        (status = 200, description = "Settlements from both bond configs. Filter on `bond_type` (bidding | institutional) and `product` (sam | select | single-validator) to narrow the set.", body = ProtectedEventsResponse),
     )
 )]
 pub async fn handler(

--- a/api/src/repositories/protected_events.rs
+++ b/api/src/repositories/protected_events.rs
@@ -2,6 +2,7 @@ use gcp_bigquery_client::model::query_request::QueryRequest;
 use solana_sdk::pubkey::Pubkey;
 use std::{str::FromStr, sync::Arc, time::Duration};
 use tokio::{sync::RwLock, time::sleep};
+use validator_bonds_common::dto::BondType;
 
 use crate::dto::ProtectedEventRecord;
 
@@ -21,7 +22,11 @@ async fn get_protected_events(
         .query(
             project_id,
             QueryRequest::new(format!(
-                "select epoch, vote_account, sum(amount) amount, meta, reason from `mainnet_beta_stakes.psr_settlements` where epoch >= {from_epoch} group by epoch, vote_account, meta, reason order by epoch desc;"
+                "select epoch, vote_account, sum(amount) amount, meta, reason, bond_type, product from ( \
+                   select epoch, vote_account, amount, meta, reason, 'bidding' bond_type, product from `mainnet_beta_stakes.psr_settlements` where epoch >= {from_epoch} \
+                   union all \
+                   select epoch, vote_account, amount, meta, reason, 'institutional' bond_type, product from `mainnet_beta_stakes.institutional_settlements` where epoch >= {from_epoch} \
+                 ) group by epoch, vote_account, meta, reason, bond_type, product order by epoch desc;"
             )),
         )
         .await?;
@@ -68,6 +73,14 @@ fn parse_row(
             &rs.get_string_by_name("reason")?
                 .ok_or_else(|| anyhow::anyhow!("missing reason"))?,
         )?,
+        bond_type: BondType::parse_from_str(
+            &rs.get_string_by_name("bond_type")?
+                .ok_or_else(|| anyhow::anyhow!("missing bond_type"))?,
+        )?,
+        // Skipped rather than defaulted, so a half-applied migration 005 surfaces here.
+        product: rs
+            .get_string_by_name("product")?
+            .ok_or_else(|| anyhow::anyhow!("missing product"))?,
     })
 }
 

--- a/api/src/repositories/protected_events.rs
+++ b/api/src/repositories/protected_events.rs
@@ -33,18 +33,9 @@ async fn get_protected_events(
         .await?;
 
     let mut protected_events = vec![];
-    let mut skipped = 0usize;
+    // Fail the whole fetch, never a row: a dropped row reads as "this validator owes nothing".
     while rs.next_row() {
-        match parse_row(&rs) {
-            Ok(record) => protected_events.push(record),
-            Err(err) => {
-                skipped += 1;
-                log::error!("Skipping unparseable protected_events row: {err}");
-            }
-        }
-    }
-    if skipped > 0 {
-        log::warn!("Skipped {skipped} unparseable protected_events row(s)");
+        protected_events.push(parse_row(&rs)?);
     }
 
     Ok(protected_events)
@@ -244,7 +235,6 @@ mod tests {
         assert_eq!(record.product, "single-validator");
     }
 
-    // A null would reach the API as a dropped row, not an error, so the parse has to reject it.
     #[test]
     fn a_row_without_a_product_is_rejected() {
         let err = parse_row(&result_set(&[("product", None)])).unwrap_err();

--- a/api/src/repositories/protected_events.rs
+++ b/api/src/repositories/protected_events.rs
@@ -1,9 +1,10 @@
 use gcp_bigquery_client::model::query_request::QueryRequest;
 use solana_sdk::pubkey::Pubkey;
-use std::{str::FromStr, sync::Arc, time::Duration};
-use tokio::{sync::RwLock, time::sleep};
+use std::{str::FromStr, time::Duration};
+use tokio::time::sleep;
 use validator_bonds_common::dto::BondType;
 
+use crate::context::ProtectedEventsCache;
 use crate::dto::ProtectedEventRecord;
 
 const CACHE_UPDATE_INTERVAL: Duration = Duration::from_secs(3600);
@@ -77,7 +78,8 @@ fn parse_row(
             &rs.get_string_by_name("bond_type")?
                 .ok_or_else(|| anyhow::anyhow!("missing bond_type"))?,
         )?,
-        // Skipped rather than defaulted, so a half-applied migration 005 surfaces here.
+        // Hard requirement, not a default: stakes-etl stamps every loaded row, so a null here means
+        // the column was never backfilled and guessing one would misattribute the settlement.
         product: rs
             .get_string_by_name("product")?
             .ok_or_else(|| anyhow::anyhow!("missing product"))?,
@@ -87,7 +89,7 @@ fn parse_row(
 pub async fn spawn_protected_events_cache(
     gcp_sa_key: String,
     project_id: String,
-    protected_events: Arc<RwLock<Vec<ProtectedEventRecord>>>,
+    protected_events: ProtectedEventsCache,
 ) {
     spawn_protected_events_cache_purger(
         gcp_sa_key.clone(),
@@ -103,7 +105,7 @@ pub async fn spawn_protected_events_cache(
 pub fn spawn_protected_events_cache_purger(
     gcp_sa_key: String,
     project_id: String,
-    protected_events: Arc<RwLock<Vec<ProtectedEventRecord>>>,
+    protected_events: ProtectedEventsCache,
 ) {
     tokio::spawn(async move {
         loop {
@@ -115,10 +117,7 @@ pub fn spawn_protected_events_cache_purger(
                         "Successfully fetched the protected events ({})",
                         updated_protected_events.len()
                     );
-                    protected_events
-                        .write()
-                        .await
-                        .clone_from(&updated_protected_events);
+                    *protected_events.write().await = Some(updated_protected_events);
                     log::info!("Protected Events completely updated");
                 }
                 Err(err) => log::error!("Failed to get the protected events: {err}"),
@@ -129,7 +128,7 @@ pub fn spawn_protected_events_cache_purger(
 pub fn spawn_protected_events_cache_updater(
     gcp_sa_key: String,
     project_id: String,
-    protected_events: Arc<RwLock<Vec<ProtectedEventRecord>>>,
+    protected_events: ProtectedEventsCache,
 ) {
     tokio::spawn(async move {
         loop {
@@ -137,6 +136,7 @@ pub fn spawn_protected_events_cache_updater(
                 .read()
                 .await
                 .iter()
+                .flatten()
                 .fold(0, |max_loaded_epoch, protected_event| {
                     protected_event.epoch.max(max_loaded_epoch)
                 });
@@ -152,15 +152,13 @@ pub fn spawn_protected_events_cache_updater(
                         .read()
                         .await
                         .iter()
+                        .flatten()
                         .filter(|protected_event| protected_event.epoch < max_loaded_epoch)
                         .chain(updated_protected_events.iter())
                         .cloned()
                         .collect();
 
-                    protected_events
-                        .write()
-                        .await
-                        .clone_from(&merged_protected_events);
+                    *protected_events.write().await = Some(merged_protected_events);
 
                     log::info!("Successfully extended the protected events");
                 }
@@ -170,4 +168,92 @@ pub fn spawn_protected_events_cache_updater(
             sleep(CACHE_UPDATE_INTERVAL).await;
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gcp_bigquery_client::model::{
+        query_response::{QueryResponse, ResultSet},
+        table_cell::TableCell,
+        table_field_schema::TableFieldSchema,
+        table_row::TableRow,
+        table_schema::TableSchema,
+    };
+    use settlement_common::settlement_collection::{
+        SettlementFunder, SettlementMeta, SettlementReason,
+    };
+
+    const VOTE_ACCOUNT: &str = "We11J5D4iXcNbdMwCZX2o9RRkwaWBo1AGLADfubmeTb";
+
+    // BigQuery hands every cell over as a JSON string, nulls included, so the fixture does too.
+    fn result_set(overrides: &[(&str, Option<&str>)]) -> ResultSet {
+        let meta = serde_json::to_string(&SettlementMeta {
+            funder: SettlementFunder::ValidatorBond,
+        })
+        .unwrap();
+        let reason = serde_json::to_string(&SettlementReason::Bidding).unwrap();
+        let mut cells: Vec<(&str, Option<String>)> = vec![
+            ("epoch", Some("1013".to_string())),
+            ("vote_account", Some(VOTE_ACCOUNT.to_string())),
+            ("amount", Some("37316490".to_string())),
+            ("meta", Some(meta)),
+            ("reason", Some(reason)),
+            ("bond_type", Some("bidding".to_string())),
+            ("product", Some("single-validator".to_string())),
+        ];
+        for (name, value) in overrides {
+            let cell = cells
+                .iter_mut()
+                .find(|(cell_name, _)| cell_name == name)
+                .unwrap_or_else(|| panic!("{name} is not a column of the fixture"));
+            cell.1 = value.map(str::to_string);
+        }
+
+        let mut rs = ResultSet::new(QueryResponse {
+            job_complete: Some(true),
+            total_rows: Some(cells.len().to_string()),
+            schema: Some(TableSchema::new(
+                cells
+                    .iter()
+                    .map(|(name, _)| TableFieldSchema::string(name))
+                    .collect(),
+            )),
+            rows: Some(vec![TableRow {
+                columns: Some(
+                    cells
+                        .iter()
+                        .map(|(_, value)| TableCell {
+                            value: value.as_ref().map(|v| serde_json::Value::String(v.clone())),
+                        })
+                        .collect(),
+                ),
+            }]),
+            ..Default::default()
+        });
+        assert!(rs.next_row(), "fixture must hold exactly one row");
+        rs
+    }
+
+    #[test]
+    fn a_complete_row_carries_both_settlement_dimensions() {
+        let record = parse_row(&result_set(&[])).unwrap();
+        assert_eq!(record.epoch, 1013);
+        assert_eq!(record.amount, 37316490);
+        assert_eq!(record.bond_type.as_str(), "bidding");
+        assert_eq!(record.product, "single-validator");
+    }
+
+    // A null would reach the API as a dropped row, not an error, so the parse has to reject it.
+    #[test]
+    fn a_row_without_a_product_is_rejected() {
+        let err = parse_row(&result_set(&[("product", None)])).unwrap_err();
+        assert!(err.to_string().contains("missing product"));
+    }
+
+    #[test]
+    fn a_row_with_an_unknown_bond_type_is_rejected() {
+        let err = parse_row(&result_set(&[("bond_type", Some("direct"))])).unwrap_err();
+        assert!(err.to_string().contains("Unknown bond type"));
+    }
 }

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -57,6 +57,7 @@ pub fn public_data_routes(context: WrappedContext) -> Router {
         )
         .route("/bonds/institutional", get(bonds::handler_institutional))
         .route("/protected-events", get(protected_events::handler))
+        .route("/v1/protected-events", get(protected_events::handler_v1))
         // The /validators family is versioned; the unversioned paths were removed, not aliased.
         .route("/v1/validators/verified", get(verified_validators::handler))
         .route(


### PR DESCRIPTION
Adjusting data loaded from stakes-etl that adds product info to differentiate the PSR of DS SAM to PSR of direct staking.

Related to https://github.com/marinade-finance/validator-bonds/pull/485
It should be deployed first, before the PSR pipeline processing ^ is in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the versioned `/v1/protected-events` endpoint with expanded event details, including bond type and product.
  * Protected-event data now includes both bidding and institutional settlement records.
  * Added clear error responses when protected-event data is unavailable.

* **Compatibility**
  * Preserved the legacy `/protected-events` response format for existing integrations.
  * Added documentation for both legacy and versioned endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->