### PR TITLE
[GEN-8914][direct staking] for protected api consider activating stake as well

### DIFF
--- a/api/src/handlers/collected_stake.rs
+++ b/api/src/handlers/collected_stake.rs
@@ -26,7 +26,7 @@ pub struct AuthorityStake {
 pub struct ValidatorStake {
     #[schema(value_type = Pubkey)]
     vote_account: String,
-    /// Sum of `effective` over every authority — the amount the validator's bond has to cover.
+    /// Sum of `effective` over every authority. See `/v1/validators/protected` for bond sizing.
     effective: u64,
     stake: Vec<AuthorityStake>,
 }

--- a/api/src/handlers/protected_validators.rs
+++ b/api/src/handlers/protected_validators.rs
@@ -65,7 +65,7 @@ fn protected_vote_accounts(
     operation_id = "List validators whose stakers are PSR protected",
     path = "/v1/validators/protected",
     responses(
-        (status = 200, description = "Effective bond under the bidding and the institutional config, summed, covers at least 1/2000 of the validator's Marinade stake, and is at least 1 SOL.", body = ProtectedValidatorsResponse),
+        (status = 200, description = "Effective bond under the bidding and the institutional config, summed, covers at least 1/2000 of the validator's Marinade stake including the stake still activating, and is at least 1 SOL.", body = ProtectedValidatorsResponse),
         (status = 500, description = "No stake has been collected yet, or bonds could not be read. Deliberately not an empty list, which would read as 'no validator is protected'."),
     )
 )]
@@ -105,7 +105,7 @@ pub async fn handler(
     Ok(Json(ProtectedValidatorsResponse {
         protected_validators: protected_vote_accounts(
             &bonds,
-            &snapshot.effective_by_vote_account(),
+            &snapshot.stake_to_cover_by_vote_account(),
         )
         .into_iter()
         .collect(),
@@ -115,8 +115,9 @@ pub async fn handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::repositories::collected_stake::CollectedStakeSnapshot;
     use chrono::Utc;
-    use validator_bonds_common::dto::BondType;
+    use validator_bonds_common::dto::{BondType, CollectedStakeRecord};
 
     fn sol(amount: u64) -> u64 {
         amount * 1_000_000_000
@@ -165,6 +166,31 @@ mod tests {
         protected_vote_accounts(&bonds, marinade_stake)
             .into_iter()
             .collect()
+    }
+
+    fn collected(entries: &[(&str, u64, u64)]) -> CollectedStakeSnapshot {
+        CollectedStakeSnapshot {
+            epoch: 1027,
+            slot: 443_966_005,
+            updated_at: Utc::now(),
+            records: entries
+                .iter()
+                .map(
+                    |(vote_account, effective, activating)| CollectedStakeRecord {
+                        epoch: 1027,
+                        slot: 443_966_005,
+                        label: "direct".to_string(),
+                        stake_authority: "psrStL2hNx4c7hLUUks8SmDngeYriB8pF7uyHFhM8ir".to_string(),
+                        vote_account: vote_account.to_string(),
+                        effective: *effective,
+                        activating: *activating,
+                        deactivating: 0,
+                        stake_accounts: 2,
+                        updated_at: Utc::now(),
+                    },
+                )
+                .collect(),
+        }
     }
 
     #[test]
@@ -250,5 +276,38 @@ mod tests {
             &stake(&[("voteTwice", sol(50_000))]),
         );
         assert_eq!(listed, vec!["voteTwice".to_string()]);
+    }
+
+    #[test]
+    fn stake_still_activating_is_already_covered_by_the_bond() {
+        // A bond sized only once the stake goes live leaves the first epoch of it unprotected.
+        let listed = protected(
+            vec![
+                bidding("voteActivatingCovered", sol(51)),
+                bidding("voteActivatingShort", sol(12)),
+            ],
+            &collected(&[
+                ("voteActivatingCovered", 0, sol(101_000)),
+                ("voteActivatingShort", 0, sol(101_000)),
+            ])
+            .stake_to_cover_by_vote_account(),
+        );
+        assert_eq!(listed, vec!["voteActivatingCovered".to_string()]);
+    }
+
+    #[test]
+    fn activating_stake_adds_to_the_effective_stake_of_the_same_validator() {
+        let listed = protected(
+            vec![
+                bidding("voteSumCovered", sol(25)),
+                bidding("voteSumShort", sol(25) - 1),
+            ],
+            &collected(&[
+                ("voteSumCovered", sol(30_000), sol(20_000)),
+                ("voteSumShort", sol(30_000), sol(20_000)),
+            ])
+            .stake_to_cover_by_vote_account(),
+        );
+        assert_eq!(listed, vec!["voteSumCovered".to_string()]);
     }
 }

--- a/api/src/handlers/protected_validators.rs
+++ b/api/src/handlers/protected_validators.rs
@@ -1,7 +1,9 @@
 use crate::context::WrappedContext;
 use crate::error::AppError;
 use crate::repositories::bond::get_summable_bonds;
-use crate::repositories::collected_stake::{get_collected_stake, MarinadeStakeByVoteAccount};
+use crate::repositories::collected_stake::{
+    get_collected_stake, CollectedStakeSnapshot, MarinadeStakeByVoteAccount,
+};
 use axum::extract::{Query, State};
 use axum::Json;
 use rust_decimal::Decimal;
@@ -59,6 +61,14 @@ fn protected_vote_accounts(
         .collect()
 }
 
+// The handler must keep routing through here: the tests cover this fold, never `handler` itself.
+fn protected_from_snapshot(
+    bonds: &[ValidatorBondRecord],
+    snapshot: &CollectedStakeSnapshot,
+) -> BTreeSet<String> {
+    protected_vote_accounts(bonds, &snapshot.stake_to_cover_by_vote_account())
+}
+
 #[utoipa::path(
     get,
     tag = "Validators",
@@ -103,19 +113,15 @@ pub async fn handler(
     }
 
     Ok(Json(ProtectedValidatorsResponse {
-        protected_validators: protected_vote_accounts(
-            &bonds,
-            &snapshot.stake_to_cover_by_vote_account(),
-        )
-        .into_iter()
-        .collect(),
+        protected_validators: protected_from_snapshot(&bonds, &snapshot)
+            .into_iter()
+            .collect(),
     }))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::repositories::collected_stake::CollectedStakeSnapshot;
     use chrono::Utc;
     use validator_bonds_common::dto::{BondType, CollectedStakeRecord};
 
@@ -164,6 +170,15 @@ mod tests {
         marinade_stake: &MarinadeStakeByVoteAccount,
     ) -> Vec<String> {
         protected_vote_accounts(&bonds, marinade_stake)
+            .into_iter()
+            .collect()
+    }
+
+    fn protected_snapshot(
+        bonds: Vec<ValidatorBondRecord>,
+        snapshot: &CollectedStakeSnapshot,
+    ) -> Vec<String> {
+        protected_from_snapshot(&bonds, snapshot)
             .into_iter()
             .collect()
     }
@@ -281,7 +296,7 @@ mod tests {
     #[test]
     fn stake_still_activating_is_already_covered_by_the_bond() {
         // A bond sized only once the stake goes live leaves the first epoch of it unprotected.
-        let listed = protected(
+        let listed = protected_snapshot(
             vec![
                 bidding("voteActivatingCovered", sol(51)),
                 bidding("voteActivatingShort", sol(12)),
@@ -289,15 +304,14 @@ mod tests {
             &collected(&[
                 ("voteActivatingCovered", 0, sol(101_000)),
                 ("voteActivatingShort", 0, sol(101_000)),
-            ])
-            .stake_to_cover_by_vote_account(),
+            ]),
         );
         assert_eq!(listed, vec!["voteActivatingCovered".to_string()]);
     }
 
     #[test]
     fn activating_stake_adds_to_the_effective_stake_of_the_same_validator() {
-        let listed = protected(
+        let listed = protected_snapshot(
             vec![
                 bidding("voteSumCovered", sol(25)),
                 bidding("voteSumShort", sol(25) - 1),
@@ -305,8 +319,7 @@ mod tests {
             &collected(&[
                 ("voteSumCovered", sol(30_000), sol(20_000)),
                 ("voteSumShort", sol(30_000), sol(20_000)),
-            ])
-            .stake_to_cover_by_vote_account(),
+            ]),
         );
         assert_eq!(listed, vec!["voteSumCovered".to_string()]);
     }

--- a/api/src/repositories/collected_stake.rs
+++ b/api/src/repositories/collected_stake.rs
@@ -20,14 +20,16 @@ pub struct CollectedStakeSnapshot {
 }
 
 impl CollectedStakeSnapshot {
-    /// Summed across every configured authority: the bond has to cover the validator's whole
-    /// Marinade stake, whichever product routed it.
-    pub fn effective_by_vote_account(&self) -> MarinadeStakeByVoteAccount {
-        let mut effective = MarinadeStakeByVoteAccount::new();
+    /// Summed across every configured authority, `activating` included: the bond has to cover the
+    /// validator's whole Marinade stake, whichever product routed it, and it has to cover stake
+    /// already routed there before that stake goes live. `deactivating` is a subset of `effective`.
+    pub fn stake_to_cover_by_vote_account(&self) -> MarinadeStakeByVoteAccount {
+        let mut to_cover = MarinadeStakeByVoteAccount::new();
         for record in &self.records {
-            *effective.entry(record.vote_account.clone()).or_default() += record.effective;
+            *to_cover.entry(record.vote_account.clone()).or_default() +=
+                record.effective + record.activating;
         }
-        effective
+        to_cover
     }
 }
 
@@ -206,6 +208,72 @@ mod tests {
             stake_accounts: 1,
             updated_at: stamp(0),
         }
+    }
+
+    fn snapshot(records: Vec<CollectedStakeRecord>) -> CollectedStakeSnapshot {
+        CollectedStakeSnapshot {
+            epoch: 1014,
+            slot: 438413520,
+            updated_at: stamp(0),
+            records,
+        }
+    }
+
+    fn stake_record(
+        vote_account: &str,
+        label: &str,
+        effective: u64,
+        activating: u64,
+        deactivating: u64,
+    ) -> CollectedStakeRecord {
+        CollectedStakeRecord {
+            vote_account: vote_account.to_string(),
+            label: label.to_string(),
+            effective,
+            activating,
+            deactivating,
+            ..record(1014)
+        }
+    }
+
+    #[test]
+    fn activating_stake_counts_towards_the_amount_to_cover() {
+        let to_cover = snapshot(vec![stake_record(
+            "voteActivating",
+            "direct",
+            0,
+            101_000,
+            0,
+        )])
+        .stake_to_cover_by_vote_account();
+        assert_eq!(to_cover.get("voteActivating"), Some(&101_000));
+    }
+
+    #[test]
+    fn deactivating_stake_is_not_added_on_top_of_effective() {
+        // Agave keeps deactivating stake effective for that epoch, so it is a subset, never an addend.
+        let to_cover = snapshot(vec![stake_record(
+            "voteDeactivating",
+            "native",
+            500,
+            0,
+            500,
+        )])
+        .stake_to_cover_by_vote_account();
+        assert_eq!(to_cover.get("voteDeactivating"), Some(&500));
+    }
+
+    #[test]
+    fn every_authority_of_a_vote_account_is_summed() {
+        let to_cover = snapshot(vec![
+            stake_record("voteMulti", "native", 10, 1, 0),
+            stake_record("voteMulti", "select", 20, 2, 0),
+            stake_record("voteMulti", "direct", 0, 4, 0),
+            stake_record("voteOther", "native", 7, 0, 0),
+        ])
+        .stake_to_cover_by_vote_account();
+        assert_eq!(to_cover.get("voteMulti"), Some(&37));
+        assert_eq!(to_cover.get("voteOther"), Some(&7));
     }
 
     #[test]

--- a/api/src/repositories/collected_stake.rs
+++ b/api/src/repositories/collected_stake.rs
@@ -229,6 +229,8 @@ mod tests {
         CollectedStakeRecord {
             vote_account: vote_account.to_string(),
             label: label.to_string(),
+            // Rows are unique on (epoch, stake_authority, vote_account); label and authority are 1:1.
+            stake_authority: format!("{label}-authority"),
             effective,
             activating,
             deactivating,


### PR DESCRIPTION
The `/protected` should also consider the activating stake to consider the stake that has just been delegated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Protected-validator calculations now include activating stake alongside effective stake when determining coverage.
  - Coverage is aggregated across relevant vote accounts and authorities.
  - Deactivating stake is not added separately to coverage calculations.

- **Documentation**
  - Clarified validator stake descriptions and referenced the protected-validator endpoint for bond sizing.

- **Tests**
  - Added coverage for activating, deactivating, and combined effective-plus-activating stake scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->