### PR TITLE
[GEN-8055][cli] notification info fixes and update definition

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,178 @@
+# Repo-local copy of the marinade-finance/.github deny.toml. The org static-analysis
+# workflow prefers ./deny.toml over the org-wide one, so edits here do not reach other
+# repos — and org-wide policy updates no longer reach this repo either.
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+# All ignored advisories are unfixable transitive dependencies pulled in
+# through the Solana / Anchor / SPL ecosystem (solana-sdk, solana-zk-sdk,
+# spl-token-2022, anchor-lang, …). Revisit when the upstream Solana crates
+# upgrade past these.
+ignore = [
+  # ed25519-dalek <2.0 — public-key oracle attack. solana-sdk pins 1.x.
+  "RUSTSEC-2022-0093",
+  # curve25519-dalek timing variability in Scalar*::sub. Solana-internal.
+  "RUSTSEC-2024-0344",
+  # atty unmaintained. Pulled by solana-logger via env_logger 0.9.
+  "RUSTSEC-2024-0375",
+  # derivative unmaintained. Pulled via ark-ff / ark-ec.
+  "RUSTSEC-2024-0388",
+  # paste unmaintained. Pulled via solana-program / anchor-lang.
+  "RUSTSEC-2024-0436",
+  # number_prefix unmaintained. Pulled via indicatif.
+  "RUSTSEC-2025-0119",
+  # bincode 1.x unmaintained. Pulled via solana-sdk.
+  "RUSTSEC-2025-0141",
+  # libsecp256k1 unmaintained. Pulled via solana-sdk.
+  "RUSTSEC-2025-0161",
+  # rustls-webpki 0.101.x (EOL) cert-validation bugs: URI/wildcard name
+  # constraints and a reachable CRL-parsing panic. Fixed in the 0.102/0.103
+  # lines but the 0.101 line is end-of-life. Pulled via the old rustls 0.21
+  # / tokio-tungstenite 0.20 stack that solana-pubsub-client still pins.
+  # Drop these once the Solana websocket client upgrades tungstenite/rustls.
+  "RUSTSEC-2026-0098",
+  "RUSTSEC-2026-0099",
+  "RUSTSEC-2026-0104",
+  # rustls-webpki <0.103.10 CRL distribution-point matching bug. The 0.103
+  # line is patched (repos pick up 0.103.13 via `cargo update`); the stuck
+  # 0.102.x is pulled via gcp-bigquery-client -> yup-oauth2 -> rustls 0.22.
+  # Revisit when gcp-bigquery-client moves to a rustls 0.23 release.
+  "RUSTSEC-2026-0049",
+  # Unmaintained crates pinned deep in the Solana validator stack
+  # (solana-runtime / solana-ledger / solana-storage-bigtable), reached via
+  # the snapshot-parser git dep, plus the reqwest 0.11 / gcp-bigquery-client
+  # TLS stack. No maintained drop-in at the versions those crates pin; revisit
+  # when the upstream Solana / reqwest crates move forward.
+  # instant — unmaintained. Pulled via backoff -> solana-storage-bigtable.
+  "RUSTSEC-2024-0384",
+  # backoff — unmaintained. Pulled via solana-storage-bigtable.
+  "RUSTSEC-2025-0012",
+  # proc-macro-error2 — unmaintained. Pulled via aquamarine -> solana-runtime.
+  "RUSTSEC-2026-0173",
+  # im, and its bitmaps / sized-chunks deps — unmaintained, all archived by the
+  # same owner on 2026-05-03 with no safe upgrade. Pulled via solana-runtime.
+  # The imbl fork is the upstream replacement; goes away when Solana adopts it.
+  "RUSTSEC-2026-0248",
+  "RUSTSEC-2026-0247",
+  "RUSTSEC-2026-0251",
+  # rustls-pemfile — unmaintained. Pulled via reqwest 0.11 (gcp-bigquery-client).
+  "RUSTSEC-2025-0134",
+  # ansi_term — unmaintained. Pulled via clap 2.x, which the Solana CLI
+  # helper crates (solana-clap-utils -> solana-cli-config / solana-cli-output)
+  # still depend on. Goes away when Solana's CLI crates move off clap 2.
+  "RUSTSEC-2021-0139",
+  # proc-macro-error — unmaintained, build-time only (proc-macro dep of
+  # utoipa-gen < 4). Repos on utoipa >= 4 don't pull it; bumping utoipa past
+  # 3.x is the real fix where the OpenAPI migration is worth it.
+  "RUSTSEC-2024-0370",
+]
+
+# Permissive-only allow list. Anything copyleft (GPL/LGPL/AGPL/EUPL/EPL),
+# source-disclosure-required, or commercial-restricting must NOT be added
+# without an explicit security review — the goal is that downstream consumers
+# can ship binaries built from this tree without source-disclosure obligations.
+[licenses]
+allow = [
+  # Classic permissive
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  # Boost — permissive, no patent grant. Used as alternative by `ryu`.
+  "BSL-1.0",
+  # Public-domain-equivalents. Used as alternatives by csv, aho-corasick,
+  # memchr, termcolor, walkdir, adler2, constant_time_eq, …
+  "0BSD",
+  "Unlicense",
+  "MIT-0",
+  "CC0-1.0",
+  # Weak copyleft, file-level — file-level disclosure only.
+  "MPL-2.0",
+  # zlib (libz-rs-sys / zlib-rs and tinyvec/bytemuck/cfg_eval as alternative).
+  "Zlib",
+  # ICU / idna stack pulled in via reqwest -> url -> idna.
+  "Unicode-3.0",
+  # webpki-roots ships the Mozilla CA bundle.
+  "CDLA-Permissive-2.0",
+  # bzip2 — permissive BSD-style, no source-disclosure obligation. Pulled via
+  # libbz2-rs-sys, the default backend of bzip2 0.6 (agave-snapshots 4.x).
+  "bzip2-1.0.6",
+]
+confidence-threshold = 0.93
+exceptions = []
+# First-party workspace crates are routinely unpublished (`publish = false`)
+# and carry no `license` field — they're internal binaries, integration-test
+# crates, and not-yet-released SDKs. Skip the license check for those rather
+# than forcing every repo to stamp a license on internal crates just to make
+# the supply-chain license gate (which is about third-party deps) pass.
+private = { ignore = true }
+
+# Clarify the license for crates that don't declare one in the relevant
+# release's manifest but are licensed upstream. Each expression below is a
+# verified, permissive license:
+#  - mpl-token-metadata 5.x ships without a license field despite Metaplex
+#    publishing it under Apache-2.0. This is third-party, so clarifying here
+#    is the right long-term home.
+#  - TEMPORARY: the marinade-finance first-party crates below
+#    (solana-transaction-*, solana-snapshot-parser) have no `license` field in
+#    their own Cargo.toml. The real fix is to add `license = "Apache-2.0"` in
+#    those repos directly; remove these entries once that lands and the
+#    consuming repos re-pin. Tracked as a follow-up — see the open PRs.
+[[licenses.clarify]]
+crate = "mpl-token-metadata"
+expression = "Apache-2.0"
+license-files = []
+
+# TEMP (fix upstream, then delete): marinade-finance crates missing a license field.
+[[licenses.clarify]]
+crate = "snapshot-parser"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+crate = "snapshot-parser-validator-cli"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+crate = "solana-transaction-builder"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+crate = "solana-transaction-builder-executor"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+crate = "solana-transaction-executor"
+expression = "Apache-2.0"
+license-files = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+# Path dependencies between workspace members are conventionally declared
+# without a version (`foo = { path = "../foo" }`), which cargo-deny would
+# otherwise flag as a wildcard. Allow wildcards *only* for path deps; a
+# wildcard on a crates.io dependency is still denied.
+allow-wildcard-paths = true
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+# First-party crates are routinely consumed as git dependencies pinned to a
+# tag/branch (e.g. solana-transaction-builder, solana-snapshot-parser) before
+# they're ever published to crates.io. Trust the whole marinade-finance org as
+# a git source rather than maintaining a per-repo allow-git URL list. Any other
+# git source remains denied.
+[sources.allow-org]
+github = ["marinade-finance"]

--- a/packages/validator-bonds-cli-core/__tests__/npmRegistry.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/npmRegistry.spec.ts
@@ -1,7 +1,7 @@
 import {
+  checkCliVersion,
   compareVersions,
   fetchLatestVersionInNpmRegistry,
-  requireLatestCliVersion,
 } from '../src/npmRegistry'
 
 import type { Logger } from 'pino'
@@ -344,31 +344,98 @@ describe('fetchLatestVersionInNpmRegistry', () => {
   })
 })
 
-describe('requireLatestCliVersion', () => {
+describe('checkCliVersion', () => {
   const originalFetch = global.fetch
+  const registryUrl =
+    'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli'
 
-  afterEach(() => {
-    global.fetch = originalFetch
-    jest.clearAllMocks()
-  })
-
-  it('recommends the exact version it compared against, not @latest', async () => {
+  const mockRegistry = (...publishedVersions: string[]) => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: () => ({
         name: '@marinade.finance/validator-bonds-cli',
-        versions: { '2.4.0': {}, '2.5.0': {} },
+        versions: Object.fromEntries(publishedVersions.map(v => [v, {}])),
       }),
     }) as unknown as typeof fetch
+  }
+
+  let stderrSpy: jest.SpyInstance
+  let stdoutSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    stdoutSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  it('recommends the exact version it compared against, not @latest', async () => {
+    mockRegistry('2.4.0', '2.5.0')
 
     await expect(
-      requireLatestCliVersion(
-        mockLogger,
-        'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli',
-        '2.4.0',
-      ),
+      checkCliVersion(mockLogger, registryUrl, '2.4.0'),
     ).rejects.toThrow(
       'npm install -g @marinade.finance/validator-bonds-cli@2.5.0',
     )
+  })
+
+  it('blocks on a newer minor release', async () => {
+    mockRegistry('2.5.0', '2.6.0')
+
+    await expect(
+      checkCliVersion(mockLogger, registryUrl, '2.5.3'),
+    ).rejects.toThrow('CLI version 2.5.3 is outdated')
+    expect(stderrSpy).not.toHaveBeenCalled()
+  })
+
+  it('blocks on a newer major release', async () => {
+    mockRegistry('2.6.0', '3.0.0')
+
+    await expect(
+      checkCliVersion(mockLogger, registryUrl, '2.6.0'),
+    ).rejects.toThrow('CLI version 2.6.0 is outdated')
+    expect(stderrSpy).not.toHaveBeenCalled()
+  })
+
+  it('only warns on a newer patch release', async () => {
+    mockRegistry('2.6.0', '2.6.2')
+
+    await expect(
+      checkCliVersion(mockLogger, registryUrl, '2.6.0'),
+    ).resolves.toBeUndefined()
+    expect(stderrSpy).toHaveBeenCalledTimes(1)
+    expect(stderrSpy.mock.calls[0]?.[0]).toContain(
+      'npm install -g @marinade.finance/validator-bonds-cli@2.6.2',
+    )
+    expect(stdoutSpy).not.toHaveBeenCalled()
+  })
+
+  it('says nothing when up to date or ahead', async () => {
+    mockRegistry('2.6.0')
+
+    await expect(
+      checkCliVersion(mockLogger, registryUrl, '2.6.0'),
+    ).resolves.toBeUndefined()
+    await expect(
+      checkCliVersion(mockLogger, registryUrl, '2.7.0'),
+    ).resolves.toBeUndefined()
+    expect(stderrSpy).not.toHaveBeenCalled()
+  })
+
+  it('lets an unreachable registry pass', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(
+        new TypeError('fetch failed'),
+      ) as unknown as typeof fetch
+
+    await expect(
+      checkCliVersion(mockLogger, registryUrl, '2.6.0'),
+    ).resolves.toBeUndefined()
+    expect(stderrSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/validator-bonds-cli-core/package.json
+++ b/packages/validator-bonds-cli-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-core",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Common CLI Core of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-core/src/commands/mainCommand.ts
+++ b/packages/validator-bonds-cli-core/src/commands/mainCommand.ts
@@ -27,7 +27,7 @@ import {
 import { getCliContext, setValidatorBondsCliContext } from '../context'
 import { translateKnownError } from '../errorTranslators'
 import { startFetchingNotificationBanners } from '../notifications'
-import { requireLatestCliVersion } from '../npmRegistry'
+import { checkCliVersion } from '../npmRegistry'
 
 import type {
   CliUsageConfig,
@@ -234,7 +234,7 @@ export function launchCliProgram({
       bondsApiEnabled,
     })
 
-    await requireLatestCliVersion(logger, npmRegistryUrl, version)
+    await checkCliVersion(logger, npmRegistryUrl, version)
   })
 
   const fireCompletion = (result: CompletionResult) => {

--- a/packages/validator-bonds-cli-core/src/npmRegistry.ts
+++ b/packages/validator-bonds-cli-core/src/npmRegistry.ts
@@ -89,25 +89,42 @@ export async function fetchLatestVersionInNpmRegistry(
   }
 }
 
+// patch releases keep the commands compatible, so scripted runs are not stopped by them
+function isMandatoryUpgrade(current: string, latest: string): boolean {
+  const majorMinor = (version: string) =>
+    (version.split('-')[0] as string).split('.').slice(0, 2).join('.')
+  return compareVersions(majorMinor(current), majorMinor(latest)) < 0
+}
+
 /**
  * Checks that the CLI is up to date before executing the command.
  * If the registry is unreachable or times out, the CLI is allowed to proceed.
- * If the CLI version is outdated, throws an error to block execution.
+ * A newer major or minor release blocks execution, a newer patch release only warns.
  */
-export async function requireLatestCliVersion(
+export async function checkCliVersion(
   logger: Logger,
   npmRegistryUrl: string,
   currentVersion: string,
 ): Promise<void> {
   const npmData = await fetchLatestVersionInNpmRegistry(logger, npmRegistryUrl)
-  if (compareVersions(currentVersion, npmData.version) < 0) {
-    // @latest resolves through the dist-tag, which can lag the version this gate compares against
+  if (compareVersions(currentVersion, npmData.version) >= 0) {
+    return
+  }
+  // @latest resolves through the dist-tag, which can lag the version this gate compares against
+  const installCommand = `npm install -g ${npmData.name}@${npmData.version}`
+  if (isMandatoryUpgrade(currentVersion, npmData.version)) {
     throw new Error(
       `CLI version ${currentVersion} is outdated. The latest available version is ${npmData.version}.\n` +
         '  Please update before proceeding:\n' +
-        `  npm install -g ${npmData.name}@${npmData.version}`,
+        `  ${installCommand}`,
     )
   }
+  // the pino transport writes to stdout, where printData emits the --format payload
+  console.error(
+    `CLI version ${currentVersion} is outdated. The latest available version is ${npmData.version}.\n` +
+      '  This is a patch release, the command continues. To update:\n' +
+      `  ${installCommand}`,
+  )
 }
 
 export function compareVersions(a: string, b: string): number {

--- a/packages/validator-bonds-cli-institutional/README.md
+++ b/packages/validator-bonds-cli-institutional/README.md
@@ -25,7 +25,7 @@ To get info on available commands
 ```sh
 # to verify installed version
 validator-bonds-institutional --version
-2.5.0
+2.6.0
 
 # get reference of available commands
 validator-bonds-institutional --help
@@ -135,6 +135,12 @@ For details on meanings of the particular fields in the listing, please refer to
 
 The bond account exists to be funded to cover rewards distribution.
 
+A Select bond is considered sufficiently funded when its claimable balance covers
+**1 SOL for every 2,000 SOL** of Select stake delegated to the validator.
+That is the threshold the [bond notifications](#notification-subscriptions) are evaluated against.
+The `1 SOL per 1,000 SOL` used in the examples below is the recommended amount —
+it leaves headroom so a PSR penalty or a settlement claim does not immediately push the bond under the threshold.
+
 Funding the bond means underlaying stake account is created.
 Such stake account is delegated to the validator vote account
 and is still generating staking rewards.
@@ -217,6 +223,71 @@ For technical details on creating withdraw request and claiming, please refer to
 
 For details please refer to
 [`Support for Ledger signing` in the Validator Bonds CLI README](https://github.com/marinade-finance/validator-bonds/tree/main/packages/validator-bonds-cli#support-for-ledger-signing).
+
+## Notification Subscriptions
+
+Get notified over Telegram or email when the Select bond needs attention —
+most importantly when it drops under the
+[required 1 SOL per 2,000 SOL of Select stake](#funding-bond-account) and a top-up is due.
+Bond balance changes and applied settlement claims are reported as well.
+
+Subscriptions are off-chain. No transaction is sent and nothing is paid, but the CLI signs a message
+with the bond authority or the validator identity to prove ownership of the bond.
+
+### Subscribe
+
+```sh
+# Subscribe via Telegram
+validator-bonds-institutional subscribe <bond-or-vote-account> \
+  --type telegram --address <your-telegram-handle> \
+  --authority <bond-authority-or-validator-identity-keypair>
+
+# Subscribe via email
+validator-bonds-institutional subscribe <bond-or-vote-account> \
+  --type email --address <your-email> \
+  --authority <bond-authority-or-validator-identity-keypair>
+```
+
+**Telegram activation:** After subscribing, the CLI returns a Telegram deep link and opens it in your browser.
+You **must click "Start"** in the Telegram bot to activate delivery.
+
+### Unsubscribe
+
+```sh
+# Unsubscribe a specific address
+validator-bonds-institutional unsubscribe <bond-or-vote-account> \
+  --type telegram --address <your-telegram-handle> \
+  --authority <bond-authority-or-validator-identity-keypair>
+
+# Unsubscribe all subscriptions of a given type
+validator-bonds-institutional unsubscribe <bond-or-vote-account> \
+  --type telegram \
+  --authority <bond-authority-or-validator-identity-keypair>
+```
+
+Omitting `--address` removes **all** subscriptions of the specified type for the bond.
+
+### List Current Subscriptions
+
+```sh
+validator-bonds-institutional subscriptions <bond-or-vote-account> \
+  --authority <bond-authority-or-validator-identity-keypair>
+```
+
+Shows channel type, address, and status (e.g., `active`, `pending`, `inactive`) for each subscription.
+
+### View Notifications
+
+```sh
+# Show notifications for a specific bond
+validator-bonds-institutional show-notifications <bond-or-vote-account>
+
+# Show broadcast announcements only
+validator-bonds-institutional show-notifications
+
+# Filter by priority or limit count
+validator-bonds-institutional show-notifications <bond-or-vote-account> --priority critical --limit 10
+```
 
 ## Details on Bond Processing and Select Programme Calculation
 
@@ -341,7 +412,7 @@ Options:
 
 Commands:
   bond-address <vote-account>                                  From provided vote account address derives the bond account address
-  show-bond [options] [bond-or-vote]                           Showing data of bond account(s)
+  show-bond [options] [bond-or-vote-or-withdraw-request]       Showing data of bond account(s)
   init-bond [options]                                          Create a new bond account.
   configure-bond [options] <bond-or-vote>                      Configure existing bond account.
   fund-bond [options] <bond-or-vote>                           Funding a bond account with amount of SOL within a stake account.
@@ -358,5 +429,9 @@ Commands:
                                                                Requires the bond authority signature (--authority, defaults to wallet).
   cancel-withdraw-request [options] [request-or-bond-or-vote]  Cancelling the withdraw request account, which is the withdrawal request ticket, by removing the account from
                                                                the chain.
+  subscribe [options] <bond-or-vote>                           Subscribe to bond notifications. Requires signing with bond authority or validator identity keypair.
+  unsubscribe [options] <bond-or-vote>                         Unsubscribe from bond notifications. Requires signing with bond authority or validator identity keypair.
+  subscriptions [options] <bond-or-vote>                       Show subscriptions to bond notifications. Requires signing with bond authority or validator identity keypair.
+  show-notifications [options] [bond-or-vote]                  Show notifications for a bond. When no address is provided, shows broadcast announcements.
   help [command]                                               display help for command
 ```

--- a/packages/validator-bonds-cli-institutional/package.json
+++ b/packages/validator-bonds-cli-institutional/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-institutional",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "CLI of the validator bonds contract streamlined for institutional users",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-institutional/src/index.ts
+++ b/packages/validator-bonds-cli-institutional/src/index.ts
@@ -12,7 +12,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli-institutional'
 
 launchCliProgram({
-  version: '2.5.0',
+  version: '2.6.0',
   installAdditionalOptions: program => {
     program.setOptionValueWithSource(
       'programId',

--- a/packages/validator-bonds-cli/README.md
+++ b/packages/validator-bonds-cli/README.md
@@ -934,7 +934,7 @@ When installed globally
 # Get npm global installation folder
 npm list -g
 > /usr/lib
-> +-- @marinade.finance/validator-bonds-cli@2.5.0
+> +-- @marinade.finance/validator-bonds-cli@2.6.0
 > ...
 # In this case, the `bin` folder is located at /usr/bin
 ```
@@ -954,7 +954,7 @@ npm i -g @marinade.finance/validator-bonds-cli@latest
 # Verify installation
 npm list -g
 # Output: ~/.local/share/npm/lib
-#         └── @marinade.finance/validator-bonds-cli@2.5.0
+#         └── @marinade.finance/validator-bonds-cli@2.6.0
 ```
 
 To execute the installed packages from any location,
@@ -1149,7 +1149,7 @@ Commands:
   # Get npm global installation folder
   npm list -g
   > ~/.local/share/npm/lib
-  > `-- @marinade.finance/validator-bonds-cli@2.5.0
+  > `-- @marinade.finance/validator-bonds-cli@2.6.0
   # In this case, the 'bin' folder is located at ~/.local/share/npm/bin
 
   # Get validator-bonds binary folder

--- a/packages/validator-bonds-cli/package.json
+++ b/packages/validator-bonds-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "CLI of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli/src/index.ts
+++ b/packages/validator-bonds-cli/src/index.ts
@@ -13,7 +13,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli'
 
 launchCliProgram({
-  version: '2.5.0',
+  version: '2.6.0',
   installAdditionalOptions: program => {
     program.option(
       '--program-id <pubkey>',

--- a/packages/validator-bonds-sdk/package.json
+++ b/packages/validator-bonds-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-sdk",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "SDK of the validator bonds contract",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Fixing the CLI to force the update to be only for major/minor versions
* Updating the package.json versions for release
* Readme update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CLI version checking that permits patch updates with a warning and installation guidance.
  - Major and minor version updates are blocked until the CLI is upgraded.
  - Added commands for managing bond notification subscriptions and viewing notifications.
  - `show-bond` now supports withdrawal-request addresses.

- **Documentation**
  - Documented Select bond funding thresholds and Telegram/email notification workflows.

- **Chores**
  - Updated CLI packages to version 2.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->