### PR TITLE
[GEN-8976][rent reduction] split pinned stake reserve from live rent

### DIFF
--- a/packages/validator-bonds-cli-core/__tests__/stakeAccountRent.spec.ts
+++ b/packages/validator-bonds-cli-core/__tests__/stakeAccountRent.spec.ts
@@ -1,0 +1,34 @@
+import {
+  STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE,
+  minimalSizeStakeAccount,
+} from '@marinade.finance/validator-bonds-sdk'
+import BN from 'bn.js'
+
+const MIN_STAKE = new BN(1_000_000_000)
+// SIMD-0437 step 1, live on mainnet since 2026-09-03; step 2 drops it to 1_666_240
+const LIVE_RENT_STEP_1 = 2_077_224
+
+describe('stake account rent floors', () => {
+  it('mirrors the program floor and ignores the reduced live rent', () => {
+    expect(minimalSizeStakeAccount(MIN_STAKE).toString()).toEqual('1002282880')
+    expect(STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE).toBeGreaterThan(
+      LIVE_RENT_STEP_1,
+    )
+  })
+
+  it('rejects a withdraw amount that the live rent alone would accept', () => {
+    const acceptedByLiveRent = MIN_STAKE.addn(LIVE_RENT_STEP_1)
+    expect(acceptedByLiveRent.lt(minimalSizeStakeAccount(MIN_STAKE))).toBe(true)
+  })
+
+  it('funding floor covers both the program mirror and the live rent', () => {
+    for (const liveRent of [LIVE_RENT_STEP_1, 1_666_240, 228_288, 9_999_999]) {
+      const floor = BN.max(
+        minimalSizeStakeAccount(MIN_STAKE),
+        MIN_STAKE.addn(liveRent),
+      )
+      expect(floor.gte(minimalSizeStakeAccount(MIN_STAKE))).toBe(true)
+      expect(floor.gte(MIN_STAKE.addn(liveRent))).toBe(true)
+    }
+  })
+})

--- a/packages/validator-bonds-cli-core/src/commands/manage/fundBondWithSol.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/fundBondWithSol.ts
@@ -2,6 +2,7 @@ import {
   fundBondInstruction,
   getConfig,
   getRentExemptStake,
+  minimalSizeStakeAccount,
 } from '@marinade.finance/validator-bonds-sdk'
 import {
   instanceOfWallet,
@@ -118,8 +119,10 @@ export async function manageFundBondWithSol({
 
   const configData = await getConfig(program, config)
   const rentExemptStake = await getRentExemptStake(provider)
-  const minimalAmountToFund = configData.minimumStakeLamports.add(
-    new BN(rentExemptStake),
+  // must clear the program's pinned-reserve floor as well as the live delegation floor
+  const minimalAmountToFund = BN.max(
+    minimalSizeStakeAccount(configData.minimumStakeLamports),
+    configData.minimumStakeLamports.add(new BN(rentExemptStake)),
   )
   let amountLamports: BN
   if (Number.isFinite(amount * LAMPORTS_PER_SOL)) {
@@ -158,9 +161,7 @@ export async function manageFundBondWithSol({
     lamports: amountLamports.toNumber(),
     lockup: undefined,
   })
-  // error 0xc means not enough SOL to delegate the account
-  // lamports param has to be rentExempt + 1 SOL as min delegation amount
-  // normally it was 1 lamport, in new Solana versions it could be 1 SOL (SIMD that was not activated)
+  // delegate fails with 0xc unless the created amount clears rent plus the 1 SOL minimum delegation
   const delegateStakeAccountIx = StakeProgram.delegate({
     stakePubkey: stakeAccount,
     authorizedPubkey: from,

--- a/packages/validator-bonds-cli-core/src/commands/manage/initWithdrawRequest.ts
+++ b/packages/validator-bonds-cli-core/src/commands/manage/initWithdrawRequest.ts
@@ -3,8 +3,8 @@ import {
   checkAndGetBondAddress,
   getBond,
   getConfig,
-  getRentExemptStake,
   initWithdrawRequestInstruction,
+  minimalSizeStakeAccount,
 } from '@marinade.finance/validator-bonds-sdk'
 import {
   ExecutionError,
@@ -169,9 +169,8 @@ export async function manageInitWithdrawRequest({
     // withdraw request may withdraw only if possible to create a separate stake account,
     // or when withdrawing whole stake account, the amount is greater to minimal stake account "size"
     const configData = await getConfig(program, config)
-    const rentExemptStake = await getRentExemptStake(provider)
-    const minimalAmountToWithdraw = configData.minimumStakeLamports.add(
-      new BN(rentExemptStake),
+    const minimalAmountToWithdraw = minimalSizeStakeAccount(
+      configData.minimumStakeLamports,
     )
     if (amountBN.lt(minimalAmountToWithdraw)) {
       throw new CliCommandError({

--- a/packages/validator-bonds-cli/__tests__/test-validator/initWithdrawRequest.spec.ts
+++ b/packages/validator-bonds-cli/__tests__/test-validator/initWithdrawRequest.spec.ts
@@ -2,7 +2,9 @@ import assert from 'assert'
 
 import { extendJestWithShellMatchers } from '@marinade.finance/jest-shell-matcher'
 import {
+  getConfig,
   getWithdrawRequest,
+  minimalSizeStakeAccount,
   withdrawRequestAddress,
 } from '@marinade.finance/validator-bonds-sdk'
 import { initTest } from '@marinade.finance/validator-bonds-sdk/__tests__/utils/testValidator'
@@ -174,6 +176,8 @@ describe('Init withdraw request using CLI', () => {
     expect(withdrawRequestDataAll.bond).toEqual(bondAccount)
     expect(withdrawRequestDataAll.requestedAmount).toEqual(U64_MAX)
 
+    const { minimumStakeLamports } = await getConfig(program, configAccount)
+    const minimalAmount = minimalSizeStakeAccount(minimumStakeLamports)
     await expect([
       'pnpm',
       [
@@ -195,8 +199,9 @@ describe('Init withdraw request using CLI', () => {
       ],
     ]).toHaveMatchingSpawnOutput({
       code: 200,
-      stdout:
-        /100 lamports is less than the minimal amount 1002282880 lamports/,
+      stdout: new RegExp(
+        `100 lamports is less than the minimal amount ${minimalAmount.toString()} lamports`,
+      ),
     })
   })
 

--- a/packages/validator-bonds-sdk/src/web3.js/stakeAccount.ts
+++ b/packages/validator-bonds-sdk/src/web3.js/stakeAccount.ts
@@ -267,7 +267,7 @@ export async function getRentExemptStake(
   )
 }
 
-// Pinned into every Meta by the stake program, which ignores it and takes the real floor from the Rent sysvar (SIMD-0490); bonds compares against the stored field, so never use the live rent here.
+// The bonds program checks the stored Meta.rent_exempt_reserve, which the stake program still pins at this value (SIMD-0490) even though live rent is now lower (SIMD-0437) — mirror it, never read live rent.
 export const STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE = 2_282_880
 
 // Mirrors `minimal_size_stake_account` of the validator-bonds program.

--- a/packages/validator-bonds-sdk/src/web3.js/stakeAccount.ts
+++ b/packages/validator-bonds-sdk/src/web3.js/stakeAccount.ts
@@ -267,6 +267,14 @@ export async function getRentExemptStake(
   )
 }
 
+// Pinned into every Meta by the stake program, which ignores it and takes the real floor from the Rent sysvar (SIMD-0490); bonds compares against the stored field, so never use the live rent here.
+export const STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE = 2_282_880
+
+// Mirrors `minimal_size_stake_account` of the validator-bonds program.
+export function minimalSizeStakeAccount(minimumStakeLamports: BN): BN {
+  return minimumStakeLamports.addn(STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE)
+}
+
 function pubkeyOrNull(
   value?: ConstructorParameters<typeof PublicKey>[0] | null,
 ): PublicKey | null {

--- a/scripts/settlement-json-listing.sh
+++ b/scripts/settlement-json-listing.sh
@@ -67,7 +67,7 @@ CONFIG_PUBKEY=$("$SCRIPT_DIR"/bonds-config-pubkey.sh "$CLAIM_TYPE")
 MERKLE_TREES_EPOCH=$(jq '.epoch' "$MERKLE_TREES_JSON_FILE")
 echo "EPOCH: $MERKLE_TREES_EPOCH"
 
-# stake account minimal size
+# stake account minimal size; 2282880 is the pinned reserve bonds compares against, not today's rent
 CONFIG_MIN_STAKE=$(config_min_stake "$CONFIG_PUBKEY")
 STAKE_ACCOUNT_MINIMAL_SIZE=$(($CONFIG_MIN_STAKE + 2282880))
 echo "  (minimal delegated stake account lamports: ${STAKE_ACCOUNT_MINIMAL_SIZE})"

--- a/settlement-pipelines/src/bin/claim_settlement.rs
+++ b/settlement-pipelines/src/bin/claim_settlement.rs
@@ -19,7 +19,7 @@ use settlement_pipelines::settlement_data::{parse_from_merkle_tree_collections, 
 use settlement_pipelines::settlements::{list_claimable_settlements, ClaimableSettlementsReturn};
 use settlement_pipelines::stake_accounts::{
     get_stake_state_type, prepare_merge_instructions, prioritize_for_claiming,
-    STAKE_ACCOUNT_RENT_EXEMPTION,
+    STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE,
 };
 use settlement_pipelines::stake_accounts_cache::StakeAccountsCache;
 use settlement_pipelines::FINALIZATION_WAIT_TIMEOUT;
@@ -139,7 +139,8 @@ async fn real_main(
         .await
         .map_err(CliError::retry_able)?;
 
-    let minimal_stake_lamports = config.minimum_stake_lamports + STAKE_ACCOUNT_RENT_EXEMPTION;
+    let minimal_stake_lamports =
+        config.minimum_stake_lamports + STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE;
 
     let json_loaded_settlements_per_epoch =
         parse_from_merkle_tree_collections(&collections, args.epoch).map_err(CliError::critical)?;

--- a/settlement-pipelines/src/bin/close_settlement.rs
+++ b/settlement-pipelines/src/bin/close_settlement.rs
@@ -20,8 +20,8 @@ use settlement_pipelines::settlements::{
     load_expired_settlements, obtain_settlement_closing_refunds, SettlementRefundPubkeys,
 };
 use settlement_pipelines::stake_accounts::{
-    filter_settlement_funded, IGNORE_DANGLING_NOT_CLOSABLE_STAKE_ACCOUNTS_LIST,
-    STAKE_ACCOUNT_RENT_EXEMPTION,
+    fetch_stake_account_rent, filter_settlement_funded,
+    IGNORE_DANGLING_NOT_CLOSABLE_STAKE_ACCOUNTS_LIST, STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE,
 };
 use solana_cli_output::display::build_balance_message;
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -187,6 +187,9 @@ async fn close_settlements(
     reporting: &mut ReportHandler<CloseSettlementReport>,
 ) -> anyhow::Result<()> {
     let (bonds_withdrawer_authority, _) = find_bonds_withdrawer_authority(config_address);
+    let stake_account_rent = fetch_stake_account_rent(rpc_client.clone())
+        .await
+        .map_err(CliError::retry_able)?;
     for (settlement_address, settlement, _) in expired_settlements.iter() {
         let (split_rent_collector, split_rent_refund_account) =
             match obtain_settlement_closing_refunds(
@@ -194,6 +197,7 @@ async fn close_settlements(
                 settlement_address,
                 settlement,
                 &bonds_withdrawer_authority,
+                stake_account_rent,
             )
             .await
             {
@@ -294,7 +298,8 @@ async fn reset_stake_accounts(
             .map_err(CliError::retry_able)?;
     let settlement_funded_stake_accounts =
         filter_settlement_funded(all_bonds_stake_accounts, &clock);
-    let minimal_stake_lamports = config.minimum_stake_lamports + STAKE_ACCOUNT_RENT_EXEMPTION;
+    let minimal_stake_lamports =
+        config.minimum_stake_lamports + STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE;
     for (stake_pubkey, lamports, stake_state) in settlement_funded_stake_accounts {
         let staker_authority = if let Some(authorized) = stake_state.authorized() {
             authorized.staker
@@ -551,7 +556,7 @@ impl PrintReportable for CloseSettlementReport {
                 return vec!["No report available, not initialized yet.".to_string()];
             };
             let minimal_stake_account_lamports =
-                config.minimum_stake_lamports + STAKE_ACCOUNT_RENT_EXEMPTION;
+                config.minimum_stake_lamports + STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE;
 
             let (reset_stake_number, reset_stake_lamports) = self.reset_stake_total();
             let (withdrawn_stake_number, withdrawn_stake_lamports) = self.withdrawn_stake_total();

--- a/settlement-pipelines/src/bin/close_settlement.rs
+++ b/settlement-pipelines/src/bin/close_settlement.rs
@@ -198,6 +198,7 @@ async fn close_settlements(
     } else {
         0
     };
+    let mut closed_settlements: Vec<(Pubkey, Settlement)> = vec![];
     for (settlement_address, settlement, _) in expired_settlements.iter() {
         let (split_rent_collector, split_rent_refund_account) =
             match obtain_settlement_closing_refunds(
@@ -244,6 +245,7 @@ async fn close_settlements(
                 "Close Settlement {settlement_address}, refunding split rent from stake account {split_rent_refund_account}"
             ),
         )?;
+        closed_settlements.push((*settlement_address, settlement.clone()));
     }
 
     let execution_result = execute_parallel(
@@ -255,7 +257,7 @@ async fn close_settlements(
     .await;
     reporting
         .reportable
-        .set_closed_settlements(expired_settlements);
+        .set_closed_settlements(closed_settlements);
 
     reporting.add_tx_execution_result(execution_result, "CloseSettlements");
 
@@ -677,11 +679,8 @@ impl CloseSettlementReport {
         self.withdraw_wallet = withdraw_wallet;
     }
 
-    fn set_closed_settlements(&mut self, settlements: &[(Pubkey, Settlement, Option<Bond>)]) {
-        self.closed_settlements = settlements
-            .iter()
-            .map(|(p, s, _)| (*p, s.clone()))
-            .collect::<Vec<(Pubkey, Settlement)>>();
+    fn set_closed_settlements(&mut self, settlements: Vec<(Pubkey, Settlement)>) {
+        self.closed_settlements = settlements;
     }
 
     fn add_reset_stake(

--- a/settlement-pipelines/src/bin/close_settlement.rs
+++ b/settlement-pipelines/src/bin/close_settlement.rs
@@ -187,9 +187,17 @@ async fn close_settlements(
     reporting: &mut ReportHandler<CloseSettlementReport>,
 ) -> anyhow::Result<()> {
     let (bonds_withdrawer_authority, _) = find_bonds_withdrawer_authority(config_address);
-    let stake_account_rent = fetch_stake_account_rent(rpc_client.clone())
-        .await
-        .map_err(CliError::retry_able)?;
+    // unused by settlements without a split rent collector, so an empty or split-free batch must not fail on the lookup
+    let stake_account_rent = if expired_settlements
+        .iter()
+        .any(|(_, settlement, _)| settlement.split_rent_collector.is_some())
+    {
+        fetch_stake_account_rent(rpc_client.clone())
+            .await
+            .map_err(CliError::retry_able)?
+    } else {
+        0
+    };
     for (settlement_address, settlement, _) in expired_settlements.iter() {
         let (split_rent_collector, split_rent_refund_account) =
             match obtain_settlement_closing_refunds(

--- a/settlement-pipelines/src/bin/fund_settlement.rs
+++ b/settlement-pipelines/src/bin/fund_settlement.rs
@@ -25,9 +25,9 @@ use settlement_pipelines::settlement_data::{
     SettlementRecord,
 };
 use settlement_pipelines::stake_accounts::{
-    fund_settlement_split_underflow, get_delegated_amount, get_stake_state_type,
-    prepare_merge_instructions, settlement_funded_claimable_lamports, StakeAccountStateType,
-    STAKE_ACCOUNT_RENT_EXEMPTION,
+    fetch_stake_account_rent, fund_settlement_split_underflow, get_delegated_amount,
+    get_stake_state_type, prepare_merge_instructions, settlement_funded_claimable_lamports,
+    StakeAccountStateType, STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE,
 };
 use solana_cli_output::display::build_balance_message;
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -229,7 +229,12 @@ async fn prepare_funding(
     let stake_activation = StakeActivation::fetch(rpc_client.clone())
         .await
         .map_err(CliError::retry_able)?;
-    let minimal_stake_lamports = config.minimum_stake_lamports + STAKE_ACCOUNT_RENT_EXEMPTION;
+    let minimal_stake_lamports =
+        config.minimum_stake_lamports + STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE;
+    // what the on-chain `split_stake_account` will be created with, mirroring Anchor's `init`
+    let split_stake_rent_exempt = fetch_stake_account_rent(rpc_client.clone())
+        .await
+        .map_err(CliError::retry_able)?;
 
     let mut fund_bond_stake_accounts = get_on_chain_bond_stake_accounts(
         &all_stake_accounts,
@@ -381,6 +386,7 @@ async fn prepare_funding(
                     funding_stake_accounts,
                     amount_needed,
                     minimal_stake_lamports,
+                    split_stake_rent_exempt,
                 );
                 for underwater in underwater_stake_accounts.iter() {
                     reporting.warning().with_msg(format!(
@@ -564,8 +570,10 @@ async fn prepare_funding(
                             let lamports_available_after_split = destination_merged_lamports
                                 .saturating_sub(amount_to_fund)
                                 .saturating_sub(minimal_stake_lamports);
+                            // the program splits only when the leftover also covers the split account's own rent
                             if fund_destination
-                                && lamports_available_after_split >= minimal_stake_lamports
+                                && lamports_available_after_split
+                                    >= minimal_stake_lamports + split_stake_rent_exempt
                             {
                                 funding_stake_accounts.push(FundBondStakeAccount {
                                     lamports: lamports_available_after_split,
@@ -677,7 +685,8 @@ async fn fund_settlements(
     transaction_builder.add_signer_checked(&marinade_wallet);
 
     let (withdrawer_authority, _) = find_bonds_withdrawer_authority(config_address);
-    let minimal_stake_lamports = config.minimum_stake_lamports + STAKE_ACCOUNT_RENT_EXEMPTION;
+    let minimal_stake_lamports =
+        config.minimum_stake_lamports + STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE;
 
     // WARN: the prior processing REQUIRES that the fund bond transactions are executed in sequence (execute_in_sequence)
     //       Funding works with ordered stake accounts where one stake account can be used for multiple settlements
@@ -831,6 +840,7 @@ fn underwater_split_stake_accounts(
     stake_accounts: &[FundBondStakeAccount],
     amount_needed: u64,
     minimal_stake_lamports: u64,
+    split_stake_rent_exempt: u64,
 ) -> Vec<UnderwaterStakeAccount> {
     stake_accounts
         .iter()
@@ -840,7 +850,7 @@ fn underwater_split_stake_accounts(
                 account.lamports,
                 amount_needed,
                 minimal_stake_lamports,
-                STAKE_ACCOUNT_RENT_EXEMPTION,
+                split_stake_rent_exempt,
             )
             .map(|delegation_stake| UnderwaterStakeAccount {
                 stake_account: account.stake_account,
@@ -1251,7 +1261,9 @@ mod tests {
     use validator_bonds::state::settlement::Settlement;
 
     const SOL: u64 = 1_000_000_000;
-    const MIN: u64 = SOL + STAKE_ACCOUNT_RENT_EXEMPTION;
+    const MIN: u64 = SOL + STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE;
+    // SIMD-0437 step 1: Anchor funds the split account below the pinned reserve
+    const LIVE_RENT: u64 = 2_077_224;
 
     fn on_chain_settlement() -> Settlement {
         Settlement {
@@ -1345,7 +1357,8 @@ mod tests {
 
         // 10 SOL available >= 3 + MIN + rent needed -> the program would split and underflow
         let amount_needed_split = 3 * SOL;
-        let underwater_accounts = underwater_split_stake_accounts(&pool, amount_needed_split, MIN);
+        let underwater_accounts =
+            underwater_split_stake_accounts(&pool, amount_needed_split, MIN, LIVE_RENT);
         assert_eq!(underwater_accounts.len(), 1);
         assert_eq!(underwater_accounts[0].stake_account, underwater_address);
         assert_eq!(underwater_accounts[0].lamports, 10 * SOL);
@@ -1365,7 +1378,7 @@ mod tests {
         // 10 SOL available < 10 + MIN + rent needed -> whole-account path, no underflow to avoid
         let amount_needed_no_split = 10 * SOL;
         let underwater_accounts =
-            underwater_split_stake_accounts(&pool, amount_needed_no_split, MIN);
+            underwater_split_stake_accounts(&pool, amount_needed_no_split, MIN, LIVE_RENT);
         assert!(underwater_accounts.is_empty());
 
         let to_fund =
@@ -1384,7 +1397,8 @@ mod tests {
         let mut pool = vec![underwater];
 
         let amount_needed = 3 * SOL;
-        let underwater_accounts = underwater_split_stake_accounts(&pool, amount_needed, MIN);
+        let underwater_accounts =
+            underwater_split_stake_accounts(&pool, amount_needed, MIN, LIVE_RENT);
         assert_eq!(underwater_accounts.len(), 1);
 
         let to_fund = take_stake_accounts_to_fund(&mut pool, &underwater_accounts, amount_needed);

--- a/settlement-pipelines/src/bin/verify_settlement.rs
+++ b/settlement-pipelines/src/bin/verify_settlement.rs
@@ -11,7 +11,7 @@ use settlement_pipelines::reporting::{
     with_reporting_ext, PrintReportable, ReportHandler, ReportSerializable,
 };
 use settlement_pipelines::stake_accounts::{
-    settlement_funded_claimable_lamports, STAKE_ACCOUNT_RENT_EXEMPTION,
+    settlement_funded_claimable_lamports, STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE,
 };
 use solana_sdk::pubkey::Pubkey;
 use std::collections::{HashMap, HashSet};
@@ -274,7 +274,8 @@ async fn real_main(
         collect_stake_accounts(rpc_client.clone(), Some(&bonds_withdrawer_authority), None)
             .await
             .map_err(CliError::retry_able)?;
-    let minimal_stake_lamports = config_data.minimum_stake_lamports + STAKE_ACCOUNT_RENT_EXEMPTION;
+    let minimal_stake_lamports =
+        config_data.minimum_stake_lamports + STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE;
 
     let epochs: Vec<_> = claiming_epoch_range.clone().collect();
     info!(
@@ -380,7 +381,7 @@ mod tests {
     use solana_sdk::stake::state::{Authorized, Lockup, Meta, StakeStateV2};
 
     const SOL: u64 = 1_000_000_000;
-    const MIN: u64 = SOL + STAKE_ACCOUNT_RENT_EXEMPTION;
+    const MIN: u64 = SOL + STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE;
 
     fn make_settlement(
         max_total_claim: u64,
@@ -428,7 +429,7 @@ mod tests {
             Pubkey::new_unique(),
             lamports,
             StakeStateV2::Initialized(Meta {
-                rent_exempt_reserve: STAKE_ACCOUNT_RENT_EXEMPTION,
+                rent_exempt_reserve: STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE,
                 authorized: Authorized {
                     staker,
                     withdrawer: Pubkey::new_unique(),

--- a/settlement-pipelines/src/settlements.rs
+++ b/settlement-pipelines/src/settlements.rs
@@ -7,7 +7,6 @@ use validator_bonds::state::config::{find_bonds_withdrawer_authority, Config};
 use validator_bonds::state::settlement::{find_settlement_staker_authority, Settlement};
 use validator_bonds_common::cli_result::CliError;
 
-use crate::stake_accounts::STAKE_ACCOUNT_RENT_EXEMPTION;
 use crate::CONTRACT_V2_DEPLOYMENT_EPOCH;
 use validator_bonds_common::settlement_claims::SettlementClaimsBitmap;
 use validator_bonds_common::settlements::{
@@ -213,6 +212,7 @@ pub async fn obtain_settlement_closing_refunds(
     settlement_address: &Pubkey,
     settlement: &Settlement,
     bonds_withdrawer_authority: &Pubkey,
+    stake_account_rent: u64,
 ) -> anyhow::Result<SettlementRefundPubkeys> {
     let (settlement_staker_authority, _) = find_settlement_staker_authority(settlement_address);
     let (split_rent_collector, split_rent_refund_account) = {
@@ -238,9 +238,7 @@ pub async fn obtain_settlement_closing_refunds(
             let split_rent_refund_account = if let Some(found_matching_account) =
                 split_rent_refund_accounts.iter().find(|collected_stake| {
                     collected_stake.2.delegation().is_some()
-                        && collected_stake
-                            .1
-                            .saturating_sub(STAKE_ACCOUNT_RENT_EXEMPTION)
+                        && collected_stake.1.saturating_sub(stake_account_rent)
                             >= settlement.split_rent_amount
                 }) {
                 found_matching_account.0

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -22,10 +22,10 @@ use validator_bonds_common::stake_accounts::{
     is_locked, CollectedStakeAccount, CollectedStakeAccounts, StakeActivation,
 };
 
-/// The bonds program checks the stored `Meta.rent_exempt_reserve`, which the stake program still pins at this value (SIMD-0490) even though live rent is now lower (SIMD-0437); for live rent use `fetch_stake_account_rent`.
+// The bonds program checks the stored Meta.rent_exempt_reserve, which the stake program still pins at this value (SIMD-0490) even though live rent is now lower (SIMD-0437); for live rent use fetch_stake_account_rent.
 pub const STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE: u64 = 2282880;
 
-/// Live rent for a stake account, i.e. what Anchor's `init` pays for a `split_stake_account`.
+// Live rent for a stake account, i.e. what Anchor's `init` pays for a `split_stake_account`.
 pub async fn fetch_stake_account_rent(rpc_client: Arc<RpcClient>) -> anyhow::Result<u64> {
     rpc_client
         .get_minimum_balance_for_rent_exemption(std::mem::size_of::<StakeStateV2>())

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -22,7 +22,7 @@ use validator_bonds_common::stake_accounts::{
     is_locked, CollectedStakeAccount, CollectedStakeAccounts, StakeActivation,
 };
 
-/// Pinned into every `Meta` by the stake program, which ignores it (SIMD-0490); `minimal_size_stake_account` compares against the stored field, so never load this from chain — use `fetch_stake_account_rent` to mirror the chain's own floor.
+/// The bonds program checks the stored `Meta.rent_exempt_reserve`, which the stake program still pins at this value (SIMD-0490) even though live rent is now lower (SIMD-0437); for live rent use `fetch_stake_account_rent`.
 pub const STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE: u64 = 2282880;
 
 /// Live rent for a stake account, i.e. what Anchor's `init` pays for a `split_stake_account`.

--- a/settlement-pipelines/src/stake_accounts.rs
+++ b/settlement-pipelines/src/stake_accounts.rs
@@ -3,6 +3,7 @@ use anchor_client::anchor_lang::solana_program::stake_history::StakeHistoryEntry
 use anchor_client::{DynSigner, Program};
 use anyhow::anyhow;
 use log::warn;
+use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::clock::Clock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::stake::program::ID as stake_program_id;
@@ -21,8 +22,16 @@ use validator_bonds_common::stake_accounts::{
     is_locked, CollectedStakeAccount, CollectedStakeAccounts, StakeActivation,
 };
 
-// TODO: better to be loaded from chain
-pub const STAKE_ACCOUNT_RENT_EXEMPTION: u64 = 2282880;
+/// Pinned into every `Meta` by the stake program, which ignores it (SIMD-0490); `minimal_size_stake_account` compares against the stored field, so never load this from chain — use `fetch_stake_account_rent` to mirror the chain's own floor.
+pub const STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE: u64 = 2282880;
+
+/// Live rent for a stake account, i.e. what Anchor's `init` pays for a `split_stake_account`.
+pub async fn fetch_stake_account_rent(rpc_client: Arc<RpcClient>) -> anyhow::Result<u64> {
+    rpc_client
+        .get_minimum_balance_for_rent_exemption(std::mem::size_of::<StakeStateV2>())
+        .await
+        .map_err(|e| anyhow!("Cannot fetch stake account rent exemption: {e:?}"))
+}
 
 pub const MARINADE_LIQUID_STAKER_AUTHORITY: &str = "4bZ6o3eUUNXhKuqjdCnCoPAoLgWiuLYixKaxoa8PpiKk";
 pub const MARINADE_INSTITUTIONAL_STAKER_AUTHORITY: &str =
@@ -334,11 +343,11 @@ mod tests {
     const SOL: u64 = 1_000_000_000;
     // minimum delegation (1 SOL) + rent exemption, matching `minimal_stake_lamports` used by the
     // funding pipeline.
-    const MIN: u64 = SOL + STAKE_ACCOUNT_RENT_EXEMPTION;
+    const MIN: u64 = SOL + STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE;
 
     fn initialized_stake(staker: Pubkey, withdrawer: Pubkey) -> StakeStateV2 {
         StakeStateV2::Initialized(Meta {
-            rent_exempt_reserve: STAKE_ACCOUNT_RENT_EXEMPTION,
+            rent_exempt_reserve: STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE,
             authorized: Authorized { staker, withdrawer },
             lockup: Lockup::default(),
         })
@@ -421,6 +430,38 @@ mod tests {
             },
             StakeFlags::empty(),
         )
+    }
+
+    // Passing the pinned reserve as the split rent lifts the predicted threshold and hides a splitting underwater account.
+    #[test]
+    fn fund_settlement_split_underflow_uses_the_live_split_rent_not_the_pinned_reserve() {
+        const LIVE_RENT: u64 = 2_077_224;
+        const NEEDED: u64 = 3 * SOL;
+        let gap = STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE - LIVE_RENT;
+        assert_eq!(gap, 205_656);
+
+        let state = delegated_stake(100 * SOL);
+        // sits inside the band: the program splits, the pinned reserve would predict no split
+        let available = NEEDED + MIN + LIVE_RENT + gap - 1;
+        assert_eq!(
+            fund_settlement_split_underflow(&state, available, NEEDED, MIN, LIVE_RENT),
+            Some(100 * SOL)
+        );
+        assert_eq!(
+            fund_settlement_split_underflow(
+                &state,
+                available,
+                NEEDED,
+                MIN,
+                STAKE_ACCOUNT_PSEUDO_RENT_EXEMPT_RESERVE
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn stake_account_size_matches_what_the_program_allocates() {
+        assert_eq!(std::mem::size_of::<StakeStateV2>(), 200);
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Stake-account funding and withdrawal validation now consistently enforce the required minimum balance.
  - Settlement workflows use a pinned reserve for stake-account minimums while applying live rent requirements to split accounts and eligible refunds.
  - Improved handling of split-account rent and refund calculations across varying rent scenarios.

- **New Features**
  - Added shared stake-account minimum-balance calculations for consistent CLI and settlement behavior.

- **Tests**
  - Expanded coverage for reduced rent values, insufficient withdrawals, funding thresholds, and settlement balance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->