### PR TITLE
[GEN-8660][sanity] adding checks for ceiling

### DIFF
--- a/.buildkite/sanity-unified.yml
+++ b/.buildkite/sanity-unified.yml
@@ -4,6 +4,8 @@ env:
   gs_bucket: gs://marinade-validator-bonds-mainnet
   past_epochs_to_check: 10
   max_total_claims: 150000
+  settlement_config: ./settlement-config.yaml
+  fee_revenue_margin_sol: 1
   SETTLEMENTS_FILES: $SETTLEMENTS_FILES
   PIPELINES_AUTO_APPROVAL: $PIPELINES_AUTO_APPROVAL
 
@@ -90,11 +92,15 @@ steps:
           pnpm cli:check check-merkle-tree \
             --merkle-trees ./unified-merkle-trees.json \
             --max-total-claims $max_total_claims \
+            --settlement-config $settlement_config \
+            --fee-revenue-margin-sol $fee_revenue_margin_sol \
             --settlement-sources $$settlement_sources
         else
           pnpm cli:check check-merkle-tree \
             --merkle-trees ./unified-merkle-trees.json \
-            --max-total-claims $max_total_claims
+            --max-total-claims $max_total_claims \
+            --settlement-config $settlement_config \
+            --fee-revenue-margin-sol $fee_revenue_margin_sol
         fi
     soft_fail:
       - exit_status: "*"

--- a/packages/validator-bonds-sanity-check/__tests__/checkMerkleTree.spec.ts
+++ b/packages/validator-bonds-sanity-check/__tests__/checkMerkleTree.spec.ts
@@ -517,7 +517,7 @@ fee_config:
     expect(ceiling).toBeUndefined()
   })
 
-  it.each(['.nan', '.inf', '-.inf', 'not-a-number', '-5'])(
+  it.each(['.nan', '.inf', '-.inf', 'not-a-number', '-5', '-0.5'])(
     'rejects the revenue target %s that would disable the gate',
     value => {
       expect(() =>
@@ -531,14 +531,30 @@ fee_config:
           ),
           feeRevenueMarginSol: new Decimal(1),
         }),
-      ).toThrow('must be a finite number > 0')
+      ).toThrow('must be a finite number >= 0')
     },
   )
 
-  it('rejects a config without fee_config instead of gating nothing', () => {
+  it('accepts a zero revenue target, which means charge the minimum fee', () => {
+    const ceiling = loadFeeRevenueCeiling({
+      settlementConfig: writeConfig(
+        'zero-revenue.yaml',
+        FEE_CONFIG.replace('min_sol_revenue: 200', 'min_sol_revenue: 0'),
+      ),
+      feeRevenueMarginSol: new Decimal(1),
+    })
+
+    expect(ceiling?.toFixed(0)).toBe('1')
+  })
+
+  it.each([
+    ['no fee_config key', '---\nsettlements: []\n'],
+    ['an empty document', ''],
+    ['a valueless fee_config key', '---\nfee_config:\n'],
+  ])('rejects %s instead of gating nothing', (_label, content) => {
     expect(() =>
       loadFeeRevenueCeiling({
-        settlementConfig: writeConfig('empty.yaml', '---\nsettlements: []\n'),
+        settlementConfig: writeConfig(`empty-${_label}.yaml`, content),
         feeRevenueMarginSol: new Decimal(1),
       }),
     ).toThrow('No fee_config found in')

--- a/packages/validator-bonds-sanity-check/__tests__/checkMerkleTree.spec.ts
+++ b/packages/validator-bonds-sanity-check/__tests__/checkMerkleTree.spec.ts
@@ -17,9 +17,11 @@ import {
   checkTotalClaimsCeiling,
   validateMaxTotalClaims,
 } from '../src/commands/checkMerkleTree'
+import { ClaimKind } from '../src/dtoSettlements'
 
 import type { MerkleTreeMetrics } from '../src/commands/checkMerkleTree'
-import type { MerkleTree, UnifiedMerkleTreesDto } from '../src/dtoMerkleTree'
+import type { UnifiedMerkleTreesDto } from '../src/dtoMerkleTree'
+import type { Settlement } from '../src/dtoSettlements'
 
 beforeAll(() => {
   setContext(new CLIContext({ logger: NULL_LOG, commandName: 'test' }))
@@ -305,70 +307,110 @@ describe('checkFeeRevenueCeiling', () => {
   const MARINADE = 'BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x'
   const STAKER = '4bZ6o3eUUNXhKuqjdCnCoPAoLgWiuLYixKaxoa8PpiKk'
 
-  function mockTrees(
-    trees: { authority: string; claim: bigint }[][],
-  ): MerkleTree[] {
-    return trees.map(
-      nodes =>
+  function mockSettlements(
+    settlements: {
+      reason: string
+      claims: { authority: string; amount: bigint; kind?: ClaimKind }[]
+    }[],
+  ): Settlement[] {
+    return settlements.map(
+      ({ reason, claims }) =>
         ({
-          tree_nodes: nodes.map(({ authority, claim }) => ({
+          reason: { getReasonType: () => reason },
+          claims: claims.map(({ authority, amount, kind }) => ({
             stake_authority: new PublicKey(authority),
-            claim,
+            claim_amount: amount,
+            kind: kind ?? ClaimKind.FeeDeposit,
           })),
-        }) as unknown as MerkleTree,
+        }) as unknown as Settlement,
     )
   }
 
   it('passes on the epoch 1010 shape where the fee is capped below min_sol_revenue', () => {
     const { exceeded, feeRevenueSol, report } = checkFeeRevenueCeiling({
       epoch: 1010,
-      merkleTrees: mockTrees([
-        [
-          { authority: DAO, claim: 168_101_753_000n },
-          { authority: MARINADE, claim: 18_677_973_000n },
-          { authority: STAKER, claim: 803_083_988n },
-        ],
+      settlements: mockSettlements([
+        {
+          reason: 'Bidding',
+          claims: [
+            { authority: DAO, amount: 168_086_686_690n },
+            { authority: MARINADE, amount: 18_676_298_521n },
+            {
+              authority: STAKER,
+              amount: 803_083_988n,
+              kind: ClaimKind.StakerPayout,
+            },
+          ],
+        },
       ]),
-      feeAuthorities: [DAO, MARINADE],
       maxFeeRevenueSol: new Decimal(201),
     })
 
     expect(exceeded).toBe(false)
-    expect(feeRevenueSol.toFixed(6)).toBe('186.779726')
+    expect(feeRevenueSol.toFixed(6)).toBe('186.762985')
     expect(report).toContain('WITHIN CEILING')
   })
 
-  it('sums fee claims across every validator tree', () => {
+  it('sums fee claims across every settlement', () => {
     const { feeRevenueSol } = checkFeeRevenueCeiling({
       epoch: 1021,
-      merkleTrees: mockTrees([
-        [
-          { authority: DAO, claim: 90_000_000_000n },
-          { authority: MARINADE, claim: 10_000_000_000n },
-        ],
-        [
-          { authority: DAO, claim: 90_000_000_000n },
-          { authority: MARINADE, claim: 10_000_000_000n },
-        ],
+      settlements: mockSettlements([
+        {
+          reason: 'Bidding',
+          claims: [
+            { authority: DAO, amount: 90_000_000_000n },
+            { authority: MARINADE, amount: 10_000_000_000n },
+          ],
+        },
+        {
+          reason: 'PriorityFee',
+          claims: [
+            { authority: DAO, amount: 90_000_000_000n },
+            { authority: MARINADE, amount: 10_000_000_000n },
+          ],
+        },
       ]),
-      feeAuthorities: [DAO, MARINADE],
       maxFeeRevenueSol: new Decimal(201),
     })
 
     expect(feeRevenueSol.toFixed(0)).toBe('200')
   })
 
+  it('excludes penalty fee deposits that the revenue target does not cover', () => {
+    const { exceeded, feeRevenueSol } = checkFeeRevenueCeiling({
+      epoch: 1010,
+      settlements: mockSettlements([
+        {
+          reason: 'Bidding',
+          claims: [{ authority: DAO, amount: 200_000_000_000n }],
+        },
+        {
+          reason: 'BidTooLowPenalty',
+          claims: [
+            { authority: DAO, amount: 15_066_404n },
+            { authority: MARINADE, amount: 1_674_045n },
+          ],
+        },
+      ]),
+      maxFeeRevenueSol: new Decimal(201),
+    })
+
+    expect(feeRevenueSol.toFixed(0)).toBe('200')
+    expect(exceeded).toBe(false)
+  })
+
   it('fails when the fee optimizer over-collects against the ceiling', () => {
     const { exceeded, report } = checkFeeRevenueCeiling({
       epoch: 1021,
-      merkleTrees: mockTrees([
-        [
-          { authority: DAO, claim: 234_000_000_000n },
-          { authority: MARINADE, claim: 26_000_000_000n },
-          { authority: STAKER, claim: 1_000_000_000n },
-        ],
+      settlements: mockSettlements([
+        {
+          reason: 'Bidding',
+          claims: [
+            { authority: DAO, amount: 234_000_000_000n },
+            { authority: MARINADE, amount: 26_000_000_000n },
+          ],
+        },
       ]),
-      feeAuthorities: [DAO, MARINADE],
       maxFeeRevenueSol: new Decimal(201),
     })
 
@@ -376,31 +418,26 @@ describe('checkFeeRevenueCeiling', () => {
     expect(report).toContain('CEILING EXCEEDED')
   })
 
-  it('ignores claims of stakers that are not fee authorities', () => {
+  it('ignores staker payouts inside a fee-bearing settlement', () => {
     const { feeRevenueSol } = checkFeeRevenueCeiling({
       epoch: 1021,
-      merkleTrees: mockTrees([
-        [
-          { authority: DAO, claim: 1_000_000_000n },
-          { authority: STAKER, claim: 500_000_000_000n },
-        ],
+      settlements: mockSettlements([
+        {
+          reason: 'Bidding',
+          claims: [
+            { authority: DAO, amount: 1_000_000_000n },
+            {
+              authority: STAKER,
+              amount: 500_000_000_000n,
+              kind: ClaimKind.StakerPayout,
+            },
+          ],
+        },
       ]),
-      feeAuthorities: [DAO, MARINADE],
       maxFeeRevenueSol: new Decimal(201),
     })
 
     expect(feeRevenueSol.toFixed(0)).toBe('1')
-  })
-
-  it('rejects a malformed fee authority instead of silently gating nothing', () => {
-    expect(() =>
-      checkFeeRevenueCeiling({
-        epoch: 1021,
-        merkleTrees: mockTrees([[{ authority: DAO, claim: 1n }]]),
-        feeAuthorities: ['not-a-pubkey'],
-        maxFeeRevenueSol: new Decimal(201),
-      }),
-    ).toThrow('Invalid fee authority public key: not-a-pubkey')
   })
 })
 
@@ -441,11 +478,7 @@ fee_config:
       feeRevenueMarginSol: new Decimal(1),
     })
 
-    expect(ceiling?.maxFeeRevenueSol.toFixed(0)).toBe('201')
-    expect(ceiling?.feeAuthorities).toEqual([
-      'BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x',
-      'mDAo14E6YJfEHcVZLcc235RVjviypmKMhftq7jeiLJz',
-    ])
+    expect(ceiling?.toFixed(0)).toBe('201')
   })
 
   it('follows min_sol_revenue when the configured revenue target changes', () => {
@@ -457,7 +490,7 @@ fee_config:
       feeRevenueMarginSol: new Decimal(1),
     })
 
-    expect(ceiling?.maxFeeRevenueSol.toFixed(0)).toBe('211')
+    expect(ceiling?.toFixed(0)).toBe('211')
   })
 
   it('skips the check when no revenue target is configured', () => {
@@ -472,6 +505,36 @@ fee_config:
     expect(ceiling).toBeUndefined()
   })
 
+  it('skips the check when the revenue target is left empty', () => {
+    const ceiling = loadFeeRevenueCeiling({
+      settlementConfig: writeConfig(
+        'null-revenue.yaml',
+        FEE_CONFIG.replace('min_sol_revenue: 200', 'min_sol_revenue:'),
+      ),
+      feeRevenueMarginSol: new Decimal(1),
+    })
+
+    expect(ceiling).toBeUndefined()
+  })
+
+  it.each(['.nan', '.inf', '-.inf', 'not-a-number', '-5'])(
+    'rejects the revenue target %s that would disable the gate',
+    value => {
+      expect(() =>
+        loadFeeRevenueCeiling({
+          settlementConfig: writeConfig(
+            `revenue-${value}.yaml`,
+            FEE_CONFIG.replace(
+              'min_sol_revenue: 200',
+              `min_sol_revenue: ${value}`,
+            ),
+          ),
+          feeRevenueMarginSol: new Decimal(1),
+        }),
+      ).toThrow('must be a finite number > 0')
+    },
+  )
+
   it('rejects a config without fee_config instead of gating nothing', () => {
     expect(() =>
       loadFeeRevenueCeiling({
@@ -481,14 +544,22 @@ fee_config:
     ).toThrow('No fee_config found in')
   })
 
+  it('reports a missing config path as a CLI error', () => {
+    expect(() =>
+      loadFeeRevenueCeiling({
+        settlementConfig: join(tmpDir, 'does-not-exist.yaml'),
+        feeRevenueMarginSol: new Decimal(1),
+      }),
+    ).toThrow('Failed to load settlement config from path')
+  })
+
   it('parses the production settlement-config.yaml', () => {
     const ceiling = loadFeeRevenueCeiling({
       settlementConfig: join(__dirname, '../../../settlement-config.yaml'),
       feeRevenueMarginSol: new Decimal(1),
     })
 
-    expect(ceiling?.feeAuthorities).toHaveLength(2)
-    expect(ceiling?.maxFeeRevenueSol.isFinite()).toBe(true)
+    expect(ceiling?.isFinite()).toBe(true)
   })
 })
 

--- a/packages/validator-bonds-sanity-check/__tests__/checkMerkleTree.spec.ts
+++ b/packages/validator-bonds-sanity-check/__tests__/checkMerkleTree.spec.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 
 import { CLIContext, readLargeJsonFile } from '@marinade.finance/cli-common'
 import { NULL_LOG, setContext } from '@marinade.finance/ts-common'
+import { PublicKey } from '@solana/web3.js'
 import Decimal from 'decimal.js'
 
 import {
@@ -11,12 +12,14 @@ import {
   reportMerkleTreeAnomalies,
   detectIndividualAnomaly,
   checkEpochHopGuardrail,
+  checkFeeRevenueCeiling,
+  loadFeeRevenueCeiling,
   checkTotalClaimsCeiling,
   validateMaxTotalClaims,
 } from '../src/commands/checkMerkleTree'
 
 import type { MerkleTreeMetrics } from '../src/commands/checkMerkleTree'
-import type { UnifiedMerkleTreesDto } from '../src/dtoMerkleTree'
+import type { MerkleTree, UnifiedMerkleTreesDto } from '../src/dtoMerkleTree'
 
 beforeAll(() => {
   setContext(new CLIContext({ logger: NULL_LOG, commandName: 'test' }))
@@ -294,6 +297,198 @@ describe('checkTotalClaimsCeiling', () => {
     })
 
     expect(exceeded).toBe(true)
+  })
+})
+
+describe('checkFeeRevenueCeiling', () => {
+  const DAO = 'mDAo14E6YJfEHcVZLcc235RVjviypmKMhftq7jeiLJz'
+  const MARINADE = 'BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x'
+  const STAKER = '4bZ6o3eUUNXhKuqjdCnCoPAoLgWiuLYixKaxoa8PpiKk'
+
+  function mockTrees(
+    trees: { authority: string; claim: bigint }[][],
+  ): MerkleTree[] {
+    return trees.map(
+      nodes =>
+        ({
+          tree_nodes: nodes.map(({ authority, claim }) => ({
+            stake_authority: new PublicKey(authority),
+            claim,
+          })),
+        }) as unknown as MerkleTree,
+    )
+  }
+
+  it('passes on the epoch 1010 shape where the fee is capped below min_sol_revenue', () => {
+    const { exceeded, feeRevenueSol, report } = checkFeeRevenueCeiling({
+      epoch: 1010,
+      merkleTrees: mockTrees([
+        [
+          { authority: DAO, claim: 168_101_753_000n },
+          { authority: MARINADE, claim: 18_677_973_000n },
+          { authority: STAKER, claim: 803_083_988n },
+        ],
+      ]),
+      feeAuthorities: [DAO, MARINADE],
+      maxFeeRevenueSol: new Decimal(201),
+    })
+
+    expect(exceeded).toBe(false)
+    expect(feeRevenueSol.toFixed(6)).toBe('186.779726')
+    expect(report).toContain('WITHIN CEILING')
+  })
+
+  it('sums fee claims across every validator tree', () => {
+    const { feeRevenueSol } = checkFeeRevenueCeiling({
+      epoch: 1021,
+      merkleTrees: mockTrees([
+        [
+          { authority: DAO, claim: 90_000_000_000n },
+          { authority: MARINADE, claim: 10_000_000_000n },
+        ],
+        [
+          { authority: DAO, claim: 90_000_000_000n },
+          { authority: MARINADE, claim: 10_000_000_000n },
+        ],
+      ]),
+      feeAuthorities: [DAO, MARINADE],
+      maxFeeRevenueSol: new Decimal(201),
+    })
+
+    expect(feeRevenueSol.toFixed(0)).toBe('200')
+  })
+
+  it('fails when the fee optimizer over-collects against the ceiling', () => {
+    const { exceeded, report } = checkFeeRevenueCeiling({
+      epoch: 1021,
+      merkleTrees: mockTrees([
+        [
+          { authority: DAO, claim: 234_000_000_000n },
+          { authority: MARINADE, claim: 26_000_000_000n },
+          { authority: STAKER, claim: 1_000_000_000n },
+        ],
+      ]),
+      feeAuthorities: [DAO, MARINADE],
+      maxFeeRevenueSol: new Decimal(201),
+    })
+
+    expect(exceeded).toBe(true)
+    expect(report).toContain('CEILING EXCEEDED')
+  })
+
+  it('ignores claims of stakers that are not fee authorities', () => {
+    const { feeRevenueSol } = checkFeeRevenueCeiling({
+      epoch: 1021,
+      merkleTrees: mockTrees([
+        [
+          { authority: DAO, claim: 1_000_000_000n },
+          { authority: STAKER, claim: 500_000_000_000n },
+        ],
+      ]),
+      feeAuthorities: [DAO, MARINADE],
+      maxFeeRevenueSol: new Decimal(201),
+    })
+
+    expect(feeRevenueSol.toFixed(0)).toBe('1')
+  })
+
+  it('rejects a malformed fee authority instead of silently gating nothing', () => {
+    expect(() =>
+      checkFeeRevenueCeiling({
+        epoch: 1021,
+        merkleTrees: mockTrees([[{ authority: DAO, claim: 1n }]]),
+        feeAuthorities: ['not-a-pubkey'],
+        maxFeeRevenueSol: new Decimal(201),
+      }),
+    ).toThrow('Invalid fee authority public key: not-a-pubkey')
+  })
+})
+
+describe('loadFeeRevenueCeiling', () => {
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'fee-revenue-ceiling-'))
+  })
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeConfig(name: string, content: string): string {
+    const path = join(tmpDir, name)
+    writeFileSync(path, content)
+    return path
+  }
+
+  const FEE_CONFIG = `---
+fee_config:
+  max_fee_bps: 1600
+  min_fee_bps: 200
+  min_sol_revenue: 200
+  marinade:
+    stake_authority: BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x
+    withdraw_authority: BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x
+  dao:
+    fee_split_share_bps: 9000
+    stake_authority: mDAo14E6YJfEHcVZLcc235RVjviypmKMhftq7jeiLJz
+    withdraw_authority: mDAo14E6YJfEHcVZLcc235RVjviypmKMhftq7jeiLJz
+`
+
+  it('derives the ceiling from min_sol_revenue plus the margin', () => {
+    const ceiling = loadFeeRevenueCeiling({
+      settlementConfig: writeConfig('config.yaml', FEE_CONFIG),
+      feeRevenueMarginSol: new Decimal(1),
+    })
+
+    expect(ceiling?.maxFeeRevenueSol.toFixed(0)).toBe('201')
+    expect(ceiling?.feeAuthorities).toEqual([
+      'BBaQsiRo744NAYaqL3nKRfgeJayoqVicEQsEnLpfsJ6x',
+      'mDAo14E6YJfEHcVZLcc235RVjviypmKMhftq7jeiLJz',
+    ])
+  })
+
+  it('follows min_sol_revenue when the configured revenue target changes', () => {
+    const ceiling = loadFeeRevenueCeiling({
+      settlementConfig: writeConfig(
+        'raised.yaml',
+        FEE_CONFIG.replace('min_sol_revenue: 200', 'min_sol_revenue: 210'),
+      ),
+      feeRevenueMarginSol: new Decimal(1),
+    })
+
+    expect(ceiling?.maxFeeRevenueSol.toFixed(0)).toBe('211')
+  })
+
+  it('skips the check when no revenue target is configured', () => {
+    const ceiling = loadFeeRevenueCeiling({
+      settlementConfig: writeConfig(
+        'no-revenue.yaml',
+        FEE_CONFIG.replace('  min_sol_revenue: 200\n', ''),
+      ),
+      feeRevenueMarginSol: new Decimal(1),
+    })
+
+    expect(ceiling).toBeUndefined()
+  })
+
+  it('rejects a config without fee_config instead of gating nothing', () => {
+    expect(() =>
+      loadFeeRevenueCeiling({
+        settlementConfig: writeConfig('empty.yaml', '---\nsettlements: []\n'),
+        feeRevenueMarginSol: new Decimal(1),
+      }),
+    ).toThrow('No fee_config found in')
+  })
+
+  it('parses the production settlement-config.yaml', () => {
+    const ceiling = loadFeeRevenueCeiling({
+      settlementConfig: join(__dirname, '../../../settlement-config.yaml'),
+      feeRevenueMarginSol: new Decimal(1),
+    })
+
+    expect(ceiling?.feeAuthorities).toHaveLength(2)
+    expect(ceiling?.maxFeeRevenueSol.isFinite()).toBe(true)
   })
 })
 

--- a/packages/validator-bonds-sanity-check/src/commands/checkMerkleTree.ts
+++ b/packages/validator-bonds-sanity-check/src/commands/checkMerkleTree.ts
@@ -619,39 +619,41 @@ export function loadFeeRevenueCeiling({
   settlementConfig: string
   feeRevenueMarginSol: Decimal
 }): Decimal | undefined {
-  let parsed: SettlementConfigFile
+  let parsed: SettlementConfigFile | null
   try {
     parsed = YAML.parse(
       readFileSync(settlementConfig, 'utf-8'),
-    ) as SettlementConfigFile
+    ) as SettlementConfigFile | null
   } catch (error) {
     throw CliCommandError.instance(
       `Failed to load settlement config from path: '${settlementConfig}'`,
       error,
     )
   }
-  if (parsed.fee_config === undefined) {
+  // an empty document parses to null, and a valueless `fee_config:` key to a null value
+  if (parsed?.fee_config == null) {
     throw CliCommandError.instance(`No fee_config found in ${settlementConfig}`)
   }
 
   const minSolRevenue = parsed.fee_config.min_sol_revenue
-  if (minSolRevenue === undefined || minSolRevenue === null) {
+  if (minSolRevenue == null) {
     return undefined
   }
 
-  // YAML .nan / .inf survive into Decimal, and greaterThan against them is always false
-  let ceiling: Decimal | undefined
+  // the target is validated, not the sum: YAML .nan / .inf survive into Decimal and make
+  // greaterThan always false, and a negative target would hide behind a positive margin
+  let target: Decimal | undefined
   try {
-    ceiling = new Decimal(minSolRevenue).plus(feeRevenueMarginSol)
+    target = new Decimal(minSolRevenue)
   } catch {
-    ceiling = undefined
+    target = undefined
   }
-  if (ceiling === undefined || !ceiling.isFinite() || !ceiling.greaterThan(0)) {
+  if (target === undefined || !target.isFinite() || target.lessThan(0)) {
     throw CliCommandError.instance(
-      `fee_config.min_sol_revenue in ${settlementConfig} must be a finite number > 0, got ${String(minSolRevenue)}`,
+      `fee_config.min_sol_revenue in ${settlementConfig} must be a finite number >= 0, got ${String(minSolRevenue)}`,
     )
   }
-  return ceiling
+  return target.plus(feeRevenueMarginSol)
 }
 
 // Penalty settlements deposit to the same authorities but sit outside the revenue target.

--- a/packages/validator-bonds-sanity-check/src/commands/checkMerkleTree.ts
+++ b/packages/validator-bonds-sanity-check/src/commands/checkMerkleTree.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs'
+
 import {
   CliCommandError,
   validateAndReturn,
@@ -9,9 +11,11 @@ import {
   calculateDescriptiveStats,
   detectAnomaly,
   getContext,
+  lamportsToSol,
   loadFileOrDirectory,
   resolveFilePaths,
 } from '@marinade.finance/ts-common'
+import { PublicKey } from '@solana/web3.js'
 import Decimal from 'decimal.js'
 import YAML from 'yaml'
 
@@ -19,6 +23,7 @@ import { UnifiedMerkleTreesDto } from '../dtoMerkleTree'
 import { parseSettlements } from '../dtoSettlements'
 import { readLargeJsonFileLossless } from '../losslessJson'
 
+import type { MerkleTree } from '../dtoMerkleTree'
 import type {
   AnomalyDetectionResult,
   DescriptiveStats,
@@ -79,6 +84,17 @@ export function installCheckMerkleTree(program: Command) {
         'Size it from what the claim pipeline can drain inside the on-chain claiming window.',
       d => new Decimal(d),
       new Decimal(150_000),
+    )
+    .option(
+      '--settlement-config <path>',
+      'Path to settlement-config.yaml. Its fee_config supplies the fee authorities and min_sol_revenue, ' +
+        'which gate how much of the distribution the fee may take. Omit to skip that check.',
+    )
+    .option(
+      '--fee-revenue-margin-sol <sol>',
+      'Added to min_sol_revenue to absorb fee optimizer rounding.',
+      d => new Decimal(d),
+      DECIMAL_ONE,
     )
     .action(manageCheckMerkleTree)
 }
@@ -171,6 +187,8 @@ async function manageCheckMerkleTree({
   minAbsoluteDeviation,
   epochHopThreshold,
   maxTotalClaims,
+  settlementConfig,
+  feeRevenueMarginSol,
 }: {
   merkleTrees: string
   settlementSources?: string[]
@@ -180,6 +198,8 @@ async function manageCheckMerkleTree({
   minAbsoluteDeviation: Decimal
   epochHopThreshold: Decimal
   maxTotalClaims: Decimal
+  settlementConfig?: string
+  feeRevenueMarginSol: Decimal
 }) {
   const { logger } = getContext()
 
@@ -205,6 +225,11 @@ async function manageCheckMerkleTree({
     )
   }
   validateMaxTotalClaims(maxTotalClaims)
+  if (!feeRevenueMarginSol.isFinite() || feeRevenueMarginSol.lessThan(0)) {
+    throw CliCommandError.instance(
+      `feeRevenueMarginSol must be a finite number >= 0, got ${feeRevenueMarginSol.toString()}`,
+    )
+  }
 
   logger.info(`Loading merkle tree file: ${merkleTrees}`)
 
@@ -282,6 +307,31 @@ async function manageCheckMerkleTree({
       `Total claims ${totalClaimsCount} exceeds the ceiling of ${maxTotalClaims.toString()}. ` +
         'The claim pipeline may not drain this within the claiming window.',
     )
+  }
+
+  if (settlementConfig !== undefined) {
+    const ceiling = loadFeeRevenueCeiling({
+      settlementConfig,
+      feeRevenueMarginSol,
+    })
+    if (ceiling === undefined) {
+      logger.info(
+        `No fee_config.min_sol_revenue in ${settlementConfig}, skipping the fee revenue ceiling`,
+      )
+    } else {
+      const feeCeiling = checkFeeRevenueCeiling({
+        epoch: merkleTreesDto.epoch,
+        merkleTrees: merkleTreesDto.merkle_trees,
+        ...ceiling,
+      })
+      logger.info(feeCeiling.report)
+      if (feeCeiling.exceeded) {
+        throw CliCommandError.instance(
+          `Fee authority claims ${feeCeiling.feeRevenueSol.toString()} SOL exceed the ceiling of ${ceiling.maxFeeRevenueSol.toString()} SOL, ` +
+            'so the fee optimizer collected more than min_sol_revenue and stakers were paid less.',
+        )
+      }
+    }
   }
 
   // Check 2: Cross-validate against settlement sources if provided
@@ -549,6 +599,101 @@ export function checkTotalClaimsCeiling({
   ].join('\n')
 
   return { exceeded, report }
+}
+
+interface SettlementConfigFile {
+  fee_config?: {
+    min_sol_revenue?: string | number
+    marinade?: { stake_authority?: string }
+    dao?: { stake_authority?: string }
+  }
+}
+
+export function loadFeeRevenueCeiling({
+  settlementConfig,
+  feeRevenueMarginSol,
+}: {
+  settlementConfig: string
+  feeRevenueMarginSol: Decimal
+}): { feeAuthorities: string[]; maxFeeRevenueSol: Decimal } | undefined {
+  const feeConfig = (
+    YAML.parse(readFileSync(settlementConfig, 'utf-8')) as SettlementConfigFile
+  ).fee_config
+  if (feeConfig === undefined) {
+    throw CliCommandError.instance(`No fee_config found in ${settlementConfig}`)
+  }
+
+  const feeAuthorities = [
+    feeConfig.marinade?.stake_authority,
+    feeConfig.dao?.stake_authority,
+  ].filter((authority): authority is string => authority !== undefined)
+  if (feeAuthorities.length === 0) {
+    throw CliCommandError.instance(
+      `No fee_config stake authorities found in ${settlementConfig}`,
+    )
+  }
+
+  if (feeConfig.min_sol_revenue === undefined) {
+    return undefined
+  }
+  return {
+    feeAuthorities,
+    maxFeeRevenueSol: new Decimal(feeConfig.min_sol_revenue).plus(
+      feeRevenueMarginSol,
+    ),
+  }
+}
+
+export function checkFeeRevenueCeiling({
+  epoch,
+  merkleTrees,
+  feeAuthorities,
+  maxFeeRevenueSol,
+}: {
+  epoch: number
+  merkleTrees: MerkleTree[]
+  feeAuthorities: string[]
+  maxFeeRevenueSol: Decimal
+}): { exceeded: boolean; feeRevenueSol: Decimal; report: string } {
+  const claimed = new Map<string, bigint>()
+  for (const authority of feeAuthorities) {
+    try {
+      claimed.set(new PublicKey(authority).toBase58(), 0n)
+    } catch {
+      throw CliCommandError.instance(
+        `Invalid fee authority public key: ${authority}`,
+      )
+    }
+  }
+
+  for (const tree of merkleTrees) {
+    for (const node of tree.tree_nodes) {
+      const authority = node.stake_authority.toBase58()
+      const claimedSoFar = claimed.get(authority)
+      if (claimedSoFar !== undefined) {
+        claimed.set(authority, claimedSoFar + node.claim)
+      }
+    }
+  }
+
+  const feeRevenueLamports = [...claimed.values()].reduce(
+    (sum, value) => sum + value,
+    0n,
+  )
+  const feeRevenueSol = lamportsToSol(feeRevenueLamports.toString())
+  const exceeded = feeRevenueSol.greaterThan(maxFeeRevenueSol)
+
+  const report = [
+    `\n=== Epoch ${epoch} Fee Revenue Ceiling (max: ${maxFeeRevenueSol.toString()} SOL) ===`,
+    ...[...claimed].map(
+      ([authority, lamports]) =>
+        `  ${authority}: ${lamportsToSol(lamports.toString()).toString()} SOL`,
+    ),
+    `[${exceeded ? '⛔' : '✅'}] feeRevenue: ${feeRevenueSol.toString()} SOL`,
+    'Status: ' + (exceeded ? '⛔ CEILING EXCEEDED' : '✅ WITHIN CEILING'),
+  ].join('\n')
+
+  return { exceeded, feeRevenueSol, report }
 }
 
 export type HopGuardedField = 'totalClaimAmount' | 'avgClaimAmountPerValidator'

--- a/packages/validator-bonds-sanity-check/src/commands/checkMerkleTree.ts
+++ b/packages/validator-bonds-sanity-check/src/commands/checkMerkleTree.ts
@@ -15,15 +15,14 @@ import {
   loadFileOrDirectory,
   resolveFilePaths,
 } from '@marinade.finance/ts-common'
-import { PublicKey } from '@solana/web3.js'
 import Decimal from 'decimal.js'
 import YAML from 'yaml'
 
 import { UnifiedMerkleTreesDto } from '../dtoMerkleTree'
-import { parseSettlements } from '../dtoSettlements'
+import { ClaimKind, parseSettlements } from '../dtoSettlements'
 import { readLargeJsonFileLossless } from '../losslessJson'
 
-import type { MerkleTree } from '../dtoMerkleTree'
+import type { Settlement } from '../dtoSettlements'
 import type {
   AnomalyDetectionResult,
   DescriptiveStats,
@@ -87,8 +86,8 @@ export function installCheckMerkleTree(program: Command) {
     )
     .option(
       '--settlement-config <path>',
-      'Path to settlement-config.yaml. Its fee_config supplies the fee authorities and min_sol_revenue, ' +
-        'which gate how much of the distribution the fee may take. Omit to skip that check.',
+      'Path to settlement-config.yaml. Its fee_config.min_sol_revenue gates how much of the distribution ' +
+        'the fee may take. Needs --settlement-sources; omit either to skip that check.',
     )
     .option(
       '--fee-revenue-margin-sol <sol>',
@@ -309,29 +308,14 @@ async function manageCheckMerkleTree({
     )
   }
 
-  if (settlementConfig !== undefined) {
-    const ceiling = loadFeeRevenueCeiling({
-      settlementConfig,
-      feeRevenueMarginSol,
-    })
-    if (ceiling === undefined) {
-      logger.info(
-        `No fee_config.min_sol_revenue in ${settlementConfig}, skipping the fee revenue ceiling`,
-      )
-    } else {
-      const feeCeiling = checkFeeRevenueCeiling({
-        epoch: merkleTreesDto.epoch,
-        merkleTrees: merkleTreesDto.merkle_trees,
-        ...ceiling,
-      })
-      logger.info(feeCeiling.report)
-      if (feeCeiling.exceeded) {
-        throw CliCommandError.instance(
-          `Fee authority claims ${feeCeiling.feeRevenueSol.toString()} SOL exceed the ceiling of ${ceiling.maxFeeRevenueSol.toString()} SOL, ` +
-            'so the fee optimizer collected more than min_sol_revenue and stakers were paid less.',
-        )
-      }
-    }
+  const maxFeeRevenueSol =
+    settlementConfig === undefined
+      ? undefined
+      : loadFeeRevenueCeiling({ settlementConfig, feeRevenueMarginSol })
+  if (settlementConfig !== undefined && maxFeeRevenueSol === undefined) {
+    logger.info(
+      `No fee_config.min_sol_revenue in ${settlementConfig}, skipping the fee revenue ceiling`,
+    )
   }
 
   // Check 2: Cross-validate against settlement sources if provided
@@ -351,6 +335,7 @@ async function manageCheckMerkleTree({
 
     let sourceSettlementsTotal = DECIMAL_ZERO
     let sourceClaimsCount = 0
+    const allSettlements: Settlement[] = []
 
     for (const { data, sourcePath } of settlementDataWithPaths) {
       if (!data) continue
@@ -382,6 +367,7 @@ async function manageCheckMerkleTree({
       )
       sourceSettlementsTotal = sourceSettlementsTotal.plus(sourceSum)
       sourceClaimsCount += sourceClaims
+      allSettlements.push(...settlements.settlements)
     }
 
     logger.info(
@@ -408,6 +394,25 @@ async function manageCheckMerkleTree({
         `Large difference in claim counts: sources (${sourceClaimsCount}) vs merkle trees (${totalClaimsCount}). This may be expected due to claim merging.`,
       )
     }
+
+    if (maxFeeRevenueSol !== undefined) {
+      const feeCeiling = checkFeeRevenueCeiling({
+        epoch: merkleTreesDto.epoch,
+        settlements: allSettlements,
+        maxFeeRevenueSol,
+      })
+      logger.info(feeCeiling.report)
+      if (feeCeiling.exceeded) {
+        throw CliCommandError.instance(
+          `Fee authority claims ${feeCeiling.feeRevenueSol.toString()} SOL exceed the ceiling of ${maxFeeRevenueSol.toString()} SOL, ` +
+            'so the fee optimizer collected more than min_sol_revenue and stakers were paid less.',
+        )
+      }
+    }
+  } else if (maxFeeRevenueSol !== undefined) {
+    logger.info(
+      'No settlement sources provided, skipping the fee revenue ceiling',
+    )
   }
 
   // Check 3: Historical comparison with heuristics
@@ -603,9 +608,7 @@ export function checkTotalClaimsCeiling({
 
 interface SettlementConfigFile {
   fee_config?: {
-    min_sol_revenue?: string | number
-    marinade?: { stake_authority?: string }
-    dao?: { stake_authority?: string }
+    min_sol_revenue?: string | number | null
   }
 }
 
@@ -615,64 +618,68 @@ export function loadFeeRevenueCeiling({
 }: {
   settlementConfig: string
   feeRevenueMarginSol: Decimal
-}): { feeAuthorities: string[]; maxFeeRevenueSol: Decimal } | undefined {
-  const feeConfig = (
-    YAML.parse(readFileSync(settlementConfig, 'utf-8')) as SettlementConfigFile
-  ).fee_config
-  if (feeConfig === undefined) {
+}): Decimal | undefined {
+  let parsed: SettlementConfigFile
+  try {
+    parsed = YAML.parse(
+      readFileSync(settlementConfig, 'utf-8'),
+    ) as SettlementConfigFile
+  } catch (error) {
+    throw CliCommandError.instance(
+      `Failed to load settlement config from path: '${settlementConfig}'`,
+      error,
+    )
+  }
+  if (parsed.fee_config === undefined) {
     throw CliCommandError.instance(`No fee_config found in ${settlementConfig}`)
   }
 
-  const feeAuthorities = [
-    feeConfig.marinade?.stake_authority,
-    feeConfig.dao?.stake_authority,
-  ].filter((authority): authority is string => authority !== undefined)
-  if (feeAuthorities.length === 0) {
-    throw CliCommandError.instance(
-      `No fee_config stake authorities found in ${settlementConfig}`,
-    )
-  }
-
-  if (feeConfig.min_sol_revenue === undefined) {
+  const minSolRevenue = parsed.fee_config.min_sol_revenue
+  if (minSolRevenue === undefined || minSolRevenue === null) {
     return undefined
   }
-  return {
-    feeAuthorities,
-    maxFeeRevenueSol: new Decimal(feeConfig.min_sol_revenue).plus(
-      feeRevenueMarginSol,
-    ),
+
+  // YAML .nan / .inf survive into Decimal, and greaterThan against them is always false
+  let ceiling: Decimal | undefined
+  try {
+    ceiling = new Decimal(minSolRevenue).plus(feeRevenueMarginSol)
+  } catch {
+    ceiling = undefined
   }
+  if (ceiling === undefined || !ceiling.isFinite() || !ceiling.greaterThan(0)) {
+    throw CliCommandError.instance(
+      `fee_config.min_sol_revenue in ${settlementConfig} must be a finite number > 0, got ${String(minSolRevenue)}`,
+    )
+  }
+  return ceiling
 }
+
+// Penalty settlements deposit to the same authorities but sit outside the revenue target.
+const FEE_REVENUE_REASONS = ['Bidding', 'PriorityFee']
 
 export function checkFeeRevenueCeiling({
   epoch,
-  merkleTrees,
-  feeAuthorities,
+  settlements,
   maxFeeRevenueSol,
 }: {
   epoch: number
-  merkleTrees: MerkleTree[]
-  feeAuthorities: string[]
+  settlements: Settlement[]
   maxFeeRevenueSol: Decimal
 }): { exceeded: boolean; feeRevenueSol: Decimal; report: string } {
   const claimed = new Map<string, bigint>()
-  for (const authority of feeAuthorities) {
-    try {
-      claimed.set(new PublicKey(authority).toBase58(), 0n)
-    } catch {
-      throw CliCommandError.instance(
-        `Invalid fee authority public key: ${authority}`,
-      )
+  for (const settlement of settlements) {
+    if (!FEE_REVENUE_REASONS.includes(settlement.reason.getReasonType())) {
+      continue
     }
-  }
-
-  for (const tree of merkleTrees) {
-    for (const node of tree.tree_nodes) {
-      const authority = node.stake_authority.toBase58()
-      const claimedSoFar = claimed.get(authority)
-      if (claimedSoFar !== undefined) {
-        claimed.set(authority, claimedSoFar + node.claim)
+    for (const claim of settlement.claims) {
+      if (claim.kind !== ClaimKind.FeeDeposit) {
+        continue
       }
+      const authority = claim.stake_authority.toBase58()
+      claimed.set(
+        authority,
+        (claimed.get(authority) ?? 0n) + claim.claim_amount,
+      )
     }
   }
 

--- a/settlement-pipelines/src/bin/claim_settlement.rs
+++ b/settlement-pipelines/src/bin/claim_settlement.rs
@@ -1076,6 +1076,8 @@ struct EpochClaimSummary {
     total_nodes: u64,
     claimed_amount_sol: f64,
     total_amount_sol: f64,
+    not_claimed_no_target_sol: f64,
+    not_claimed_no_source_sol: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     json_nodes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1124,6 +1126,8 @@ impl ReportSerializable for ClaimSettlementsReport {
                     let sum_initial = settlements_report.sum_already_claimed();
                     let (json_loaded_nodes, json_loaded_lamports) =
                         settlements_report.sum_json_loaded_settlements();
+                    let (no_account_to, no_account_from) =
+                        settlements_report.sum_update_no_account();
 
                     // Build after amounts from chain data (current state after claiming)
                     let after_amounts: HashMap<Pubkey, (u64, u64)> = after_settlements
@@ -1200,6 +1204,8 @@ impl ReportSerializable for ClaimSettlementsReport {
                         total_nodes: sum_initial.max_merkle_nodes,
                         claimed_amount_sol: lamports_to_sol(after_claimed_lamports),
                         total_amount_sol: lamports_to_sol(sum_initial.max_total_claim),
+                        not_claimed_no_target_sol: lamports_to_sol(no_account_to),
+                        not_claimed_no_source_sol: lamports_to_sol(no_account_from),
                         json_nodes: if json_loaded_nodes > 0 {
                             Some(json_loaded_nodes)
                         } else {


### PR DESCRIPTION
Added a sanity check for the DAO fund ceiling and a small additional reporting detail around claiming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added fee-revenue ceiling validation based on eligible settlement activity.
  - Added settlement configuration and fee-revenue margin settings to sanity checks.
  - Settlement summaries now include unclaimed SOL caused by missing destination or source stake accounts.

- **Bug Fixes**
  - Improved handling of missing, optional, empty, invalid, and unreadable fee-revenue configuration.
  - Excludes penalty deposits and staker payouts from eligible fee-revenue calculations.

- **Tests**
  - Added coverage for settlement-based revenue calculations, configuration scenarios, and ceiling violations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->