### PR TITLE
[GEN-8245] fix api loading  protected events processing

### DIFF
--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -1,6 +1,9 @@
 use crate::dto::{SettlementMetaSchema, ValidatorBondRecordSchema};
 use crate::{
-    dto::{LegacyProtectedEventRecord, ProtectedEventRecord},
+    dto::{
+        LegacyProtectedEventRecord, LegacyProtectedEventsResponse, ProtectedEventRecord,
+        ProtectedEventsResponse,
+    },
     handlers::{
         bonds, collected_stake, docs, protected_events, protected_validators, verified_validators,
     },
@@ -35,8 +38,8 @@ use utoipa::{
         schemas(ProtectedEvent),
         schemas(bonds::BondsResponse),
         schemas(bonds::AuctionContextResponse),
-        schemas(protected_events::ProtectedEventsResponse),
-        schemas(protected_events::LegacyProtectedEventsResponse),
+        schemas(ProtectedEventsResponse),
+        schemas(LegacyProtectedEventsResponse),
         schemas(verified_validators::VerifiedValidatorsResponse),
         schemas(protected_validators::ProtectedValidatorsResponse),
         schemas(collected_stake::CollectedStakeResponse),
@@ -123,6 +126,28 @@ mod tests {
             assert!(
                 !documented.contains_key(removed),
                 "{removed} was moved under /v1 and must no longer be documented",
+            );
+        }
+    }
+
+    // The window is the only reason a consumer can stop pulling the whole history, so an
+    // undocumented one is an unusable one.
+    #[test]
+    fn both_protected_events_paths_document_the_epoch_window() {
+        let docs = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        for path in ["/protected-events", "/v1/protected-events"] {
+            let params = docs["paths"][path]["get"]["parameters"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{path} must document its parameters"));
+            let window = params
+                .iter()
+                .find(|param| param["name"] == "from_epoch")
+                .unwrap_or_else(|| panic!("{path} must document from_epoch"));
+            assert_eq!(window["in"], "query");
+            assert_eq!(window["required"], false);
+            assert!(
+                window["description"].is_string(),
+                "{path} must describe from_epoch",
             );
         }
     }

--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -149,6 +149,10 @@ mod tests {
                 window["description"].is_string(),
                 "{path} must describe from_epoch",
             );
+            assert!(
+                docs["paths"][path]["get"]["responses"]["400"].is_object(),
+                "{path} rejects an unparsable from_epoch and must document it",
+            );
         }
     }
 }

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -15,25 +15,37 @@ pub type ProtectedEventsCache = Arc<RwLock<Option<ProtectedEvents>>>;
 /// request. `records` stays for the incremental refresh and for the `from_epoch` windows.
 pub struct ProtectedEvents {
     pub records: Vec<ProtectedEventRecord>,
+    pub min_epoch: Option<u64>,
     pub v1_body: Bytes,
     pub legacy_body: Bytes,
 }
 
 impl ProtectedEvents {
-    pub fn new(records: Vec<ProtectedEventRecord>) -> anyhow::Result<Self> {
+    pub fn new(mut records: Vec<ProtectedEventRecord>) -> anyhow::Result<Self> {
+        // The refresh appends the fresh block to the older one; unsorted, the feed jumps back up.
+        records.sort_by(|left, right| right.epoch.cmp(&left.epoch));
         let legacy = LegacyProtectedEventsResponse {
             protected_events: legacy_projection(&records),
         };
         let legacy_body = Bytes::from(serde_json::to_vec(&legacy)?);
+        let min_epoch = records.iter().map(|record| record.epoch).min();
         let v1 = ProtectedEventsResponse {
             protected_events: records,
         };
         let v1_body = Bytes::from(serde_json::to_vec(&v1)?);
         Ok(Self {
             records: v1.protected_events,
+            min_epoch,
             v1_body,
             legacy_body,
         })
+    }
+
+    /// Whether the window drops a record, so a window reaching the whole feed can answer from the
+    /// rendered body.
+    pub fn narrows(&self, from_epoch: u64) -> bool {
+        self.min_epoch
+            .is_some_and(|min_epoch| from_epoch > min_epoch)
     }
 }
 

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1,12 +1,41 @@
+use axum::body::Bytes;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio_postgres::Client;
 
-use crate::dto::ProtectedEventRecord;
+use crate::dto::{
+    legacy_projection, LegacyProtectedEventsResponse, ProtectedEventRecord, ProtectedEventsResponse,
+};
 
 /// `None` until a BigQuery fetch has succeeded once. Distinguishes "never loaded" from an epoch
 /// that genuinely settled nothing, which the handlers answer as 500 and 200 respectively.
-pub type ProtectedEventsCache = Arc<RwLock<Option<Vec<ProtectedEventRecord>>>>;
+pub type ProtectedEventsCache = Arc<RwLock<Option<ProtectedEvents>>>;
+
+/// Both endpoints answer the whole feed, so the bodies are rendered per refresh instead of per
+/// request. `records` stays for the incremental refresh and for the `from_epoch` windows.
+pub struct ProtectedEvents {
+    pub records: Vec<ProtectedEventRecord>,
+    pub v1_body: Bytes,
+    pub legacy_body: Bytes,
+}
+
+impl ProtectedEvents {
+    pub fn new(records: Vec<ProtectedEventRecord>) -> anyhow::Result<Self> {
+        let legacy = LegacyProtectedEventsResponse {
+            protected_events: legacy_projection(&records),
+        };
+        let legacy_body = Bytes::from(serde_json::to_vec(&legacy)?);
+        let v1 = ProtectedEventsResponse {
+            protected_events: records,
+        };
+        let v1_body = Bytes::from(serde_json::to_vec(&v1)?);
+        Ok(Self {
+            records: v1.protected_events,
+            v1_body,
+            legacy_body,
+        })
+    }
+}
 
 pub struct Context {
     pub psql_client: Client,

--- a/api/src/dto.rs
+++ b/api/src/dto.rs
@@ -131,6 +131,18 @@ pub fn legacy_projection(records: &[ProtectedEventRecord]) -> Vec<LegacyProtecte
         .collect()
 }
 
+// Here rather than with the handler: the cache renders both bodies once per refresh.
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct ProtectedEventsResponse {
+    pub protected_events: Vec<ProtectedEventRecord>,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+#[schema(deprecated)]
+pub struct LegacyProtectedEventsResponse {
+    pub protected_events: Vec<LegacyProtectedEventRecord>,
+}
+
 /// DEPRECATED: this `{ "funder": ... }` wrapper is retained only for backward compatibility.
 /// The generated settlement JSON now exposes `funder` directly, and any field carrying this
 /// wrapper will be replaced by a top-level `funder` in a future API version.

--- a/api/src/dto.rs
+++ b/api/src/dto.rs
@@ -115,9 +115,11 @@ pub struct LegacyProtectedEventRecord {
 /// Narrows the one BigQuery feed to what the pre-`/v1` endpoint meant. Pinning the product keeps
 /// `(epoch, vote_account, meta, reason)` unique, so this stays a field drop and never re-sums:
 /// folding direct staking into a SAM amount would report a number that is true of neither.
-pub fn legacy_projection(records: &[ProtectedEventRecord]) -> Vec<LegacyProtectedEventRecord> {
+pub fn legacy_projection<'a>(
+    records: impl IntoIterator<Item = &'a ProtectedEventRecord>,
+) -> Vec<LegacyProtectedEventRecord> {
     records
-        .iter()
+        .into_iter()
         .filter(|record| {
             matches!(record.bond_type, BondType::Bidding) && record.product == LEGACY_PRODUCT
         })

--- a/api/src/handlers/protected_events.rs
+++ b/api/src/handlers/protected_events.rs
@@ -1,32 +1,53 @@
 use crate::{
     context::WrappedContext,
-    dto::{legacy_projection, LegacyProtectedEventRecord, ProtectedEventRecord},
+    dto::{
+        legacy_projection, LegacyProtectedEventsResponse, ProtectedEventRecord,
+        ProtectedEventsResponse,
+    },
     error::AppError,
 };
+use axum::body::Bytes;
 use axum::extract::{Query, State};
-use axum::Json;
+use axum::http::header;
+use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Debug, utoipa::ToSchema)]
-pub struct ProtectedEventsResponse {
-    protected_events: Vec<ProtectedEventRecord>,
-}
-
-#[derive(Serialize, Debug, utoipa::ToSchema)]
-#[schema(deprecated)]
-pub struct LegacyProtectedEventsResponse {
-    protected_events: Vec<LegacyProtectedEventRecord>,
-}
 
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
 #[into_params(parameter_in = Query)]
-pub struct QueryParams {}
+pub struct QueryParams {
+    pub from_epoch: Option<u64>,
+}
+
+fn json_response(body: Bytes) -> impl IntoResponse {
+    ([(header::CONTENT_TYPE, "application/json")], body)
+}
+
+fn render(response: &impl Serialize) -> Result<Bytes, AppError> {
+    let body = serde_json::to_vec(response).map_err(|err| AppError {
+        message: format!("Failed to render the protected events: {err}"),
+    })?;
+    Ok(Bytes::from(body))
+}
+
+fn records_from_epoch(
+    records: &[ProtectedEventRecord],
+    from_epoch: u64,
+) -> Vec<ProtectedEventRecord> {
+    records
+        .iter()
+        .filter(|record| record.epoch >= from_epoch)
+        .cloned()
+        .collect()
+}
 
 #[utoipa::path(
     get,
     tag = "Protected Events",
     operation_id = "List Bid PSR (protected events)",
     path = "/protected-events",
+    params(
+        ("from_epoch" = Option<u64>, Query, description = "Report epochs from this one on, inclusive. Omitted, the whole history is reported."),
+    ),
     responses(
         (status = 200, description = "DEPRECATED: SAM bidding PSR only. Please use /v1/protected-events instead, which also covers the institutional bond and direct staking, split by product.", body = LegacyProtectedEventsResponse),
         (status = 500, description = "No settlements have been read from BigQuery yet. Deliberately not an empty list, which would read as 'no validator owes a protected event'."),
@@ -35,21 +56,23 @@ pub struct QueryParams {}
 #[deprecated]
 pub async fn handler(
     State(context): State<WrappedContext>,
-    Query(_query_params): Query<QueryParams>,
-) -> Result<Json<LegacyProtectedEventsResponse>, AppError> {
-    let protected_events = legacy_projection(
-        context
-            .read()
-            .await
-            .protected_events_records
-            .read()
-            .await
-            .as_deref()
-            .ok_or_else(|| AppError {
-                message: "No protected events loaded from BigQuery yet".to_string(),
-            })?,
-    );
-    Ok(Json(LegacyProtectedEventsResponse { protected_events }))
+    Query(query_params): Query<QueryParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let context = context.read().await;
+    let cache = context.protected_events_records.read().await;
+    let protected_events = cache.as_ref().ok_or_else(|| AppError {
+        message: "No protected events loaded from BigQuery yet".to_string(),
+    })?;
+    let body = match query_params.from_epoch {
+        None => protected_events.legacy_body.clone(),
+        Some(epoch) => render(&LegacyProtectedEventsResponse {
+            protected_events: legacy_projection(&records_from_epoch(
+                &protected_events.records,
+                epoch,
+            )),
+        })?,
+    };
+    Ok(json_response(body))
 }
 
 #[utoipa::path(
@@ -57,6 +80,9 @@ pub async fn handler(
     tag = "Protected Events",
     operation_id = "List PSR (protected events) per bond type and product",
     path = "/v1/protected-events",
+    params(
+        ("from_epoch" = Option<u64>, Query, description = "Report epochs from this one on, inclusive. Omitted, the whole history is reported."),
+    ),
     responses(
         (status = 200, description = "Settlements from both bond configs. One row per `bond_type` (bidding | institutional) and `product` (sam | select | single-validator), so `(epoch, vote_account, meta, reason)` is no longer unique.", body = ProtectedEventsResponse),
         (status = 500, description = "No settlements have been read from BigQuery yet. Deliberately not an empty list, which would read as 'no validator owes a protected event'."),
@@ -64,17 +90,99 @@ pub async fn handler(
 )]
 pub async fn handler_v1(
     State(context): State<WrappedContext>,
-    Query(_query_params): Query<QueryParams>,
-) -> Result<Json<ProtectedEventsResponse>, AppError> {
-    let protected_events = context
-        .read()
-        .await
-        .protected_events_records
-        .read()
-        .await
-        .clone()
-        .ok_or_else(|| AppError {
-            message: "No protected events loaded from BigQuery yet".to_string(),
-        })?;
-    Ok(Json(ProtectedEventsResponse { protected_events }))
+    Query(query_params): Query<QueryParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let context = context.read().await;
+    let cache = context.protected_events_records.read().await;
+    let protected_events = cache.as_ref().ok_or_else(|| AppError {
+        message: "No protected events loaded from BigQuery yet".to_string(),
+    })?;
+    let body = match query_params.from_epoch {
+        None => protected_events.v1_body.clone(),
+        Some(epoch) => render(&ProtectedEventsResponse {
+            protected_events: records_from_epoch(&protected_events.records, epoch),
+        })?,
+    };
+    Ok(json_response(body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::ProtectedEvents;
+    use settlement_common::settlement_collection::{
+        SettlementFunder, SettlementMeta, SettlementReason,
+    };
+    use solana_sdk::pubkey::Pubkey;
+    use validator_bonds_common::dto::BondType;
+
+    fn record(epoch: u64, bond_type: BondType, product: &str) -> ProtectedEventRecord {
+        ProtectedEventRecord {
+            epoch,
+            amount: epoch,
+            vote_account: Pubkey::new_unique(),
+            meta: SettlementMeta {
+                funder: SettlementFunder::ValidatorBond,
+            },
+            reason: SettlementReason::Bidding,
+            bond_type,
+            product: product.to_string(),
+        }
+    }
+
+    fn records() -> Vec<ProtectedEventRecord> {
+        vec![
+            record(1017, BondType::Bidding, "sam"),
+            record(1017, BondType::Institutional, "select"),
+            record(1018, BondType::Bidding, "sam"),
+            record(1018, BondType::Bidding, "single-validator"),
+        ]
+    }
+
+    fn epochs(body: &Bytes) -> Vec<u64> {
+        let parsed: serde_json::Value = serde_json::from_slice(body).unwrap();
+        parsed["protected_events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|record| record["epoch"].as_u64().unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn the_rendered_v1_body_carries_every_record() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        assert_eq!(epochs(&events.v1_body), vec![1017, 1017, 1018, 1018]);
+    }
+
+    #[test]
+    fn the_rendered_legacy_body_carries_bidding_sam_only() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        assert_eq!(epochs(&events.legacy_body), vec![1017, 1018]);
+    }
+
+    #[test]
+    fn the_rendered_legacy_body_publishes_no_new_dimension() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        let body = String::from_utf8(events.legacy_body.to_vec()).unwrap();
+        assert!(!body.contains("bond_type"), "{body}");
+        assert!(!body.contains("product"), "{body}");
+    }
+
+    #[test]
+    fn a_window_reports_the_epoch_it_starts_at() {
+        let windowed = records_from_epoch(&records(), 1018);
+        assert_eq!(
+            windowed
+                .iter()
+                .map(|record| record.epoch)
+                .collect::<Vec<_>>(),
+            vec![1018, 1018]
+        );
+    }
+
+    #[test]
+    fn a_window_past_the_last_epoch_reports_nothing() {
+        assert!(records_from_epoch(&records(), 1019).is_empty());
+    }
 }

--- a/api/src/handlers/protected_events.rs
+++ b/api/src/handlers/protected_events.rs
@@ -1,5 +1,5 @@
 use crate::{
-    context::WrappedContext,
+    context::{ProtectedEvents, WrappedContext},
     dto::{
         legacy_projection, LegacyProtectedEventsResponse, ProtectedEventRecord,
         ProtectedEventsResponse,
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
 #[into_params(parameter_in = Query)]
 pub struct QueryParams {
+    /// Report epochs from this one on, inclusive. Omitted, the whole history is reported.
     pub from_epoch: Option<u64>,
 }
 
@@ -29,15 +30,56 @@ fn render(response: &impl Serialize) -> Result<Bytes, AppError> {
     Ok(Bytes::from(body))
 }
 
-fn records_from_epoch(
-    records: &[ProtectedEventRecord],
+/// Selected under the cache guard, rendered after it is dropped: the refresh waits on that guard.
+enum Body<T> {
+    Rendered(Bytes),
+    Window(T),
+}
+
+impl<T: Serialize> Body<T> {
+    fn into_bytes(self) -> Result<Bytes, AppError> {
+        match self {
+            Body::Rendered(body) => Ok(body),
+            Body::Window(window) => render(&window),
+        }
+    }
+}
+
+fn records_from_epoch<'a>(
+    records: &'a [ProtectedEventRecord],
     from_epoch: u64,
-) -> Vec<ProtectedEventRecord> {
+) -> impl Iterator<Item = &'a ProtectedEventRecord> + 'a {
     records
         .iter()
-        .filter(|record| record.epoch >= from_epoch)
-        .cloned()
-        .collect()
+        .filter(move |record| record.epoch >= from_epoch)
+}
+
+fn v1_body(events: &ProtectedEvents, from_epoch: Option<u64>) -> Body<ProtectedEventsResponse> {
+    match from_epoch {
+        Some(from_epoch) if events.narrows(from_epoch) => Body::Window(ProtectedEventsResponse {
+            protected_events: records_from_epoch(&events.records, from_epoch)
+                .cloned()
+                .collect(),
+        }),
+        _ => Body::Rendered(events.v1_body.clone()),
+    }
+}
+
+fn legacy_body(
+    events: &ProtectedEvents,
+    from_epoch: Option<u64>,
+) -> Body<LegacyProtectedEventsResponse> {
+    match from_epoch {
+        Some(from_epoch) if events.narrows(from_epoch) => {
+            Body::Window(LegacyProtectedEventsResponse {
+                protected_events: legacy_projection(records_from_epoch(
+                    &events.records,
+                    from_epoch,
+                )),
+            })
+        }
+        _ => Body::Rendered(events.legacy_body.clone()),
+    }
 }
 
 #[utoipa::path(
@@ -45,11 +87,10 @@ fn records_from_epoch(
     tag = "Protected Events",
     operation_id = "List Bid PSR (protected events)",
     path = "/protected-events",
-    params(
-        ("from_epoch" = Option<u64>, Query, description = "Report epochs from this one on, inclusive. Omitted, the whole history is reported."),
-    ),
+    params(QueryParams),
     responses(
         (status = 200, description = "DEPRECATED: SAM bidding PSR only. Please use /v1/protected-events instead, which also covers the institutional bond and direct staking, split by product.", body = LegacyProtectedEventsResponse),
+        (status = 400, description = "`from_epoch` is not a non-negative integer."),
         (status = 500, description = "No settlements have been read from BigQuery yet. Deliberately not an empty list, which would read as 'no validator owes a protected event'."),
     )
 )]
@@ -58,21 +99,15 @@ pub async fn handler(
     State(context): State<WrappedContext>,
     Query(query_params): Query<QueryParams>,
 ) -> Result<impl IntoResponse, AppError> {
-    let context = context.read().await;
-    let cache = context.protected_events_records.read().await;
-    let protected_events = cache.as_ref().ok_or_else(|| AppError {
-        message: "No protected events loaded from BigQuery yet".to_string(),
-    })?;
-    let body = match query_params.from_epoch {
-        None => protected_events.legacy_body.clone(),
-        Some(epoch) => render(&LegacyProtectedEventsResponse {
-            protected_events: legacy_projection(&records_from_epoch(
-                &protected_events.records,
-                epoch,
-            )),
-        })?,
+    let body = {
+        let context = context.read().await;
+        let cache = context.protected_events_records.read().await;
+        let protected_events = cache.as_ref().ok_or_else(|| AppError {
+            message: "No protected events loaded from BigQuery yet".to_string(),
+        })?;
+        legacy_body(protected_events, query_params.from_epoch)
     };
-    Ok(json_response(body))
+    Ok(json_response(body.into_bytes()?))
 }
 
 #[utoipa::path(
@@ -80,11 +115,10 @@ pub async fn handler(
     tag = "Protected Events",
     operation_id = "List PSR (protected events) per bond type and product",
     path = "/v1/protected-events",
-    params(
-        ("from_epoch" = Option<u64>, Query, description = "Report epochs from this one on, inclusive. Omitted, the whole history is reported."),
-    ),
+    params(QueryParams),
     responses(
         (status = 200, description = "Settlements from both bond configs. One row per `bond_type` (bidding | institutional) and `product` (sam | select | single-validator), so `(epoch, vote_account, meta, reason)` is no longer unique.", body = ProtectedEventsResponse),
+        (status = 400, description = "`from_epoch` is not a non-negative integer."),
         (status = 500, description = "No settlements have been read from BigQuery yet. Deliberately not an empty list, which would read as 'no validator owes a protected event'."),
     )
 )]
@@ -92,24 +126,20 @@ pub async fn handler_v1(
     State(context): State<WrappedContext>,
     Query(query_params): Query<QueryParams>,
 ) -> Result<impl IntoResponse, AppError> {
-    let context = context.read().await;
-    let cache = context.protected_events_records.read().await;
-    let protected_events = cache.as_ref().ok_or_else(|| AppError {
-        message: "No protected events loaded from BigQuery yet".to_string(),
-    })?;
-    let body = match query_params.from_epoch {
-        None => protected_events.v1_body.clone(),
-        Some(epoch) => render(&ProtectedEventsResponse {
-            protected_events: records_from_epoch(&protected_events.records, epoch),
-        })?,
+    let body = {
+        let context = context.read().await;
+        let cache = context.protected_events_records.read().await;
+        let protected_events = cache.as_ref().ok_or_else(|| AppError {
+            message: "No protected events loaded from BigQuery yet".to_string(),
+        })?;
+        v1_body(protected_events, query_params.from_epoch)
     };
-    Ok(json_response(body))
+    Ok(json_response(body.into_bytes()?))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::ProtectedEvents;
     use settlement_common::settlement_collection::{
         SettlementFunder, SettlementMeta, SettlementReason,
     };
@@ -152,13 +182,26 @@ mod tests {
     #[test]
     fn the_rendered_v1_body_carries_every_record() {
         let events = ProtectedEvents::new(records()).unwrap();
-        assert_eq!(epochs(&events.v1_body), vec![1017, 1017, 1018, 1018]);
+        assert_eq!(epochs(&events.v1_body), vec![1018, 1018, 1017, 1017]);
     }
 
     #[test]
     fn the_rendered_legacy_body_carries_bidding_sam_only() {
         let events = ProtectedEvents::new(records()).unwrap();
-        assert_eq!(epochs(&events.legacy_body), vec![1017, 1018]);
+        assert_eq!(epochs(&events.legacy_body), vec![1018, 1017]);
+    }
+
+    // The shape the incremental refresh produces: the retained older block, then the fresh one.
+    #[test]
+    fn the_rendered_feed_is_epoch_ordered_however_the_refresh_merged_it() {
+        let events = ProtectedEvents::new(vec![
+            record(1017, BondType::Bidding, "sam"),
+            record(1016, BondType::Bidding, "sam"),
+            record(1018, BondType::Bidding, "sam"),
+        ])
+        .unwrap();
+        assert_eq!(epochs(&events.v1_body), vec![1018, 1017, 1016]);
+        assert_eq!(epochs(&events.legacy_body), vec![1018, 1017, 1016]);
     }
 
     #[test]
@@ -171,10 +214,8 @@ mod tests {
 
     #[test]
     fn a_window_reports_the_epoch_it_starts_at() {
-        let windowed = records_from_epoch(&records(), 1018);
         assert_eq!(
-            windowed
-                .iter()
+            records_from_epoch(&records(), 1018)
                 .map(|record| record.epoch)
                 .collect::<Vec<_>>(),
             vec![1018, 1018]
@@ -183,6 +224,47 @@ mod tests {
 
     #[test]
     fn a_window_past_the_last_epoch_reports_nothing() {
-        assert!(records_from_epoch(&records(), 1019).is_empty());
+        assert_eq!(records_from_epoch(&records(), 1019).count(), 0);
+    }
+
+    #[test]
+    fn a_window_reaching_the_whole_feed_answers_from_the_rendered_body() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        for from_epoch in [None, Some(0), Some(1017)] {
+            assert_eq!(
+                v1_body(&events, from_epoch).into_bytes().unwrap(),
+                events.v1_body
+            );
+            assert_eq!(
+                legacy_body(&events, from_epoch).into_bytes().unwrap(),
+                events.legacy_body
+            );
+        }
+    }
+
+    #[test]
+    fn a_window_dropping_an_epoch_is_rendered_per_request() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        assert_eq!(
+            epochs(&v1_body(&events, Some(1018)).into_bytes().unwrap()),
+            vec![1018, 1018]
+        );
+        assert_eq!(
+            epochs(&legacy_body(&events, Some(1018)).into_bytes().unwrap()),
+            vec![1018]
+        );
+    }
+
+    #[test]
+    fn an_empty_feed_answers_every_window_from_the_rendered_body() {
+        let events = ProtectedEvents::new(vec![]).unwrap();
+        assert_eq!(
+            v1_body(&events, Some(1018)).into_bytes().unwrap(),
+            events.v1_body
+        );
+        assert_eq!(
+            legacy_body(&events, Some(1018)).into_bytes().unwrap(),
+            events.legacy_body
+        );
     }
 }

--- a/api/src/repositories/protected_events.rs
+++ b/api/src/repositories/protected_events.rs
@@ -1,4 +1,6 @@
+use gcp_bigquery_client::model::get_query_results_parameters::GetQueryResultsParameters;
 use gcp_bigquery_client::model::query_request::QueryRequest;
+use gcp_bigquery_client::model::query_response::ResultSet;
 use solana_sdk::pubkey::Pubkey;
 use std::{str::FromStr, time::Duration};
 use tokio::time::sleep;
@@ -33,17 +35,62 @@ async fn get_protected_events(
         .await?;
 
     let mut protected_events = vec![];
-    // Fail the whole fetch, never a row: a dropped row reads as "this validator owes nothing".
-    while rs.next_row() {
-        protected_events.push(parse_row(&rs)?);
+    loop {
+        // Fail the whole fetch, never a row: a dropped row reads as "this validator owes nothing".
+        while rs.next_row() {
+            protected_events.push(parse_row(&rs)?);
+        }
+        let Some(page_token) = rs.query_response().page_token.clone() else {
+            break;
+        };
+        let job = rs
+            .query_response()
+            .job_reference
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("BigQuery paged the results but named no job"))?;
+        let job_id = job
+            .job_id
+            .ok_or_else(|| anyhow::anyhow!("BigQuery job reference carries no job id"))?;
+        let results = client
+            .job()
+            .get_query_results(
+                project_id,
+                &job_id,
+                GetQueryResultsParameters {
+                    page_token: Some(page_token),
+                    // mandatory outside US and EU, and the queried dataset is europe-central2
+                    location: job.location,
+                    ..Default::default()
+                },
+            )
+            .await?;
+        rs = ResultSet::new(results.into());
     }
+    ensure_all_rows_loaded(&rs, protected_events.len())?;
 
     Ok(protected_events)
 }
 
-fn parse_row(
-    rs: &gcp_bigquery_client::model::query_response::ResultSet,
-) -> anyhow::Result<ProtectedEventRecord> {
+// `jobs.query` answers with one page and stops; a short read reads as "no validator owes anything".
+fn ensure_all_rows_loaded(rs: &ResultSet, loaded: usize) -> anyhow::Result<()> {
+    let response = rs.query_response();
+    anyhow::ensure!(
+        response.job_complete.unwrap_or(false),
+        "BigQuery job has not completed, {loaded} rows read so far"
+    );
+    let total_rows: usize = response
+        .total_rows
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("BigQuery reported no total row count"))?
+        .parse()?;
+    anyhow::ensure!(
+        loaded == total_rows,
+        "Read {loaded} of {total_rows} rows BigQuery reports"
+    );
+    Ok(())
+}
+
+fn parse_row(rs: &ResultSet) -> anyhow::Result<ProtectedEventRecord> {
     Ok(ProtectedEventRecord {
         epoch: rs
             .get_i64_by_name("epoch")?
@@ -245,5 +292,55 @@ mod tests {
     fn a_row_with_an_unknown_bond_type_is_rejected() {
         let err = parse_row(&result_set(&[("bond_type", Some("direct"))])).unwrap_err();
         assert!(err.to_string().contains("Unknown bond type"));
+    }
+
+    fn last_page(job_complete: Option<bool>, total_rows: Option<&str>) -> ResultSet {
+        ResultSet::new(QueryResponse {
+            job_complete,
+            total_rows: total_rows.map(str::to_string),
+            schema: Some(TableSchema::new(vec![TableFieldSchema::string("epoch")])),
+            rows: Some(vec![]),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn reading_every_row_bigquery_reports_is_accepted() {
+        ensure_all_rows_loaded(&last_page(Some(true), Some("63917")), 63917).unwrap();
+    }
+
+    #[test]
+    fn an_empty_result_is_accepted() {
+        ensure_all_rows_loaded(&last_page(Some(true), Some("0")), 0).unwrap();
+    }
+
+    #[test]
+    fn a_truncated_read_is_rejected() {
+        let err = ensure_all_rows_loaded(&last_page(Some(true), Some("63917")), 50000).unwrap_err();
+        assert_eq!(err.to_string(), "Read 50000 of 63917 rows BigQuery reports");
+    }
+
+    #[test]
+    fn an_unfinished_job_is_rejected() {
+        let err = ensure_all_rows_loaded(&last_page(Some(false), None), 0).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "BigQuery job has not completed, 0 rows read so far"
+        );
+    }
+
+    #[test]
+    fn a_result_without_a_completion_flag_is_rejected() {
+        let err = ensure_all_rows_loaded(&last_page(None, Some("1")), 1).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "BigQuery job has not completed, 1 rows read so far"
+        );
+    }
+
+    #[test]
+    fn a_result_without_a_total_row_count_is_rejected() {
+        let err = ensure_all_rows_loaded(&last_page(Some(true), None), 10).unwrap_err();
+        assert_eq!(err.to_string(), "BigQuery reported no total row count");
     }
 }

--- a/api/src/repositories/protected_events.rs
+++ b/api/src/repositories/protected_events.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use gcp_bigquery_client::model::get_query_results_parameters::GetQueryResultsParameters;
 use gcp_bigquery_client::model::query_request::QueryRequest;
 use gcp_bigquery_client::model::query_response::ResultSet;
@@ -11,6 +12,10 @@ use crate::dto::ProtectedEventRecord;
 
 const CACHE_UPDATE_INTERVAL: Duration = Duration::from_secs(3600);
 const CACHE_PURGE_INTERVAL: Duration = Duration::from_secs(24 * 3600);
+// Until the first fetch lands both endpoints answer 500, so a failure must not wait out a refresh.
+const CACHE_RETRY_INTERVAL: Duration = Duration::from_secs(60);
+const COMPLETION_POLL_TIMEOUT_MS: i32 = 30_000;
+const MAX_COMPLETION_POLLS: u32 = 10;
 
 async fn get_protected_events(
     gcp_sa_key: &str,
@@ -35,40 +40,58 @@ async fn get_protected_events(
         .await?;
 
     let mut protected_events = vec![];
+    let mut polls = 0;
     loop {
         // Fail the whole fetch, never a row: a dropped row reads as "this validator owes nothing".
         while rs.next_row() {
             protected_events.push(parse_row(&rs)?);
         }
-        let Some(page_token) = rs.query_response().page_token.clone() else {
+        let Some((job_id, parameters)) = next_page(&rs)? else {
             break;
         };
-        let job = rs
-            .query_response()
-            .job_reference
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("BigQuery paged the results but named no job"))?;
-        let job_id = job
-            .job_id
-            .ok_or_else(|| anyhow::anyhow!("BigQuery job reference carries no job id"))?;
+        if parameters.page_token.is_none() {
+            polls += 1;
+            anyhow::ensure!(
+                polls <= MAX_COMPLETION_POLLS,
+                "BigQuery job {job_id} has not completed after {MAX_COMPLETION_POLLS} polls"
+            );
+        }
         let results = client
             .job()
-            .get_query_results(
-                project_id,
-                &job_id,
-                GetQueryResultsParameters {
-                    page_token: Some(page_token),
-                    // mandatory outside US and EU, and the queried dataset is europe-central2
-                    location: job.location,
-                    ..Default::default()
-                },
-            )
+            .get_query_results(project_id, &job_id, parameters)
             .await?;
         rs = ResultSet::new(results.into());
     }
     ensure_all_rows_loaded(&rs, protected_events.len())?;
 
     Ok(protected_events)
+}
+
+// A query outrunning its request timeout answers `job_complete: false` with no page token, and its
+// rows are then reachable only by re-asking for the job itself.
+fn next_page(rs: &ResultSet) -> anyhow::Result<Option<(String, GetQueryResultsParameters)>> {
+    let response = rs.query_response();
+    let page_token = response.page_token.clone();
+    if response.job_complete.unwrap_or(false) && page_token.is_none() {
+        return Ok(None);
+    }
+    let job = response
+        .job_reference
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("BigQuery has more results to give but named no job"))?;
+    let job_id = job
+        .job_id
+        .ok_or_else(|| anyhow::anyhow!("BigQuery job reference carries no job id"))?;
+    Ok(Some((
+        job_id,
+        GetQueryResultsParameters {
+            page_token,
+            // mandatory outside US and EU, and the queried dataset is europe-central2
+            location: job.location,
+            timeout_ms: Some(COMPLETION_POLL_TIMEOUT_MS),
+            ..Default::default()
+        },
+    )))
 }
 
 // `jobs.query` answers with one page and stops; a short read reads as "no validator owes anything".
@@ -78,11 +101,13 @@ fn ensure_all_rows_loaded(rs: &ResultSet, loaded: usize) -> anyhow::Result<()> {
         response.job_complete.unwrap_or(false),
         "BigQuery job has not completed, {loaded} rows read so far"
     );
-    let total_rows: usize = response
+    let reported_rows = response
         .total_rows
         .as_deref()
-        .ok_or_else(|| anyhow::anyhow!("BigQuery reported no total row count"))?
-        .parse()?;
+        .ok_or_else(|| anyhow::anyhow!("BigQuery reported no total row count"))?;
+    let total_rows: usize = reported_rows.parse().with_context(|| {
+        format!("BigQuery reported an unparsable total row count: {reported_rows}")
+    })?;
     anyhow::ensure!(
         loaded == total_rows,
         "Read {loaded} of {total_rows} rows BigQuery reports"
@@ -124,6 +149,16 @@ fn parse_row(rs: &ResultSet) -> anyhow::Result<ProtectedEventRecord> {
     })
 }
 
+async fn store(cache: &ProtectedEventsCache, records: Vec<ProtectedEventRecord>, stored: &str) {
+    match ProtectedEvents::new(records) {
+        Ok(events) => {
+            *cache.write().await = Some(events);
+            log::info!("{stored}");
+        }
+        Err(err) => log::error!("{stored} failed, the protected events did not render: {err}"),
+    }
+}
+
 pub async fn spawn_protected_events_cache(
     gcp_sa_key: String,
     project_id: String,
@@ -155,15 +190,12 @@ pub fn spawn_protected_events_cache_purger(
                         "Successfully fetched the protected events ({})",
                         updated_protected_events.len()
                     );
-                    match ProtectedEvents::new(updated_protected_events) {
-                        Ok(events) => {
-                            *protected_events.write().await = Some(events);
-                            log::info!("Protected Events completely updated");
-                        }
-                        Err(err) => {
-                            log::error!("Failed to render the protected events: {err}")
-                        }
-                    }
+                    store(
+                        &protected_events,
+                        updated_protected_events,
+                        "Protected Events completely updated",
+                    )
+                    .await;
                 }
                 Err(err) => log::error!("Failed to get the protected events: {err}"),
             };
@@ -186,7 +218,8 @@ pub fn spawn_protected_events_cache_updater(
                     protected_event.epoch.max(max_loaded_epoch)
                 });
 
-            match get_protected_events(&gcp_sa_key, &project_id, max_loaded_epoch).await {
+            let fetched = get_protected_events(&gcp_sa_key, &project_id, max_loaded_epoch).await;
+            let next_attempt = match fetched {
                 Ok(updated_protected_events) => {
                     log::info!(
                         "Successfully fetched the protected events ({}) from epoch: {max_loaded_epoch}",
@@ -203,20 +236,21 @@ pub fn spawn_protected_events_cache_updater(
                         .cloned()
                         .collect();
 
-                    match ProtectedEvents::new(merged_protected_events) {
-                        Ok(events) => {
-                            *protected_events.write().await = Some(events);
-                            log::info!("Successfully extended the protected events");
-                        }
-                        Err(err) => {
-                            log::error!("Failed to render the protected events: {err}")
-                        }
-                    }
+                    store(
+                        &protected_events,
+                        merged_protected_events,
+                        "Successfully extended the protected events",
+                    )
+                    .await;
+                    CACHE_UPDATE_INTERVAL
                 }
-                Err(err) => log::error!("Failed to get the protected events: {err}"),
+                Err(err) => {
+                    log::error!("Failed to get the protected events: {err}");
+                    CACHE_RETRY_INTERVAL
+                }
             };
 
-            sleep(CACHE_UPDATE_INTERVAL).await;
+            sleep(next_attempt).await;
         }
     });
 }
@@ -225,6 +259,7 @@ pub fn spawn_protected_events_cache_updater(
 mod tests {
     use super::*;
     use gcp_bigquery_client::model::{
+        job_reference::JobReference,
         query_response::{QueryResponse, ResultSet},
         table_cell::TableCell,
         table_field_schema::TableFieldSchema,
@@ -355,5 +390,83 @@ mod tests {
     fn a_result_without_a_total_row_count_is_rejected() {
         let err = ensure_all_rows_loaded(&last_page(Some(true), None), 10).unwrap_err();
         assert_eq!(err.to_string(), "BigQuery reported no total row count");
+    }
+
+    #[test]
+    fn a_failed_fetch_is_retried_sooner_than_the_next_refresh() {
+        assert!(CACHE_RETRY_INTERVAL < CACHE_UPDATE_INTERVAL);
+    }
+
+    #[test]
+    fn a_result_with_an_unparsable_total_row_count_is_rejected() {
+        let err = ensure_all_rows_loaded(&last_page(Some(true), Some("many")), 10).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "BigQuery reported an unparsable total row count: many"
+        );
+    }
+
+    fn page(job_complete: bool, page_token: Option<&str>, job: Option<JobReference>) -> ResultSet {
+        ResultSet::new(QueryResponse {
+            job_complete: Some(job_complete),
+            page_token: page_token.map(str::to_string),
+            job_reference: job,
+            total_rows: Some("0".to_string()),
+            schema: Some(TableSchema::new(vec![TableFieldSchema::string("epoch")])),
+            rows: Some(vec![]),
+            ..Default::default()
+        })
+    }
+
+    fn job() -> JobReference {
+        JobReference {
+            job_id: Some("job_abc".to_string()),
+            location: Some("europe-central2".to_string()),
+            project_id: Some("marinade".to_string()),
+        }
+    }
+
+    #[test]
+    fn a_completed_result_without_a_page_token_ends_the_read() {
+        assert!(next_page(&page(true, None, Some(job()))).unwrap().is_none());
+    }
+
+    #[test]
+    fn a_page_token_is_carried_into_the_next_request() {
+        let (job_id, parameters) = next_page(&page(true, Some("token_2"), Some(job())))
+            .unwrap()
+            .unwrap();
+        assert_eq!(job_id, "job_abc");
+        assert_eq!(parameters.page_token.as_deref(), Some("token_2"));
+        assert_eq!(parameters.location.as_deref(), Some("europe-central2"));
+    }
+
+    // The regression the paging guard exists for: no rows, no token, and the job still running.
+    #[test]
+    fn an_unfinished_job_is_polled_rather_than_reported_as_read() {
+        let (job_id, parameters) = next_page(&page(false, None, Some(job()))).unwrap().unwrap();
+        assert_eq!(job_id, "job_abc");
+        assert_eq!(parameters.page_token, None);
+        assert_eq!(parameters.location.as_deref(), Some("europe-central2"));
+        assert_eq!(parameters.timeout_ms, Some(COMPLETION_POLL_TIMEOUT_MS));
+    }
+
+    #[test]
+    fn more_results_without_a_job_reference_are_rejected() {
+        let err = next_page(&page(false, None, None)).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "BigQuery has more results to give but named no job"
+        );
+    }
+
+    #[test]
+    fn a_job_reference_without_an_id_is_rejected() {
+        let job = JobReference {
+            job_id: None,
+            ..job()
+        };
+        let err = next_page(&page(true, Some("token_2"), Some(job))).unwrap_err();
+        assert_eq!(err.to_string(), "BigQuery job reference carries no job id");
     }
 }

--- a/api/src/repositories/protected_events.rs
+++ b/api/src/repositories/protected_events.rs
@@ -6,7 +6,7 @@ use std::{str::FromStr, time::Duration};
 use tokio::time::sleep;
 use validator_bonds_common::dto::BondType;
 
-use crate::context::ProtectedEventsCache;
+use crate::context::{ProtectedEvents, ProtectedEventsCache};
 use crate::dto::ProtectedEventRecord;
 
 const CACHE_UPDATE_INTERVAL: Duration = Duration::from_secs(3600);
@@ -155,8 +155,15 @@ pub fn spawn_protected_events_cache_purger(
                         "Successfully fetched the protected events ({})",
                         updated_protected_events.len()
                     );
-                    *protected_events.write().await = Some(updated_protected_events);
-                    log::info!("Protected Events completely updated");
+                    match ProtectedEvents::new(updated_protected_events) {
+                        Ok(events) => {
+                            *protected_events.write().await = Some(events);
+                            log::info!("Protected Events completely updated");
+                        }
+                        Err(err) => {
+                            log::error!("Failed to render the protected events: {err}")
+                        }
+                    }
                 }
                 Err(err) => log::error!("Failed to get the protected events: {err}"),
             };
@@ -174,7 +181,7 @@ pub fn spawn_protected_events_cache_updater(
                 .read()
                 .await
                 .iter()
-                .flatten()
+                .flat_map(|events| &events.records)
                 .fold(0, |max_loaded_epoch, protected_event| {
                     protected_event.epoch.max(max_loaded_epoch)
                 });
@@ -190,15 +197,21 @@ pub fn spawn_protected_events_cache_updater(
                         .read()
                         .await
                         .iter()
-                        .flatten()
+                        .flat_map(|events| &events.records)
                         .filter(|protected_event| protected_event.epoch < max_loaded_epoch)
                         .chain(updated_protected_events.iter())
                         .cloned()
                         .collect();
 
-                    *protected_events.write().await = Some(merged_protected_events);
-
-                    log::info!("Successfully extended the protected events");
+                    match ProtectedEvents::new(merged_protected_events) {
+                        Ok(events) => {
+                            *protected_events.write().await = Some(events);
+                            log::info!("Successfully extended the protected events");
+                        }
+                        Err(err) => {
+                            log::error!("Failed to render the protected events: {err}")
+                        }
+                    }
                 }
                 Err(err) => log::error!("Failed to get the protected events: {err}"),
             };


### PR DESCRIPTION
On checking the https://github.com/marinade-finance/validator-bonds/pull/491, there seems to be some issues coming from bq pagination. Fixing that mostly + other smaller points.
Connected to here: https://github.com/marinade-finance/ops-infra/pull/2780

---

`/protected-events` and `/v1/protected-events` report the complete event history again, and stop re-rendering it on every request.

- Page the BigQuery read and reject a short result, since a single-page read silently dropped 13,917 rows — epochs 530–732 vanished from the feed after `/v1` widened the query past BigQuery's one-page limit
- Poll a bounded number of times when BigQuery answers `job_complete: false`, so a slow query no longer caches an empty result that reads as "no validator owes a protected event"
- Render both response bodies once per cache refresh instead of per request, so a request is a `Bytes` clone rather than a 64k-record clone plus a 12 MB serde render that one IP could demand 30 times a second
- Add an optional `?from_epoch=` window to both endpoints so the PSR dashboard can pull the recent epochs it needs instead of 489 epochs of history, with the memoized body still served whenever the window drops nothing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `from_epoch` filtering to both protected-events endpoints.
  * Improved protected-event response ordering and support for narrowed time windows.
  * Added API documentation for the new query parameter and possible error responses.

* **Bug Fixes**
  * Improved handling of paginated and incomplete data results.
  * Added validation for reported row counts and query completion.
  * Cache refresh failures now retry sooner, improving data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->