### PR TITLE
[GEN-8895][GEN-8897][direct staking][stakes-etl] report + verification of blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/scripts/generate-direct-staking-report.bash
+++ b/scripts/generate-direct-staking-report.bash
@@ -16,26 +16,27 @@ fi
 # ten times settlement-config-direct-staking.yaml's min_settlement_lamports; keep the two in step
 tiny_settlement_lamports=100000000
 
+named_validators_limit=3
+
 decimal_format="%0.9f"
+
+join_parts() {
+    local separator="$1" running="" joined=""
+    shift
+    for part in "$@"; do
+        joined+="$running$part"
+        running="$separator"
+    done
+    printf '%s' "$joined"
+}
 
 epoch="$(<"$allocation_report_file" jq '.epoch' -r)"
 slot="$(<"$allocation_report_file" jq '.slot' -r)"
+covered="$(<"$allocation_report_file" jq '.routed | length' -r)"
 
-echo "Direct staking PSR in epoch $epoch (slot $slot)"
-
-# the two bond snapshots are collected per bond type, so a skew silently changes routing
-bidding_bonds_epoch="$(<"$allocation_report_file" jq '.bidding_bonds_epoch' -r)"
-institutional_bonds_epoch="$(<"$allocation_report_file" jq '.institutional_bonds_epoch' -r)"
-if [[ "$bidding_bonds_epoch" != "$institutional_bonds_epoch" ]]; then
-    echo "  WARNING bond snapshots disagree: bidding epoch $bidding_bonds_epoch, institutional epoch $institutional_bonds_epoch"
-fi
-
-while IFS=$'\t' read -r settlements_in claims_in bidding_settlements bidding_amount institutional_settlements institutional_amount dropped_settlements dropped_amount; do
-  echo "  generated: $settlements_in settlements, ☉$(printf $decimal_format "$claims_in")"
-  echo "  bidding config: $bidding_settlements settlements, ☉$(printf $decimal_format "$bidding_amount")"
-  echo "  institutional config: $institutional_settlements settlements, ☉$(printf $decimal_format "$institutional_amount")"
-  echo "  dropped: $dropped_settlements settlements, ☉$(printf $decimal_format "$dropped_amount")"
-done < <(<"$allocation_report_file" jq -r '.totals | [
+IFS=$'\t' read -r settlements_in claims_in bidding_settlements bidding_amount \
+  institutional_settlements institutional_amount dropped_settlements dropped_amount \
+  < <(<"$allocation_report_file" jq -r '.totals | [
   (.settlements_in | tostring),
   (.claims_amount_in / 1e9),
   (.bidding_settlements | tostring),
@@ -46,37 +47,54 @@ done < <(<"$allocation_report_file" jq -r '.totals | [
   (.dropped_claims_amount / 1e9)
 ] | @tsv')
 
-covered=$(<"$allocation_report_file" jq '.routed | length' -r)
-echo "  covered validators: $covered"
+header="Direct staking PSR in epoch $epoch (slot $slot)"
+if (( settlements_in == 0 )); then
+    echo "$header: no claims"
+else
+    echo "$header: $settlements_in settlements, ☉$(printf $decimal_format "$claims_in"), $covered validators"
+    breakdown=()
+    if (( bidding_settlements > 0 )); then
+        breakdown+=("bidding $bidding_settlements ☉$(printf $decimal_format "$bidding_amount")")
+    fi
+    if (( institutional_settlements > 0 )); then
+        breakdown+=("institutional $institutional_settlements ☉$(printf $decimal_format "$institutional_amount")")
+    fi
+    if (( dropped_settlements > 0 )); then
+        breakdown+=("dropped $dropped_settlements ☉$(printf $decimal_format "$dropped_amount")")
+    fi
+    echo "  $(join_parts ", " "${breakdown[@]}")"
+fi
+
+warnings=()
 
 # a drop means the front-end gate let a user stake to a validator with no usable bond
 dropped_count=$(<"$allocation_report_file" jq '.dropped_no_usable_bond | length' -r)
 if (( dropped_count > 0 )); then
-    echo
-    echo "  UNPROTECTED — no usable bond ($dropped_count):"
-    while IFS=$'\t' read -r vote_account settlements amount; do
-      echo "    $vote_account: $settlements settlements, ☉$(printf $decimal_format "$amount")"
-    done < <(<"$allocation_report_file" jq -r '.dropped_no_usable_bond | sort_by(-.claims_amount) | .[]
-      | [.vote_account, (.settlements | tostring), (.claims_amount / 1e9)] | @tsv')
+    named=$(<"$allocation_report_file" jq -r --argjson limit "$named_validators_limit" \
+      '.dropped_no_usable_bond | sort_by(-.claims_amount) | .[:$limit] | map(.vote_account) | join(", ")')
+    if (( dropped_count > named_validators_limit )); then
+        named="$named +$(( dropped_count - named_validators_limit ))"
+    fi
+    warnings+=("UNPROTECTED: $named")
 fi
 
 exposure_count=$(<"$allocation_report_file" jq '.exposure_warnings | length' -r)
 if (( exposure_count > 0 )); then
-    echo
-    echo "  EXPOSURE above threshold, direct staking claims only ($exposure_count):"
-    while IFS=$'\t' read -r vote_account bond_type exposure_bps threshold_bps amount; do
-      echo "    $vote_account ($bond_type): $exposure_bps bps of bond, threshold $threshold_bps bps, ☉$(printf $decimal_format "$amount")"
-    done < <(<"$allocation_report_file" jq -r '.exposure_warnings | sort_by(-.exposure_bps) | .[]
-      | [.vote_account, .bond_type, (.exposure_bps | tostring), (.threshold_bps | tostring), (.claims_amount / 1e9)] | @tsv')
+    warnings+=("exposure over threshold: $exposure_count")
 fi
 
 tiny_count=$(<"$allocation_report_file" jq --argjson limit "$tiny_settlement_lamports" '[.routed[] | select(.claims_amount < $limit)] | length' -r)
 if (( tiny_count > 0 )); then
-    echo
-    echo "  tiny settlements — candidates for raising min_settlement_lamports ($tiny_count):"
-    while IFS=$'\t' read -r vote_account bond_type settlements amount; do
-      echo "    $vote_account ($bond_type): $settlements settlements, ☉$(printf $decimal_format "$amount")"
-    done < <(<"$allocation_report_file" jq -r --argjson limit "$tiny_settlement_lamports" '
-      .routed | map(select(.claims_amount < $limit)) | sort_by(.claims_amount) | .[]
-      | [.vote_account, .bond_type, (.settlements | tostring), (.claims_amount / 1e9)] | @tsv')
+    warnings+=("tiny settlements: $tiny_count")
+fi
+
+# the two bond snapshots are collected per bond type, so a skew silently changes routing
+bidding_bonds_epoch="$(<"$allocation_report_file" jq '.bidding_bonds_epoch' -r)"
+institutional_bonds_epoch="$(<"$allocation_report_file" jq '.institutional_bonds_epoch' -r)"
+if [[ "$bidding_bonds_epoch" != "$institutional_bonds_epoch" ]]; then
+    warnings+=("bond snapshots disagree: $bidding_bonds_epoch/$institutional_bonds_epoch")
+fi
+
+if (( ${#warnings[@]} > 0 )); then
+    echo "  WARNING $(join_parts " | " "${warnings[@]}")"
 fi

--- a/settlement-distributions/bid-distribution/src/rewards.rs
+++ b/settlement-distributions/bid-distribution/src/rewards.rs
@@ -323,6 +323,7 @@ pub fn load_rewards_from_directory(
         &validators_inflation,
         &validators_mev,
     )?;
+    verify_block_rewards_present(&validators_blocks)?;
 
     info!("Aggregating rewards by vote account...");
     let rewards_by_vote_account = aggregate_rewards(
@@ -356,6 +357,18 @@ fn verify_stakers_rewards_present(
     if !validators_mev.is_empty() && mev_rewards.is_empty() {
         return Err(anyhow::anyhow!(
             "{VALIDATORS_MEV_REWARDS_FILE} has entries but {MEV_REWARDS_FILE} is empty - either the stakers' MEV rewards export is incomplete or no stakers received MEV rewards; refusing to derive 100% commissions"
+        ));
+    }
+    Ok(())
+}
+
+// unlike inflation and mev, block rewards have no stakers' counterpart file to cross-check against
+fn verify_block_rewards_present(
+    validators_blocks: &[ValidatorBlockRewardEntry],
+) -> anyhow::Result<()> {
+    if validators_blocks.is_empty() {
+        return Err(anyhow::anyhow!(
+            "{VALIDATORS_BLOCKS_REWARDS_FILE} is empty - every bond would be charged zero block commission and the stakers' block rewards would drop out of the payout"
         ));
     }
     Ok(())
@@ -605,6 +618,22 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("mev.json is empty"), "{error}");
+    }
+
+    #[test]
+    fn test_verify_block_rewards_present() {
+        let blocks = vec![ValidatorBlockRewardEntry {
+            epoch: 1,
+            identity_account: Pubkey::default(),
+            node_pubkey: Pubkey::default(),
+            authorized_voter: Pubkey::default(),
+            vote_account: Pubkey::new_unique(),
+            amount: 10,
+        }];
+        assert!(verify_block_rewards_present(&blocks).is_ok());
+
+        let error = verify_block_rewards_present(&[]).unwrap_err().to_string();
+        assert!(error.contains("validators_blocks.json is empty"), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
The direct staking Slack report is long when reported. This makes it a bit more concise.

A side point is an additional verification of the loaded rewards data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Staking reports now provide compact summaries of coverage, settlements, claims, and validator exposure.
  - Reports limit lengthy validator lists and present aggregate counts for easier review.
  - Protected-validator coverage now includes activating stake alongside effective stake.

- **Bug Fixes**
  - Reports consolidate warnings, including bond-snapshot mismatches.
  - Reward processing now rejects empty validator block-reward data instead of proceeding with invalid input.
  - Stake coverage calculations now correctly account for activating, effective, and deactivating stake.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->