### PR TITLE
[GEN-8245] fix api loading protected events processing (review fixes)

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1,51 +1,92 @@
 use axum::body::Bytes;
-use std::sync::Arc;
+use serde::Serialize;
+use std::{cmp::Reverse, sync::Arc};
 use tokio::sync::RwLock;
 use tokio_postgres::Client;
 
-use crate::dto::{
-    legacy_projection, LegacyProtectedEventsResponse, ProtectedEventRecord, ProtectedEventsResponse,
-};
+use crate::dto::{legacy_projection, ProtectedEventRecord};
 
 /// `None` until a BigQuery fetch has succeeded once. Distinguishes "never loaded" from an epoch
 /// that genuinely settled nothing, which the handlers answer as 500 and 200 respectively.
 pub type ProtectedEventsCache = Arc<RwLock<Option<ProtectedEvents>>>;
 
+// The envelope is written by hand so the epoch offsets can be taken as the records go in;
+// `the_bodies_match_the_serde_rendering_of_the_response_dtos` pins it to the documented DTOs.
+const BODY_PREFIX: &[u8] = br#"{"protected_events":["#;
+const BODY_SUFFIX: &[u8] = b"]}";
+
 /// Both endpoints answer the whole feed, so the bodies are rendered per refresh instead of per
-/// request. `records` stays for the incremental refresh and for the `from_epoch` windows.
+/// request. `records` stays for the incremental refresh.
 pub struct ProtectedEvents {
     pub records: Vec<ProtectedEventRecord>,
-    pub min_epoch: Option<u64>,
-    pub v1_body: Bytes,
-    pub legacy_body: Bytes,
+    pub v1: EpochWindowedBody,
+    pub legacy: EpochWindowedBody,
+}
+
+/// A rendered feed plus, per epoch, where that epoch's last record ends. Records run
+/// epoch-descending, so every `from_epoch` window is a prefix and costs a slice, not a re-render.
+pub struct EpochWindowedBody {
+    body: Bytes,
+    epoch_ends: Vec<(u64, usize)>,
+}
+
+impl EpochWindowedBody {
+    fn new<T: Serialize>(records: impl IntoIterator<Item = (u64, T)>) -> anyhow::Result<Self> {
+        let mut body = BODY_PREFIX.to_vec();
+        let mut epoch_ends: Vec<(u64, usize)> = vec![];
+        for (epoch, record) in records {
+            if body.len() > BODY_PREFIX.len() {
+                body.push(b',');
+            }
+            serde_json::to_writer(&mut body, &record)?;
+            match epoch_ends.last_mut() {
+                Some((last_epoch, end)) if *last_epoch == epoch => *end = body.len(),
+                _ => epoch_ends.push((epoch, body.len())),
+            }
+        }
+        body.extend_from_slice(BODY_SUFFIX);
+        Ok(Self {
+            body: Bytes::from(body),
+            epoch_ends,
+        })
+    }
+
+    pub fn window(&self, from_epoch: Option<u64>) -> Bytes {
+        let Some(from_epoch) = from_epoch else {
+            return self.body.clone();
+        };
+        let kept = self
+            .epoch_ends
+            .partition_point(|(epoch, _)| *epoch >= from_epoch);
+        if kept == self.epoch_ends.len() {
+            return self.body.clone();
+        }
+        let end = match kept.checked_sub(1) {
+            Some(last) => self.epoch_ends[last].1,
+            None => BODY_PREFIX.len(),
+        };
+        let mut window = Vec::with_capacity(end + BODY_SUFFIX.len());
+        window.extend_from_slice(&self.body[..end]);
+        window.extend_from_slice(BODY_SUFFIX);
+        Bytes::from(window)
+    }
 }
 
 impl ProtectedEvents {
     pub fn new(mut records: Vec<ProtectedEventRecord>) -> anyhow::Result<Self> {
         // The refresh appends the fresh block to the older one; unsorted, the feed jumps back up.
-        records.sort_by(|left, right| right.epoch.cmp(&left.epoch));
-        let legacy = LegacyProtectedEventsResponse {
-            protected_events: legacy_projection(&records),
-        };
-        let legacy_body = Bytes::from(serde_json::to_vec(&legacy)?);
-        let min_epoch = records.iter().map(|record| record.epoch).min();
-        let v1 = ProtectedEventsResponse {
-            protected_events: records,
-        };
-        let v1_body = Bytes::from(serde_json::to_vec(&v1)?);
+        records.sort_by_key(|record| Reverse(record.epoch));
+        let legacy = EpochWindowedBody::new(
+            legacy_projection(&records)
+                .into_iter()
+                .map(|record| (record.epoch, record)),
+        )?;
+        let v1 = EpochWindowedBody::new(records.iter().map(|record| (record.epoch, record)))?;
         Ok(Self {
-            records: v1.protected_events,
-            min_epoch,
-            v1_body,
-            legacy_body,
+            records,
+            v1,
+            legacy,
         })
-    }
-
-    /// Whether the window drops a record, so a window reaching the whole feed can answer from the
-    /// rendered body.
-    pub fn narrows(&self, from_epoch: u64) -> bool {
-        self.min_epoch
-            .is_some_and(|min_epoch| from_epoch > min_epoch)
     }
 }
 
@@ -70,3 +111,177 @@ impl Context {
 }
 
 pub type WrappedContext = Arc<RwLock<Context>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dto::{LegacyProtectedEventsResponse, ProtectedEventsResponse};
+    use settlement_common::settlement_collection::{
+        SettlementFunder, SettlementMeta, SettlementReason,
+    };
+    use solana_sdk::pubkey::Pubkey;
+    use validator_bonds_common::dto::BondType;
+
+    fn record(epoch: u64, bond_type: BondType, product: &str) -> ProtectedEventRecord {
+        ProtectedEventRecord {
+            epoch,
+            amount: epoch,
+            vote_account: Pubkey::new_unique(),
+            meta: SettlementMeta {
+                funder: SettlementFunder::ValidatorBond,
+            },
+            reason: SettlementReason::Bidding,
+            bond_type,
+            product: product.to_string(),
+        }
+    }
+
+    fn records() -> Vec<ProtectedEventRecord> {
+        vec![
+            record(1017, BondType::Bidding, "sam"),
+            record(1017, BondType::Institutional, "select"),
+            record(1018, BondType::Bidding, "sam"),
+            record(1018, BondType::Bidding, "single-validator"),
+        ]
+    }
+
+    fn epochs(body: &Bytes) -> Vec<u64> {
+        let parsed: serde_json::Value = serde_json::from_slice(body).unwrap();
+        parsed["protected_events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|record| record["epoch"].as_u64().unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn the_rendered_v1_body_carries_every_record() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        assert_eq!(
+            epochs(&events.v1.window(None)),
+            vec![1018, 1018, 1017, 1017]
+        );
+    }
+
+    #[test]
+    fn the_rendered_legacy_body_carries_bidding_sam_only() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        assert_eq!(epochs(&events.legacy.window(None)), vec![1018, 1017]);
+    }
+
+    // The shape the incremental refresh produces: the retained older block, then the fresh one.
+    #[test]
+    fn the_rendered_feed_is_epoch_ordered_however_the_refresh_merged_it() {
+        let events = ProtectedEvents::new(vec![
+            record(1017, BondType::Bidding, "sam"),
+            record(1016, BondType::Bidding, "sam"),
+            record(1018, BondType::Bidding, "sam"),
+        ])
+        .unwrap();
+        assert_eq!(epochs(&events.v1.window(None)), vec![1018, 1017, 1016]);
+        assert_eq!(epochs(&events.legacy.window(None)), vec![1018, 1017, 1016]);
+    }
+
+    #[test]
+    fn the_rendered_legacy_body_publishes_no_new_dimension() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        let body = String::from_utf8(events.legacy.window(None).to_vec()).unwrap();
+        assert!(!body.contains("bond_type"), "{body}");
+        assert!(!body.contains("product"), "{body}");
+    }
+
+    // The bodies are written by hand, so nothing but this pins them to the documented DTOs.
+    #[test]
+    fn the_bodies_match_the_serde_rendering_of_the_response_dtos() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        let sorted = events.records.clone();
+        assert_eq!(
+            events.v1.window(None),
+            serde_json::to_vec(&ProtectedEventsResponse {
+                protected_events: sorted.clone(),
+            })
+            .unwrap()
+        );
+        assert_eq!(
+            events.legacy.window(None),
+            serde_json::to_vec(&LegacyProtectedEventsResponse {
+                protected_events: legacy_projection(&sorted),
+            })
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn a_window_reaching_the_whole_feed_answers_from_the_rendered_body() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        for from_epoch in [None, Some(0), Some(1017)] {
+            assert_eq!(events.v1.window(from_epoch), events.v1.window(None));
+            assert_eq!(events.legacy.window(from_epoch), events.legacy.window(None));
+        }
+    }
+
+    #[test]
+    fn a_window_reports_the_epoch_it_starts_at() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        assert_eq!(epochs(&events.v1.window(Some(1018))), vec![1018, 1018]);
+        assert_eq!(epochs(&events.legacy.window(Some(1018))), vec![1018]);
+    }
+
+    #[test]
+    fn a_window_matches_the_serde_rendering_of_the_records_it_keeps() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        let kept: Vec<_> = events
+            .records
+            .iter()
+            .filter(|record| record.epoch >= 1018)
+            .cloned()
+            .collect();
+        assert_eq!(
+            events.v1.window(Some(1018)),
+            serde_json::to_vec(&ProtectedEventsResponse {
+                protected_events: kept.clone(),
+            })
+            .unwrap()
+        );
+        assert_eq!(
+            events.legacy.window(Some(1018)),
+            serde_json::to_vec(&LegacyProtectedEventsResponse {
+                protected_events: legacy_projection(&kept),
+            })
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn a_window_past_the_last_epoch_reports_an_empty_feed() {
+        let events = ProtectedEvents::new(records()).unwrap();
+        assert_eq!(
+            events.v1.window(Some(1019)),
+            Bytes::from(r#"{"protected_events":[]}"#)
+        );
+        assert_eq!(
+            events.legacy.window(Some(1019)),
+            Bytes::from(r#"{"protected_events":[]}"#)
+        );
+    }
+
+    // The legacy projection drops whole epochs, so its offsets are not the v1 ones.
+    #[test]
+    fn a_window_narrowing_past_an_epoch_the_legacy_feed_dropped_reports_nothing() {
+        let events = ProtectedEvents::new(vec![
+            record(1017, BondType::Bidding, "sam"),
+            record(1018, BondType::Institutional, "select"),
+        ])
+        .unwrap();
+        assert_eq!(epochs(&events.v1.window(Some(1018))), vec![1018]);
+        assert_eq!(epochs(&events.legacy.window(Some(1018))), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn an_empty_feed_answers_every_window_from_the_rendered_body() {
+        let events = ProtectedEvents::new(vec![]).unwrap();
+        assert_eq!(events.v1.window(Some(1018)), events.v1.window(None));
+        assert_eq!(events.legacy.window(Some(1018)), events.legacy.window(None));
+    }
+}

--- a/api/src/handlers/protected_events.rs
+++ b/api/src/handlers/protected_events.rs
@@ -1,11 +1,4 @@
-use crate::{
-    context::{ProtectedEvents, WrappedContext},
-    dto::{
-        legacy_projection, LegacyProtectedEventsResponse, ProtectedEventRecord,
-        ProtectedEventsResponse,
-    },
-    error::AppError,
-};
+use crate::{context::WrappedContext, error::AppError};
 use axum::body::Bytes;
 use axum::extract::{Query, State};
 use axum::http::header;
@@ -21,65 +14,6 @@ pub struct QueryParams {
 
 fn json_response(body: Bytes) -> impl IntoResponse {
     ([(header::CONTENT_TYPE, "application/json")], body)
-}
-
-fn render(response: &impl Serialize) -> Result<Bytes, AppError> {
-    let body = serde_json::to_vec(response).map_err(|err| AppError {
-        message: format!("Failed to render the protected events: {err}"),
-    })?;
-    Ok(Bytes::from(body))
-}
-
-/// Selected under the cache guard, rendered after it is dropped: the refresh waits on that guard.
-enum Body<T> {
-    Rendered(Bytes),
-    Window(T),
-}
-
-impl<T: Serialize> Body<T> {
-    fn into_bytes(self) -> Result<Bytes, AppError> {
-        match self {
-            Body::Rendered(body) => Ok(body),
-            Body::Window(window) => render(&window),
-        }
-    }
-}
-
-fn records_from_epoch<'a>(
-    records: &'a [ProtectedEventRecord],
-    from_epoch: u64,
-) -> impl Iterator<Item = &'a ProtectedEventRecord> + 'a {
-    records
-        .iter()
-        .filter(move |record| record.epoch >= from_epoch)
-}
-
-fn v1_body(events: &ProtectedEvents, from_epoch: Option<u64>) -> Body<ProtectedEventsResponse> {
-    match from_epoch {
-        Some(from_epoch) if events.narrows(from_epoch) => Body::Window(ProtectedEventsResponse {
-            protected_events: records_from_epoch(&events.records, from_epoch)
-                .cloned()
-                .collect(),
-        }),
-        _ => Body::Rendered(events.v1_body.clone()),
-    }
-}
-
-fn legacy_body(
-    events: &ProtectedEvents,
-    from_epoch: Option<u64>,
-) -> Body<LegacyProtectedEventsResponse> {
-    match from_epoch {
-        Some(from_epoch) if events.narrows(from_epoch) => {
-            Body::Window(LegacyProtectedEventsResponse {
-                protected_events: legacy_projection(records_from_epoch(
-                    &events.records,
-                    from_epoch,
-                )),
-            })
-        }
-        _ => Body::Rendered(events.legacy_body.clone()),
-    }
 }
 
 #[utoipa::path(
@@ -99,15 +33,14 @@ pub async fn handler(
     State(context): State<WrappedContext>,
     Query(query_params): Query<QueryParams>,
 ) -> Result<impl IntoResponse, AppError> {
-    let body = {
-        let context = context.read().await;
-        let cache = context.protected_events_records.read().await;
-        let protected_events = cache.as_ref().ok_or_else(|| AppError {
-            message: "No protected events loaded from BigQuery yet".to_string(),
-        })?;
-        legacy_body(protected_events, query_params.from_epoch)
-    };
-    Ok(json_response(body.into_bytes()?))
+    let context = context.read().await;
+    let cache = context.protected_events_records.read().await;
+    let protected_events = cache.as_ref().ok_or_else(|| AppError {
+        message: "No protected events loaded from BigQuery yet".to_string(),
+    })?;
+    Ok(json_response(
+        protected_events.legacy.window(query_params.from_epoch),
+    ))
 }
 
 #[utoipa::path(
@@ -126,145 +59,12 @@ pub async fn handler_v1(
     State(context): State<WrappedContext>,
     Query(query_params): Query<QueryParams>,
 ) -> Result<impl IntoResponse, AppError> {
-    let body = {
-        let context = context.read().await;
-        let cache = context.protected_events_records.read().await;
-        let protected_events = cache.as_ref().ok_or_else(|| AppError {
-            message: "No protected events loaded from BigQuery yet".to_string(),
-        })?;
-        v1_body(protected_events, query_params.from_epoch)
-    };
-    Ok(json_response(body.into_bytes()?))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use settlement_common::settlement_collection::{
-        SettlementFunder, SettlementMeta, SettlementReason,
-    };
-    use solana_sdk::pubkey::Pubkey;
-    use validator_bonds_common::dto::BondType;
-
-    fn record(epoch: u64, bond_type: BondType, product: &str) -> ProtectedEventRecord {
-        ProtectedEventRecord {
-            epoch,
-            amount: epoch,
-            vote_account: Pubkey::new_unique(),
-            meta: SettlementMeta {
-                funder: SettlementFunder::ValidatorBond,
-            },
-            reason: SettlementReason::Bidding,
-            bond_type,
-            product: product.to_string(),
-        }
-    }
-
-    fn records() -> Vec<ProtectedEventRecord> {
-        vec![
-            record(1017, BondType::Bidding, "sam"),
-            record(1017, BondType::Institutional, "select"),
-            record(1018, BondType::Bidding, "sam"),
-            record(1018, BondType::Bidding, "single-validator"),
-        ]
-    }
-
-    fn epochs(body: &Bytes) -> Vec<u64> {
-        let parsed: serde_json::Value = serde_json::from_slice(body).unwrap();
-        parsed["protected_events"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|record| record["epoch"].as_u64().unwrap())
-            .collect()
-    }
-
-    #[test]
-    fn the_rendered_v1_body_carries_every_record() {
-        let events = ProtectedEvents::new(records()).unwrap();
-        assert_eq!(epochs(&events.v1_body), vec![1018, 1018, 1017, 1017]);
-    }
-
-    #[test]
-    fn the_rendered_legacy_body_carries_bidding_sam_only() {
-        let events = ProtectedEvents::new(records()).unwrap();
-        assert_eq!(epochs(&events.legacy_body), vec![1018, 1017]);
-    }
-
-    // The shape the incremental refresh produces: the retained older block, then the fresh one.
-    #[test]
-    fn the_rendered_feed_is_epoch_ordered_however_the_refresh_merged_it() {
-        let events = ProtectedEvents::new(vec![
-            record(1017, BondType::Bidding, "sam"),
-            record(1016, BondType::Bidding, "sam"),
-            record(1018, BondType::Bidding, "sam"),
-        ])
-        .unwrap();
-        assert_eq!(epochs(&events.v1_body), vec![1018, 1017, 1016]);
-        assert_eq!(epochs(&events.legacy_body), vec![1018, 1017, 1016]);
-    }
-
-    #[test]
-    fn the_rendered_legacy_body_publishes_no_new_dimension() {
-        let events = ProtectedEvents::new(records()).unwrap();
-        let body = String::from_utf8(events.legacy_body.to_vec()).unwrap();
-        assert!(!body.contains("bond_type"), "{body}");
-        assert!(!body.contains("product"), "{body}");
-    }
-
-    #[test]
-    fn a_window_reports_the_epoch_it_starts_at() {
-        assert_eq!(
-            records_from_epoch(&records(), 1018)
-                .map(|record| record.epoch)
-                .collect::<Vec<_>>(),
-            vec![1018, 1018]
-        );
-    }
-
-    #[test]
-    fn a_window_past_the_last_epoch_reports_nothing() {
-        assert_eq!(records_from_epoch(&records(), 1019).count(), 0);
-    }
-
-    #[test]
-    fn a_window_reaching_the_whole_feed_answers_from_the_rendered_body() {
-        let events = ProtectedEvents::new(records()).unwrap();
-        for from_epoch in [None, Some(0), Some(1017)] {
-            assert_eq!(
-                v1_body(&events, from_epoch).into_bytes().unwrap(),
-                events.v1_body
-            );
-            assert_eq!(
-                legacy_body(&events, from_epoch).into_bytes().unwrap(),
-                events.legacy_body
-            );
-        }
-    }
-
-    #[test]
-    fn a_window_dropping_an_epoch_is_rendered_per_request() {
-        let events = ProtectedEvents::new(records()).unwrap();
-        assert_eq!(
-            epochs(&v1_body(&events, Some(1018)).into_bytes().unwrap()),
-            vec![1018, 1018]
-        );
-        assert_eq!(
-            epochs(&legacy_body(&events, Some(1018)).into_bytes().unwrap()),
-            vec![1018]
-        );
-    }
-
-    #[test]
-    fn an_empty_feed_answers_every_window_from_the_rendered_body() {
-        let events = ProtectedEvents::new(vec![]).unwrap();
-        assert_eq!(
-            v1_body(&events, Some(1018)).into_bytes().unwrap(),
-            events.v1_body
-        );
-        assert_eq!(
-            legacy_body(&events, Some(1018)).into_bytes().unwrap(),
-            events.legacy_body
-        );
-    }
+    let context = context.read().await;
+    let cache = context.protected_events_records.read().await;
+    let protected_events = cache.as_ref().ok_or_else(|| AppError {
+        message: "No protected events loaded from BigQuery yet".to_string(),
+    })?;
+    Ok(json_response(
+        protected_events.v1.window(query_params.from_epoch),
+    ))
 }

--- a/api/src/repositories/protected_events.rs
+++ b/api/src/repositories/protected_events.rs
@@ -13,9 +13,30 @@ use crate::dto::ProtectedEventRecord;
 const CACHE_UPDATE_INTERVAL: Duration = Duration::from_secs(3600);
 const CACHE_PURGE_INTERVAL: Duration = Duration::from_secs(24 * 3600);
 // Until the first fetch lands both endpoints answer 500, so a failure must not wait out a refresh.
+// Doubled per consecutive failure so an unhealthy BigQuery is not hammered for the whole outage.
 const CACHE_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 const COMPLETION_POLL_TIMEOUT_MS: i32 = 30_000;
 const MAX_COMPLETION_POLLS: u32 = 10;
+// The paging loop bounds token-less polls only; a page token that never advances would spin here
+// forever and silently stop the refresh, so the whole read is bounded in wall-clock terms too.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(900);
+
+async fn fetch_protected_events(
+    gcp_sa_key: &str,
+    project_id: &str,
+    from_epoch: u64,
+) -> anyhow::Result<Vec<ProtectedEventRecord>> {
+    tokio::time::timeout(
+        FETCH_TIMEOUT,
+        get_protected_events(gcp_sa_key, project_id, from_epoch),
+    )
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "Reading the protected events from epoch {from_epoch} timed out after {FETCH_TIMEOUT:?}"
+        )
+    })?
+}
 
 async fn get_protected_events(
     gcp_sa_key: &str,
@@ -149,13 +170,21 @@ fn parse_row(rs: &ResultSet) -> anyhow::Result<ProtectedEventRecord> {
     })
 }
 
-async fn store(cache: &ProtectedEventsCache, records: Vec<ProtectedEventRecord>, stored: &str) {
+async fn store(
+    cache: &ProtectedEventsCache,
+    records: Vec<ProtectedEventRecord>,
+    stored: &str,
+) -> bool {
     match ProtectedEvents::new(records) {
         Ok(events) => {
             *cache.write().await = Some(events);
             log::info!("{stored}");
+            true
         }
-        Err(err) => log::error!("{stored} failed, the protected events did not render: {err}"),
+        Err(err) => {
+            log::error!("{stored} failed, the protected events did not render: {err}");
+            false
+        }
     }
 }
 
@@ -184,7 +213,7 @@ pub fn spawn_protected_events_cache_purger(
         loop {
             sleep(CACHE_PURGE_INTERVAL).await;
 
-            match get_protected_events(&gcp_sa_key, &project_id, 0).await {
+            match fetch_protected_events(&gcp_sa_key, &project_id, 0).await {
                 Ok(updated_protected_events) => {
                     log::info!(
                         "Successfully fetched the protected events ({})",
@@ -208,6 +237,7 @@ pub fn spawn_protected_events_cache_updater(
     protected_events: ProtectedEventsCache,
 ) {
     tokio::spawn(async move {
+        let mut retry_in = CACHE_RETRY_INTERVAL;
         loop {
             let max_loaded_epoch = protected_events
                 .read()
@@ -218,8 +248,8 @@ pub fn spawn_protected_events_cache_updater(
                     protected_event.epoch.max(max_loaded_epoch)
                 });
 
-            let fetched = get_protected_events(&gcp_sa_key, &project_id, max_loaded_epoch).await;
-            let next_attempt = match fetched {
+            let fetched = fetch_protected_events(&gcp_sa_key, &project_id, max_loaded_epoch).await;
+            let updated = match fetched {
                 Ok(updated_protected_events) => {
                     log::info!(
                         "Successfully fetched the protected events ({}) from epoch: {max_loaded_epoch}",
@@ -241,18 +271,30 @@ pub fn spawn_protected_events_cache_updater(
                         merged_protected_events,
                         "Successfully extended the protected events",
                     )
-                    .await;
-                    CACHE_UPDATE_INTERVAL
+                    .await
                 }
                 Err(err) => {
                     log::error!("Failed to get the protected events: {err}");
-                    CACHE_RETRY_INTERVAL
+                    false
                 }
+            };
+
+            let next_attempt = if updated {
+                retry_in = CACHE_RETRY_INTERVAL;
+                CACHE_UPDATE_INTERVAL
+            } else {
+                let waiting = retry_in;
+                retry_in = next_retry(retry_in);
+                waiting
             };
 
             sleep(next_attempt).await;
         }
     });
+}
+
+fn next_retry(retry_in: Duration) -> Duration {
+    retry_in.saturating_mul(2).min(CACHE_UPDATE_INTERVAL)
 }
 
 #[cfg(test)]
@@ -395,6 +437,27 @@ mod tests {
     #[test]
     fn a_failed_fetch_is_retried_sooner_than_the_next_refresh() {
         assert!(CACHE_RETRY_INTERVAL < CACHE_UPDATE_INTERVAL);
+    }
+
+    #[test]
+    fn consecutive_failures_back_off_no_further_than_the_refresh_interval() {
+        let mut retry_in = CACHE_RETRY_INTERVAL;
+        for _ in 0..64 {
+            retry_in = next_retry(retry_in);
+            assert!(retry_in <= CACHE_UPDATE_INTERVAL, "{retry_in:?}");
+        }
+        assert_eq!(retry_in, CACHE_UPDATE_INTERVAL);
+        assert_eq!(next_retry(CACHE_RETRY_INTERVAL), CACHE_RETRY_INTERVAL * 2);
+    }
+
+    #[test]
+    fn a_read_is_bounded_beyond_the_polls_it_may_spend() {
+        assert!(
+            FETCH_TIMEOUT
+                > Duration::from_millis(
+                    MAX_COMPLETION_POLLS as u64 * COMPLETION_POLL_TIMEOUT_MS as u64
+                )
+        );
     }
 
     #[test]


### PR DESCRIPTION
I missed to apply fixes from review points from https://github.com/marinade-finance/validator-bonds/pull/499#pullrequestreview-5007822392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved protected-event feed delivery by caching serialized responses and efficiently serving epoch-based windows.
* **Reliability**
  * Added a 15-minute limit to protected-event retrievals.
  * Added exponential retry backoff for failed refreshes, up to the regular refresh interval.
  * Refresh retry timing resets after a successful update.
* **Compatibility**
  * Preserved support for both current and legacy protected-event feed formats, including differing epoch offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->