### PR TITLE
[GEN-8851][GEN-8055][cli] warn when a vote account has a bond of the other type

### DIFF
--- a/packages/validator-bonds-cli-core/__tests__/otherBondConfig.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/otherBondConfig.spec.ts
@@ -1,0 +1,29 @@
+import {
+  MARINADE_CONFIG_ADDRESS,
+  MARINADE_INSTITUTIONAL_CONFIG_ADDRESS,
+} from '@marinade.finance/validator-bonds-sdk'
+import { Keypair } from '@solana/web3.js'
+
+import { otherBondConfig } from '../src/commands/manage/subscribe'
+
+describe('otherBondConfig', () => {
+  it('points a bidding bond at the Select CLI', () => {
+    const other = otherBondConfig(MARINADE_CONFIG_ADDRESS)
+    expect(other).not.toBeNull()
+    expect(other!.config).toEqual(MARINADE_INSTITUTIONAL_CONFIG_ADDRESS)
+    expect(other!.label).toBe('Marinade Select')
+    expect(other!.cli).toBe('validator-bonds-institutional')
+  })
+
+  it('points a Select bond at the bidding CLI', () => {
+    const other = otherBondConfig(MARINADE_INSTITUTIONAL_CONFIG_ADDRESS)
+    expect(other).not.toBeNull()
+    expect(other!.config).toEqual(MARINADE_CONFIG_ADDRESS)
+    expect(other!.label).toBe('bidding')
+    expect(other!.cli).toBe('validator-bonds')
+  })
+
+  it('has no counterpart for a custom config', () => {
+    expect(otherBondConfig(Keypair.generate().publicKey)).toBeNull()
+  })
+})

--- a/packages/validator-bonds-cli-core/src/commands/manage/subscribe.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/subscribe.ts
@@ -11,6 +11,11 @@ import {
   subscribeMessage,
 } from '@marinade.finance/notifications-ts-subscription-client'
 import {
+  bondAddress,
+  MARINADE_CONFIG_ADDRESS,
+  MARINADE_INSTITUTIONAL_CONFIG_ADDRESS,
+} from '@marinade.finance/validator-bonds-sdk'
+import {
   instanceOfWallet,
   parsePubkey,
   parseWalletOrPubkeyOption,
@@ -23,6 +28,7 @@ import { formatHttpError, getBondFromAddress } from '../../utils'
 
 import type { SubscribeResponse } from '@marinade.finance/notifications-ts-subscription-client'
 import type { LoggerWrapper } from '@marinade.finance/ts-common'
+import type { ValidatorBondsProgram } from '@marinade.finance/validator-bonds-sdk'
 import type { KeypairWallet } from '@marinade.finance/web3js-1x'
 import type { Wallet as WalletInterface } from '@marinade.finance/web3js-1x'
 import type { PublicKey } from '@solana/web3.js'
@@ -235,6 +241,85 @@ export async function manageSubscribe({
     }
     throw e
   }
+
+  // Outside the try above so it can never be reported as a subscription failure
+  await warnAboutOtherBondType({
+    program,
+    logger,
+    configAddress,
+    voteAccount,
+    type,
+    channelAddress,
+    withAuthority: authority !== undefined,
+  })
+}
+
+// each CLI owns one notification type, so a vote account with both bonds needs both subscriptions
+async function warnAboutOtherBondType({
+  program,
+  logger,
+  configAddress,
+  voteAccount,
+  type,
+  channelAddress,
+  withAuthority,
+}: {
+  program: ValidatorBondsProgram
+  logger: LoggerWrapper
+  configAddress: PublicKey
+  voteAccount: PublicKey
+  type: string
+  channelAddress: string
+  withAuthority: boolean
+}): Promise<void> {
+  try {
+    const other = otherBondConfig(configAddress)
+    if (other === null) {
+      return
+    }
+    const [otherBond] = bondAddress(
+      other.config,
+      voteAccount,
+      program.programId,
+    )
+    const accountInfo =
+      await program.provider.connection.getAccountInfo(otherBond)
+    if (accountInfo === null || !accountInfo.owner.equals(program.programId)) {
+      return
+    }
+    logger.warn(
+      `This vote account also has a ${other.label} bond ` +
+        `(${otherBond.toBase58()}). Its notifications are subscribed ` +
+        `separately: ${other.cli} subscribe ${voteAccount.toBase58()}` +
+        ` --type ${type} --address ${channelAddress}` +
+        (withAuthority ? ' --authority <keypair-or-ledger>' : ''),
+    )
+  } catch (e) {
+    logger.debug({
+      msg: 'could not check for a bond of the other type',
+      error: e instanceof Error ? e.message : String(e),
+    })
+  }
+}
+
+export function otherBondConfig(
+  configAddress: PublicKey,
+): { config: PublicKey; label: string; cli: string } | null {
+  if (configAddress.equals(MARINADE_CONFIG_ADDRESS)) {
+    return {
+      config: MARINADE_INSTITUTIONAL_CONFIG_ADDRESS,
+      label: 'Marinade Select',
+      cli: 'validator-bonds-institutional',
+    }
+  }
+  if (configAddress.equals(MARINADE_INSTITUTIONAL_CONFIG_ADDRESS)) {
+    return {
+      config: MARINADE_CONFIG_ADDRESS,
+      label: 'bidding',
+      cli: 'validator-bonds',
+    }
+  }
+  return null
 }
 
 function logTelegramResult(


### PR DESCRIPTION
Notification subscriptions are keyed per notification type and each CLI can only create its own, so a vote account funding both a bidding and a Select bond needs two subscriptions. Nothing surfaced that: a Select-only subscriber missed the email-routed events of their bidding bond without any hint.

After a successful subscribe, derive the counterpart config's bond PDA and warn with the exact command for it when that bond exists on-chain. Read-only, one extra getAccountInfo, and it runs outside the try that maps failures to "Subscription failed" so it can never be reported as one.

Related: https://github.com/marinade-finance/marinade-notifications/pull/63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a post-subscription check to identify another bond configuration using the same vote account.
  * Displays a separate CLI subscription command when a matching bond is found.
  * Handles unknown configurations without affecting subscription results.

* **Tests**
  * Added coverage for supported configuration mappings and unknown configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->