### PR TITLE
[GEN-8711] Stage cargo binaries at target/release for CARGO_TARGET_DIR-aware Buildkite agents

### DIFF
--- a/.buildkite/claim-settlements.yml
+++ b/.buildkite/claim-settlements.yml
@@ -31,13 +31,7 @@ steps:
     - . "$HOME/.cargo/env"
     - cargo build --release --bin list-claimable-epoch
     - cargo build --release --bin claim-settlement
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/list-claimable-epoch" "$$TARGET_DIR/release/claim-settlement" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/{list-claimable-epoch,claim-settlement}'
     artifact_paths:
       - target/release/list-claimable-epoch
       - target/release/claim-settlement

--- a/.buildkite/claim-settlements.yml
+++ b/.buildkite/claim-settlements.yml
@@ -31,6 +31,13 @@ steps:
     - . "$HOME/.cargo/env"
     - cargo build --release --bin list-claimable-epoch
     - cargo build --release --bin claim-settlement
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/list-claimable-epoch" "$$TARGET_DIR/release/claim-settlement" target/release/
+      fi
     artifact_paths:
       - target/release/list-claimable-epoch
       - target/release/claim-settlement

--- a/.buildkite/close-settlements.yml
+++ b/.buildkite/close-settlements.yml
@@ -31,6 +31,13 @@ steps:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin list-settlement'
     - 'cargo build --release --bin close-settlement'
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/list-settlement" "$$TARGET_DIR/release/close-settlement" target/release/
+      fi
     artifact_paths:
       - target/release/list-settlement
       - target/release/close-settlement

--- a/.buildkite/close-settlements.yml
+++ b/.buildkite/close-settlements.yml
@@ -31,13 +31,7 @@ steps:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin list-settlement'
     - 'cargo build --release --bin close-settlement'
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/list-settlement" "$$TARGET_DIR/release/close-settlement" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/{list-settlement,close-settlement}'
     artifact_paths:
       - target/release/list-settlement
       - target/release/close-settlement

--- a/.buildkite/collect-bonds.yml
+++ b/.buildkite/collect-bonds.yml
@@ -12,6 +12,13 @@ steps:
     commands:
     - source "$HOME/.cargo/env"
     - cargo build --release --bin bonds-collector --bin validator-bonds-api-cli
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/bonds-collector" "$$TARGET_DIR/release/validator-bonds-api-cli" target/release/
+      fi
     artifact_paths:
       - target/release/bonds-collector
       - target/release/validator-bonds-api-cli

--- a/.buildkite/collect-bonds.yml
+++ b/.buildkite/collect-bonds.yml
@@ -12,13 +12,7 @@ steps:
     commands:
     - source "$HOME/.cargo/env"
     - cargo build --release --bin bonds-collector --bin validator-bonds-api-cli
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/bonds-collector" "$$TARGET_DIR/release/validator-bonds-api-cli" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/{bonds-collector,validator-bonds-api-cli}'
     artifact_paths:
       - target/release/bonds-collector
       - target/release/validator-bonds-api-cli

--- a/.buildkite/fund-settlements.yml
+++ b/.buildkite/fund-settlements.yml
@@ -56,13 +56,7 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin fund-settlement'
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/fund-settlement" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/fund-settlement'
     artifact_paths:
       - target/release/fund-settlement
 

--- a/.buildkite/fund-settlements.yml
+++ b/.buildkite/fund-settlements.yml
@@ -56,6 +56,13 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin fund-settlement'
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/fund-settlement" target/release/
+      fi
     artifact_paths:
       - target/release/fund-settlement
 

--- a/.buildkite/generate-merkle-trees.yml
+++ b/.buildkite/generate-merkle-trees.yml
@@ -13,6 +13,13 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin merkle-generator-cli'
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/merkle-generator-cli" target/release/
+      fi
     artifact_paths:
       - target/release/merkle-generator-cli
 

--- a/.buildkite/generate-merkle-trees.yml
+++ b/.buildkite/generate-merkle-trees.yml
@@ -13,13 +13,7 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin merkle-generator-cli'
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/merkle-generator-cli" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/merkle-generator-cli'
     artifact_paths:
       - target/release/merkle-generator-cli
 

--- a/.buildkite/init-settlements.yml
+++ b/.buildkite/init-settlements.yml
@@ -104,6 +104,13 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin init-settlement'
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/init-settlement" target/release/
+      fi
     artifact_paths:
       - target/release/init-settlement
 

--- a/.buildkite/init-settlements.yml
+++ b/.buildkite/init-settlements.yml
@@ -104,13 +104,7 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin init-settlement'
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/init-settlement" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/init-settlement'
     artifact_paths:
       - target/release/init-settlement
 

--- a/.buildkite/merge-stakes.yml
+++ b/.buildkite/merge-stakes.yml
@@ -34,13 +34,7 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin merge-stakes'
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/merge-stakes" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/merge-stakes'
     artifact_paths:
       - target/release/merge-stakes
 

--- a/.buildkite/merge-stakes.yml
+++ b/.buildkite/merge-stakes.yml
@@ -34,6 +34,13 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin merge-stakes'
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/merge-stakes" target/release/
+      fi
     artifact_paths:
       - target/release/merge-stakes
 

--- a/.buildkite/prepare-bid-distribution.yml
+++ b/.buildkite/prepare-bid-distribution.yml
@@ -15,13 +15,7 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin bid-distribution-cli'
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/bid-distribution-cli" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/bid-distribution-cli'
     artifact_paths:
       - target/release/bid-distribution-cli
 

--- a/.buildkite/prepare-bid-distribution.yml
+++ b/.buildkite/prepare-bid-distribution.yml
@@ -15,6 +15,13 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin bid-distribution-cli'
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/bid-distribution-cli" target/release/
+      fi
     artifact_paths:
       - target/release/bid-distribution-cli
 

--- a/.buildkite/prepare-institutional-distribution.yml
+++ b/.buildkite/prepare-institutional-distribution.yml
@@ -22,13 +22,7 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin institutional-distribution-cli --bin merkle-generator-cli'
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/institutional-distribution-cli" "$$TARGET_DIR/release/merkle-generator-cli" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/{institutional-distribution-cli,merkle-generator-cli}'
     artifact_paths:
       - target/release/institutional-distribution-cli
       - target/release/merkle-generator-cli

--- a/.buildkite/prepare-institutional-distribution.yml
+++ b/.buildkite/prepare-institutional-distribution.yml
@@ -22,6 +22,13 @@ steps:
     commands:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin institutional-distribution-cli --bin merkle-generator-cli'
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/institutional-distribution-cli" "$$TARGET_DIR/release/merkle-generator-cli" target/release/
+      fi
     artifact_paths:
       - target/release/institutional-distribution-cli
       - target/release/merkle-generator-cli

--- a/.buildkite/verify-settlements.yml
+++ b/.buildkite/verify-settlements.yml
@@ -41,13 +41,7 @@ steps:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin list-settlement'
     - 'cargo build --release --bin verify-settlement'
-    - |
-      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
-      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
-      if [ "$$TARGET_DIR" != "target" ]; then
-        mkdir -p target/release
-        cp -f "$$TARGET_DIR/release/list-settlement" "$$TARGET_DIR/release/verify-settlement" target/release/
-      fi
+    - '[ "$${CARGO_TARGET_DIR:-target}" = target ] || install -D -t target/release "$$CARGO_TARGET_DIR"/release/{list-settlement,verify-settlement}'
     artifact_paths:
       - target/release/verify-settlement
       - target/release/list-settlement

--- a/.buildkite/verify-settlements.yml
+++ b/.buildkite/verify-settlements.yml
@@ -41,6 +41,13 @@ steps:
     - '. "$HOME/.cargo/env"'
     - 'cargo build --release --bin list-settlement'
     - 'cargo build --release --bin verify-settlement'
+    - |
+      # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release for the artifact upload
+      TARGET_DIR="$${CARGO_TARGET_DIR:-target}"
+      if [ "$$TARGET_DIR" != "target" ]; then
+        mkdir -p target/release
+        cp -f "$$TARGET_DIR/release/list-settlement" "$$TARGET_DIR/release/verify-settlement" target/release/
+      fi
     artifact_paths:
       - target/release/verify-settlement
       - target/release/list-settlement

--- a/scripts/regression-test-settlements.sh
+++ b/scripts/regression-test-settlements.sh
@@ -155,15 +155,7 @@ if [[ ! -x "$BID_CLI" || ! -x "$MERKLE_CLI" || ! -x "$INST_CLI" ]]; then
     --bin bid-distribution-cli \
     --bin institutional-distribution-cli \
     --bin merkle-generator-cli)
-  # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release
-  TARGET_DIR="${CARGO_TARGET_DIR:-target}"
-  if [[ "$TARGET_DIR" != "target" ]]; then
-    (cd "$REPO_ROOT" && mkdir -p target/release && cp -f \
-      "$TARGET_DIR/release/bid-distribution-cli" \
-      "$TARGET_DIR/release/institutional-distribution-cli" \
-      "$TARGET_DIR/release/merkle-generator-cli" \
-      target/release/)
-  fi
+  [ "${CARGO_TARGET_DIR:-target}" = target ] || (cd "$REPO_ROOT" && install -D -t target/release "$CARGO_TARGET_DIR"/release/{bid-distribution-cli,institutional-distribution-cli,merkle-generator-cli})
 fi
 
 SETTLEMENT_CONFIG="$REPO_ROOT/settlement-config.yaml"

--- a/scripts/regression-test-settlements.sh
+++ b/scripts/regression-test-settlements.sh
@@ -155,6 +155,15 @@ if [[ ! -x "$BID_CLI" || ! -x "$MERKLE_CLI" || ! -x "$INST_CLI" ]]; then
     --bin bid-distribution-cli \
     --bin institutional-distribution-cli \
     --bin merkle-generator-cli)
+  # agents may set CARGO_TARGET_DIR to a shared cache; stage binaries at target/release
+  TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+  if [[ "$TARGET_DIR" != "target" ]]; then
+    (cd "$REPO_ROOT" && mkdir -p target/release && cp -f \
+      "$TARGET_DIR/release/bid-distribution-cli" \
+      "$TARGET_DIR/release/institutional-distribution-cli" \
+      "$TARGET_DIR/release/merkle-generator-cli" \
+      target/release/)
+  fi
 fi
 
 SETTLEMENT_CONFIG="$REPO_ROOT/settlement-config.yaml"


### PR DESCRIPTION
Buildkite agents will soon export `CARGO_TARGET_DIR` globally (agent `environment` hook pointing at a host build cache under `/mnt/storage-1/cargo-target/<pipeline>-<repo>-<commit>-<rustc-hash>`), so `cargo build` output will no longer land in `./target/release`.

This adds a staging block after every `cargo build` in the 10 rust-building pipelines (and `scripts/regression-test-settlements.sh`): when `CARGO_TARGET_DIR` is set, the named binaries are copied back into `./target/release/` so all `artifact_paths`, `artifact download`, `chmod`, and run lines keep working unchanged. When the variable is unset (hook not deployed yet) the block is a no-op, so this is safe to merge ahead of the hook.

All `CARGO_TARGET_DIR`/`TARGET_DIR` references in the YAML are `$$`-escaped to defer expansion to job runtime. Verified: YAML parses, bin sets match `--bin` args / staged names / `artifact_paths` in all 10 files, and the rendered snippet was executed both with the variable unset (no-op) and set (binaries staged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEGbV86P2XNoY8Jq6CMg6D)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build and regression-test reliability when using a custom build output directory.
  * Ensured required release binaries are available at the expected artifact and execution paths.
  * Preserved existing behavior when using the default build directory.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->