### PR TITLE
[GEN-8055][cli] clarify pending status on notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ plugins/validator-bonds/evals/report/
 # Demo recordings
 *.cast
 *.gif
+.refs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3032,7 +3032,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.17",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -10631,7 +10631,7 @@ dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.14",
+ "h2 0.4.17",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",

--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,11 @@ ignore = [
   # 0.102.x is pulled via gcp-bigquery-client -> yup-oauth2 -> rustls 0.22.
   # Revisit when gcp-bigquery-client moves to a rustls 0.23 release.
   "RUSTSEC-2026-0049",
+  # h2 unbounded empty DATA frames (DoS, low severity). Patched only in >= 0.4.16
+  # and the 0.3 line never got a release. The 0.4 stack is on 0.4.17 via `cargo
+  # update`; the stuck 0.3.27 comes through hyper 0.14 via tonic 0.9 / reqwest
+  # 0.11 / solana-storage-bigtable. Drop once those move to hyper 1.x.
+  "RUSTSEC-2026-0258",
   # Unmaintained crates pinned deep in the Solana validator stack
   # (solana-runtime / solana-ledger / solana-storage-bigtable), reached via
   # the snapshot-parser git dep, plus the reqwest 0.11 / gcp-bigquery-client

--- a/packages/validator-bonds-cli-core/package.json
+++ b/packages/validator-bonds-cli-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-core",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Common CLI Core of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-core/src/commands/manage/show-notifications.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/show-notifications.ts
@@ -146,7 +146,8 @@ export async function showNotifications({
     }
 
     if (data.length === 0) {
-      logger.info(
+      // the pino transport writes to stdout, where printData emits the --format payload
+      console.error(
         voteAccount
           ? `No notifications found for vote account ${voteAccount}`
           : 'No broadcast notifications found',

--- a/packages/validator-bonds-cli-core/src/commands/manage/subscribe.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/subscribe.ts
@@ -274,10 +274,17 @@ function logTelegramResult(
           ' Press Start in the bot to confirm.',
       )
     }
+    logger.info(
+      "The subscription is reported as 'pending' until the first notification" +
+        " is delivered, then it turns to 'active'." +
+        ' Pressing Start is enough, no further action is needed.',
+    )
     return
   }
 
-  logger.info(
-    `Successfully subscribed to telegram notifications for ${bondLabel}`,
+  logger.warn(
+    `Subscription created for ${bondLabel} but the server returned no` +
+      ' Telegram activation link. Notifications cannot be delivered until' +
+      ' the subscription is activated. Please contact support.',
   )
 }

--- a/packages/validator-bonds-cli-core/src/commands/manage/subscriptions.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/subscriptions.ts
@@ -162,6 +162,19 @@ export async function showSubscriptions({
       },
       format,
     )
+
+    if (
+      data.some(
+        s => s.channel === 'telegram' && s.telegram_status === 'pending',
+      )
+    ) {
+      logger.info(
+        "Telegram status 'pending' means no notification has been delivered yet." +
+          " It turns to 'active' after the first delivery." +
+          ' If you already pressed Start in the Telegram bot' +
+          ' the subscription is activated and delivery works.',
+      )
+    }
   } catch (e) {
     const httpMsg = formatHttpError(e, notificationsApiUrl)
     if (httpMsg) {

--- a/packages/validator-bonds-cli-core/src/commands/manage/subscriptions.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/subscriptions.ts
@@ -149,7 +149,8 @@ export async function showSubscriptions({
     )
 
     if (data.length === 0) {
-      logger.info(
+      // the pino transport writes to stdout, where printData emits the --format payload
+      console.error(
         `No notification subscriptions found for vote account ${voteAccount.toBase58()}`,
       )
       return
@@ -168,7 +169,7 @@ export async function showSubscriptions({
         s => s.channel === 'telegram' && s.telegram_status === 'pending',
       )
     ) {
-      logger.info(
+      console.error(
         "Telegram status 'pending' means no notification has been delivered yet." +
           " It turns to 'active' after the first delivery." +
           ' If you already pressed Start in the Telegram bot' +

--- a/packages/validator-bonds-cli-institutional/README.md
+++ b/packages/validator-bonds-cli-institutional/README.md
@@ -25,7 +25,7 @@ To get info on available commands
 ```sh
 # to verify installed version
 validator-bonds-institutional --version
-2.6.0
+2.6.1
 
 # get reference of available commands
 validator-bonds-institutional --help
@@ -275,6 +275,9 @@ validator-bonds-institutional subscriptions <bond-or-vote-account> \
 ```
 
 Shows channel type, address, and status (e.g., `active`, `pending`, `inactive`) for each subscription.
+
+For Telegram, `pending` only means no notification has been delivered yet; it turns to `active` after the first delivery.
+Once you pressed "Start" in the bot the subscription is activated and delivery works, even while it still reads `pending`.
 
 ### View Notifications
 

--- a/packages/validator-bonds-cli-institutional/README.md
+++ b/packages/validator-bonds-cli-institutional/README.md
@@ -277,7 +277,7 @@ validator-bonds-institutional subscriptions <bond-or-vote-account> \
 Shows channel type, address, and status (e.g., `active`, `pending`, `inactive`) for each subscription.
 
 For Telegram, `pending` only means no notification has been delivered yet; it turns to `active` after the first delivery.
-Once you pressed "Start" in the bot the subscription is activated and delivery works, even while it still reads `pending`.
+Once you press "Start" in the bot the subscription is activated and delivery works, even while it still reads `pending`.
 
 ### View Notifications
 

--- a/packages/validator-bonds-cli-institutional/package.json
+++ b/packages/validator-bonds-cli-institutional/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-institutional",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "CLI of the validator bonds contract streamlined for institutional users",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-institutional/src/index.ts
+++ b/packages/validator-bonds-cli-institutional/src/index.ts
@@ -12,7 +12,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli-institutional'
 
 launchCliProgram({
-  version: '2.6.0',
+  version: '2.6.1',
   installAdditionalOptions: program => {
     program.setOptionValueWithSource(
       'programId',

--- a/packages/validator-bonds-cli/README.md
+++ b/packages/validator-bonds-cli/README.md
@@ -697,7 +697,7 @@ validator-bonds subscriptions <bond-or-vote-account> \
 Shows channel type, address, and status (e.g., `active`, `pending`, `inactive`) for each subscription.
 
 For Telegram, `pending` only means no notification has been delivered yet; it turns to `active` after the first delivery.
-Once you pressed "Start" in the bot the subscription is activated and delivery works, even while it still reads `pending`.
+Once you press "Start" in the bot the subscription is activated and delivery works, even while it still reads `pending`.
 
 ### View Notifications
 

--- a/packages/validator-bonds-cli/README.md
+++ b/packages/validator-bonds-cli/README.md
@@ -696,6 +696,9 @@ validator-bonds subscriptions <bond-or-vote-account> \
 
 Shows channel type, address, and status (e.g., `active`, `pending`, `inactive`) for each subscription.
 
+For Telegram, `pending` only means no notification has been delivered yet; it turns to `active` after the first delivery.
+Once you pressed "Start" in the bot the subscription is activated and delivery works, even while it still reads `pending`.
+
 ### View Notifications
 
 ```sh
@@ -934,7 +937,7 @@ When installed globally
 # Get npm global installation folder
 npm list -g
 > /usr/lib
-> +-- @marinade.finance/validator-bonds-cli@2.6.0
+> +-- @marinade.finance/validator-bonds-cli@2.6.1
 > ...
 # In this case, the `bin` folder is located at /usr/bin
 ```
@@ -954,7 +957,7 @@ npm i -g @marinade.finance/validator-bonds-cli@latest
 # Verify installation
 npm list -g
 # Output: ~/.local/share/npm/lib
-#         └── @marinade.finance/validator-bonds-cli@2.6.0
+#         └── @marinade.finance/validator-bonds-cli@2.6.1
 ```
 
 To execute the installed packages from any location,
@@ -1149,7 +1152,7 @@ Commands:
   # Get npm global installation folder
   npm list -g
   > ~/.local/share/npm/lib
-  > `-- @marinade.finance/validator-bonds-cli@2.6.0
+  > `-- @marinade.finance/validator-bonds-cli@2.6.1
   # In this case, the 'bin' folder is located at ~/.local/share/npm/bin
 
   # Get validator-bonds binary folder

--- a/packages/validator-bonds-cli/__tests__/test-validator/subscriptions.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/subscriptions.spec.ts
@@ -54,6 +54,7 @@ describe('CLI subscription commands', () => {
                 channel: 'telegram',
                 channel_address: '@testuser',
                 notification_type: 'bonds',
+                telegram_status: 'pending',
               },
             ]),
           )
@@ -171,7 +172,8 @@ describe('CLI subscription commands', () => {
       },
     ]).toHaveMatchingSpawnOutput({
       code: 0,
-      stdout: /Subscription created for bond/,
+      stdout:
+        /Subscription created for bond[\s\S]*reported as 'pending' until the first notification/,
     })
   })
 
@@ -264,6 +266,7 @@ describe('CLI subscription commands', () => {
     ]).toHaveMatchingSpawnOutput({
       code: 0,
       stdout: /telegram/,
+      stderr: /Telegram status 'pending' means/,
     })
   })
 

--- a/packages/validator-bonds-cli/package.json
+++ b/packages/validator-bonds-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "CLI of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli/src/index.ts
+++ b/packages/validator-bonds-cli/src/index.ts
@@ -13,7 +13,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli'
 
 launchCliProgram({
-  version: '2.6.0',
+  version: '2.6.1',
   installAdditionalOptions: program => {
     program.option(
       '--program-id <pubkey>',

--- a/packages/validator-bonds-sdk/package.json
+++ b/packages/validator-bonds-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-sdk",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "SDK of the validator bonds contract",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`pending` is by design as the telegram bot cannot currently talk back to notification service (bigger BE changes would be needed). Clarification goes to description of the status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Telegram subscriptions now clearly show when activation is pending and explain that pressing **Start** in the bot completes activation.
  - Added guidance when no activation link is available, including how to restore notifications.
  - Subscription listings now explain pending status and activation timing.

- **Bug Fixes**
  - Status and notification messages are separated from formatted command output for cleaner results.

- **Documentation**
  - Updated Telegram subscription guidance and installation examples for version 2.6.1.

- **Chores**
  - Updated CLI and SDK package versions to 2.6.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->