### PR TITLE
[GEN-8245][version] bump select notifications 2.6.2

### DIFF
--- a/packages/validator-bonds-cli-core/__tests__/npmRegistry.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/npmRegistry.spec.ts
@@ -421,7 +421,7 @@ describe('checkCliVersion', () => {
       checkCliVersion(mockLogger, registryUrl, '2.6.0'),
     ).resolves.toBeUndefined()
     await expect(
-      checkCliVersion(mockLogger, registryUrl, '2.6.1'),
+      checkCliVersion(mockLogger, registryUrl, '2.7.1000'),
     ).resolves.toBeUndefined()
     expect(stderrSpy).not.toHaveBeenCalled()
   })

--- a/packages/validator-bonds-cli-core/__tests__/npmRegistry.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/npmRegistry.spec.ts
@@ -421,7 +421,7 @@ describe('checkCliVersion', () => {
       checkCliVersion(mockLogger, registryUrl, '2.6.0'),
     ).resolves.toBeUndefined()
     await expect(
-      checkCliVersion(mockLogger, registryUrl, '2.7.0'),
+      checkCliVersion(mockLogger, registryUrl, '2.6.1'),
     ).resolves.toBeUndefined()
     expect(stderrSpy).not.toHaveBeenCalled()
   })

--- a/packages/validator-bonds-cli-core/package.json
+++ b/packages/validator-bonds-cli-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-core",
-  "version": "2.7.0",
+  "version": "2.6.1",
   "description": "Common CLI Core of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-core/package.json
+++ b/packages/validator-bonds-cli-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-core",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Common CLI Core of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-institutional/README.md
+++ b/packages/validator-bonds-cli-institutional/README.md
@@ -25,7 +25,7 @@ To get info on available commands
 ```sh
 # to verify installed version
 validator-bonds-institutional --version
-2.6.1
+2.6.2
 
 # get reference of available commands
 validator-bonds-institutional --help

--- a/packages/validator-bonds-cli-institutional/README.md
+++ b/packages/validator-bonds-cli-institutional/README.md
@@ -25,7 +25,7 @@ To get info on available commands
 ```sh
 # to verify installed version
 validator-bonds-institutional --version
-2.7.0
+2.6.1
 
 # get reference of available commands
 validator-bonds-institutional --help

--- a/packages/validator-bonds-cli-institutional/package.json
+++ b/packages/validator-bonds-cli-institutional/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-institutional",
-  "version": "2.7.0",
+  "version": "2.6.1",
   "description": "CLI of the validator bonds contract streamlined for institutional users",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-institutional/package.json
+++ b/packages/validator-bonds-cli-institutional/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli-institutional",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "CLI of the validator bonds contract streamlined for institutional users",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli-institutional/src/index.ts
+++ b/packages/validator-bonds-cli-institutional/src/index.ts
@@ -12,7 +12,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli-institutional'
 
 launchCliProgram({
-  version: '2.6.1',
+  version: '2.6.2',
   installAdditionalOptions: program => {
     program.setOptionValueWithSource(
       'programId',

--- a/packages/validator-bonds-cli-institutional/src/index.ts
+++ b/packages/validator-bonds-cli-institutional/src/index.ts
@@ -12,7 +12,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli-institutional'
 
 launchCliProgram({
-  version: '2.7.0',
+  version: '2.6.1',
   installAdditionalOptions: program => {
     program.setOptionValueWithSource(
       'programId',

--- a/packages/validator-bonds-cli/README.md
+++ b/packages/validator-bonds-cli/README.md
@@ -937,7 +937,7 @@ When installed globally
 # Get npm global installation folder
 npm list -g
 > /usr/lib
-> +-- @marinade.finance/validator-bonds-cli@2.6.1
+> +-- @marinade.finance/validator-bonds-cli@2.6.2
 > ...
 # In this case, the `bin` folder is located at /usr/bin
 ```
@@ -957,7 +957,7 @@ npm i -g @marinade.finance/validator-bonds-cli@latest
 # Verify installation
 npm list -g
 # Output: ~/.local/share/npm/lib
-#         └── @marinade.finance/validator-bonds-cli@2.6.1
+#         └── @marinade.finance/validator-bonds-cli@2.6.2
 ```
 
 To execute the installed packages from any location,
@@ -1152,7 +1152,7 @@ Commands:
   # Get npm global installation folder
   npm list -g
   > ~/.local/share/npm/lib
-  > `-- @marinade.finance/validator-bonds-cli@2.6.1
+  > `-- @marinade.finance/validator-bonds-cli@2.6.2
   # In this case, the 'bin' folder is located at ~/.local/share/npm/bin
 
   # Get validator-bonds binary folder

--- a/packages/validator-bonds-cli/README.md
+++ b/packages/validator-bonds-cli/README.md
@@ -937,7 +937,7 @@ When installed globally
 # Get npm global installation folder
 npm list -g
 > /usr/lib
-> +-- @marinade.finance/validator-bonds-cli@2.7.0
+> +-- @marinade.finance/validator-bonds-cli@2.6.1
 > ...
 # In this case, the `bin` folder is located at /usr/bin
 ```
@@ -957,7 +957,7 @@ npm i -g @marinade.finance/validator-bonds-cli@latest
 # Verify installation
 npm list -g
 # Output: ~/.local/share/npm/lib
-#         └── @marinade.finance/validator-bonds-cli@2.7.0
+#         └── @marinade.finance/validator-bonds-cli@2.6.1
 ```
 
 To execute the installed packages from any location,
@@ -1152,7 +1152,7 @@ Commands:
   # Get npm global installation folder
   npm list -g
   > ~/.local/share/npm/lib
-  > `-- @marinade.finance/validator-bonds-cli@2.7.0
+  > `-- @marinade.finance/validator-bonds-cli@2.6.1
   # In this case, the 'bin' folder is located at ~/.local/share/npm/bin
 
   # Get validator-bonds binary folder

--- a/packages/validator-bonds-cli/package.json
+++ b/packages/validator-bonds-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "CLI of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli/package.json
+++ b/packages/validator-bonds-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-cli",
-  "version": "2.7.0",
+  "version": "2.6.1",
   "description": "CLI of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-cli/src/index.ts
+++ b/packages/validator-bonds-cli/src/index.ts
@@ -13,7 +13,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli'
 
 launchCliProgram({
-  version: '2.6.1',
+  version: '2.6.2',
   installAdditionalOptions: program => {
     program.option(
       '--program-id <pubkey>',

--- a/packages/validator-bonds-cli/src/index.ts
+++ b/packages/validator-bonds-cli/src/index.ts
@@ -13,7 +13,7 @@ export const VALIDATOR_BONDS_NPM_URL =
   'https://registry.npmjs.org/@marinade.finance/validator-bonds-cli'
 
 launchCliProgram({
-  version: '2.7.0',
+  version: '2.6.1',
   installAdditionalOptions: program => {
     program.option(
       '--program-id <pubkey>',

--- a/packages/validator-bonds-sdk/package.json
+++ b/packages/validator-bonds-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-sdk",
-  "version": "2.7.0",
+  "version": "2.6.1",
   "description": "SDK of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/packages/validator-bonds-sdk/package.json
+++ b/packages/validator-bonds-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/validator-bonds-sdk",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "SDK of the validator bonds contract",
   "repository": {
     "type": "git",

--- a/scripts/update-cli-version.sh
+++ b/scripts/update-cli-version.sh
@@ -6,11 +6,13 @@
 SCRIPT_PATH=`readlink -f "$0"`
 SCRIPT_DIR=`dirname "$SCRIPT_PATH"`
 
-CLI_INDEX="$SCRIPT_DIR/../packages/validator-bonds-cli/src/index.ts"
-CLI_INSTITUTIONAL_INDEX="$SCRIPT_DIR/../packages/validator-bonds-cli-institutional/src/index.ts"
-README="$SCRIPT_DIR/../README.md"
-README_CLI="$SCRIPT_DIR/../packages/validator-bonds-cli/README.md"
-README_INSTITUTIONAL_CLI="$SCRIPT_DIR/../packages/validator-bonds-cli-institutional/README.md"
+VERSION_FILES=(
+  "$SCRIPT_DIR/../packages/validator-bonds-cli/src/index.ts"
+  "$SCRIPT_DIR/../packages/validator-bonds-cli-institutional/src/index.ts"
+  "$SCRIPT_DIR/../README.md"
+  "$SCRIPT_DIR/../packages/validator-bonds-cli/README.md"
+  "$SCRIPT_DIR/../packages/validator-bonds-cli-institutional/README.md"
+)
 
 SDK_PACKAGE_JSON="$SCRIPT_DIR/../packages/validator-bonds-sdk/package.json"
 [ ! -f "$SDK_PACKAGE_JSON" ] && echo "$SDK_PACKAGE_JSON not found" && exit 1
@@ -34,7 +36,7 @@ done
 
 
 echo "$PREVIOUS_VERSION -> $UPDATE_NEW_VERSION"
-for I in "$CLI_INDEX" "$CLI_INSTITUTIONAL_INDEX" "$README" "$README_CLI" "$README_INSTITUTIONAL_CLI"; do
+for I in "${VERSION_FILES[@]}"; do
     UPDATE_FILE=`readlink -f "$I"`
     echo "Updating ${UPDATE_FILE}"
     sed -i "s/$PREVIOUS_ESCAPED_VERSION/$UPDATE_NEW_VERSION/" "$UPDATE_FILE"


### PR DESCRIPTION
Bumping version; only to micro update to not force auto update the cli for select. 
The idea here is to release changes for the CLI from here: https://github.com/marinade-finance/validator-bonds/pull/504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - CLI and SDK packages now report version **2.6.2**.
  - Installation, troubleshooting, and CLI version documentation now reflect **2.6.2**.

- **Bug Fixes**
  - Version checks now correctly accept a CLI running a newer patch version than the registry version.

- **Maintenance**
  - Simplified the process for updating CLI version references across documentation and command-line entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->