### PR TITLE
[GEN-8996] notifications bonds update

### DIFF
--- a/packages/bonds-eventing/__tests__/evaluate-deltas.spec.ts
+++ b/packages/bonds-eventing/__tests__/evaluate-deltas.spec.ts
@@ -4,7 +4,6 @@ import pino from 'pino'
 
 import {
   evaluateDeltas,
-  requiredEpochsFor,
   validatorToState,
   configAddressForBondType,
   solToLamports,
@@ -363,8 +362,6 @@ describe('evaluateDeltas', () => {
     expect(underfunded!.data.message).toMatch(/top-up needed .* SOL \(Δ /)
   })
 
-  // bondGoodForNEpochs subtracts (1 + minBondEpochs), so a consumer that only
-  // sees the offset cannot tell that "0" means several epochs of real runway.
   it('carries required_epochs so the offset can be undone', () => {
     const validators = [makeValidator({ bondGoodForNEpochs: -3.12 })]
     const previousState = new Map<string, ValidatorState>()
@@ -1102,13 +1099,6 @@ describe('validatorToState', () => {
     expect(
       (state.auction_validator as Record<string, unknown>).voteAccount,
     ).toBe(TEST_VOTE_ACCOUNT)
-  })
-})
-
-describe('requiredEpochsFor', () => {
-  it('adds the epoch ds-sam-sdk charges on top of minBondEpochs', () => {
-    expect(requiredEpochsFor(4)).toBe(5)
-    expect(requiredEpochsFor(0)).toBe(1)
   })
 })
 

--- a/packages/bonds-eventing/__tests__/evaluate-deltas.spec.ts
+++ b/packages/bonds-eventing/__tests__/evaluate-deltas.spec.ts
@@ -4,6 +4,7 @@ import pino from 'pino'
 
 import {
   evaluateDeltas,
+  requiredEpochsFor,
   validatorToState,
   configAddressForBondType,
   solToLamports,
@@ -1101,6 +1102,13 @@ describe('validatorToState', () => {
     expect(
       (state.auction_validator as Record<string, unknown>).voteAccount,
     ).toBe(TEST_VOTE_ACCOUNT)
+  })
+})
+
+describe('requiredEpochsFor', () => {
+  it('adds the epoch ds-sam-sdk charges on top of minBondEpochs', () => {
+    expect(requiredEpochsFor(4)).toBe(5)
+    expect(requiredEpochsFor(0)).toBe(1)
   })
 })
 

--- a/packages/bonds-eventing/__tests__/evaluate-deltas.spec.ts
+++ b/packages/bonds-eventing/__tests__/evaluate-deltas.spec.ts
@@ -362,6 +362,56 @@ describe('evaluateDeltas', () => {
     expect(underfunded!.data.message).toMatch(/top-up needed .* SOL \(Δ /)
   })
 
+  // bondGoodForNEpochs subtracts (1 + minBondEpochs), so a consumer that only
+  // sees the offset cannot tell that "0" means several epochs of real runway.
+  it('carries required_epochs so the offset can be undone', () => {
+    const validators = [makeValidator({ bondGoodForNEpochs: -3.12 })]
+    const previousState = new Map<string, ValidatorState>()
+    previousState.set(
+      TEST_VOTE_ACCOUNT,
+      makePrevState({ bond_good_for_n_epochs: 5 }),
+    )
+
+    const events = evaluateDeltas(
+      validators,
+      previousState,
+      930,
+      'bidding',
+      logger,
+      5,
+    )
+
+    const underfunded = events.find(
+      e => e.inner_type === 'bond_underfunded_change',
+    )
+    const details = underfunded!.data.details as BondUnderfundedChangeDetails
+    expect(details.required_epochs).toBe(5)
+    expect(details.current_epochs).toBe(-3.12)
+  })
+
+  it('emits required_epochs null when the caller does not supply it', () => {
+    const validators = [makeValidator({ bondGoodForNEpochs: 2 })]
+    const previousState = new Map<string, ValidatorState>()
+    previousState.set(
+      TEST_VOTE_ACCOUNT,
+      makePrevState({ bond_good_for_n_epochs: 5 }),
+    )
+
+    const events = evaluateDeltas(
+      validators,
+      previousState,
+      930,
+      'bidding',
+      logger,
+    )
+
+    const underfunded = events.find(
+      e => e.inner_type === 'bond_underfunded_change',
+    )
+    const details = underfunded!.data.details as BondUnderfundedChangeDetails
+    expect(details.required_epochs).toBeNull()
+  })
+
   it('emits bond_balance_change when funded amount changes', () => {
     // Previous: 10 SOL, Current: 8 SOL
     const validators = [makeValidator({ bondBalanceSol: 8.0 })]

--- a/packages/bonds-eventing/package.json
+++ b/packages/bonds-eventing/package.json
@@ -34,7 +34,7 @@
     "@marinade.finance/ds-sam-sdk": "0.2.0",
     "@marinade.finance/ts-common": "5.1.2",
     "@marinade.finance/validator-bonds-sdk": "workspace:*",
-    "@marinade.finance/notifications-bonds-event-v1": "1.0.4",
+    "@marinade.finance/notifications-bonds-event-v1": "link:../../../marinade-notifications/message-types/typescript/bonds-event-v1",
     "@solana/web3.js": "1.98.4",
     "commander": "14.0.1",
     "pino": "9.9.5",

--- a/packages/bonds-eventing/package.json
+++ b/packages/bonds-eventing/package.json
@@ -34,7 +34,7 @@
     "@marinade.finance/ds-sam-sdk": "0.2.0",
     "@marinade.finance/ts-common": "5.1.2",
     "@marinade.finance/validator-bonds-sdk": "workspace:*",
-    "@marinade.finance/notifications-bonds-event-v1": "link:../../../marinade-notifications/message-types/typescript/bonds-event-v1",
+    "@marinade.finance/notifications-bonds-event-v1": "1.0.5-rc.1",
     "@solana/web3.js": "1.98.4",
     "commander": "14.0.1",
     "pino": "9.9.5",

--- a/packages/bonds-eventing/package.json
+++ b/packages/bonds-eventing/package.json
@@ -34,7 +34,7 @@
     "@marinade.finance/ds-sam-sdk": "0.2.0",
     "@marinade.finance/ts-common": "5.1.2",
     "@marinade.finance/validator-bonds-sdk": "workspace:*",
-    "@marinade.finance/notifications-bonds-event-v1": "1.0.5-rc.1",
+    "@marinade.finance/notifications-bonds-event-v1": "1.0.5",
     "@solana/web3.js": "1.98.4",
     "commander": "14.0.1",
     "pino": "9.9.5",

--- a/packages/bonds-eventing/src/commands/bidding.ts
+++ b/packages/bonds-eventing/src/commands/bidding.ts
@@ -3,11 +3,7 @@ import { Option } from 'commander'
 
 import { addSharedEventingOptions } from './options'
 import { logResolvedConfig, parseConfig } from '../config'
-import {
-  evaluateDeltas,
-  requiredEpochsFor,
-  validatorToState,
-} from '../evaluate-deltas'
+import { evaluateDeltas, validatorToState } from '../evaluate-deltas'
 import { runEventingPipeline } from '../pipeline'
 import { runAuction } from '../run-auction'
 import { saveAuctionMeta } from '../state'
@@ -67,7 +63,8 @@ async function manageBidding(opts: Record<string, unknown>) {
         ep,
         bondType,
         logger,
-        requiredEpochsFor(meta.minBondEpochs),
+        // Mirrors the offset ds-sam-sdk subtracts when it computes bondGoodForNEpochs.
+        1 + meta.minBondEpochs,
       ),
     toState: (v, ep) => validatorToState(v, ep, bondType),
     saveMeta: tx => saveAuctionMeta(tx, bondType, meta, logger),

--- a/packages/bonds-eventing/src/commands/bidding.ts
+++ b/packages/bonds-eventing/src/commands/bidding.ts
@@ -57,7 +57,15 @@ async function manageBidding(opts: Record<string, unknown>) {
     epoch,
     voteAccountOf: v => v.voteAccount,
     evaluate: (vals, previousState, ep) =>
-      evaluateDeltas(vals, previousState, ep, bondType, logger),
+      evaluateDeltas(
+        vals,
+        previousState,
+        ep,
+        bondType,
+        logger,
+        // bondGoodForNEpochs subtracts (1 + minBondEpochs); consumers need it back.
+        1 + meta.minBondEpochs,
+      ),
     toState: (v, ep) => validatorToState(v, ep, bondType),
     saveMeta: tx => saveAuctionMeta(tx, bondType, meta, logger),
   })

--- a/packages/bonds-eventing/src/commands/bidding.ts
+++ b/packages/bonds-eventing/src/commands/bidding.ts
@@ -3,7 +3,11 @@ import { Option } from 'commander'
 
 import { addSharedEventingOptions } from './options'
 import { logResolvedConfig, parseConfig } from '../config'
-import { evaluateDeltas, validatorToState } from '../evaluate-deltas'
+import {
+  evaluateDeltas,
+  requiredEpochsFor,
+  validatorToState,
+} from '../evaluate-deltas'
 import { runEventingPipeline } from '../pipeline'
 import { runAuction } from '../run-auction'
 import { saveAuctionMeta } from '../state'
@@ -63,8 +67,7 @@ async function manageBidding(opts: Record<string, unknown>) {
         ep,
         bondType,
         logger,
-        // bondGoodForNEpochs subtracts (1 + minBondEpochs); consumers need it back.
-        1 + meta.minBondEpochs,
+        requiredEpochsFor(meta.minBondEpochs),
       ),
     toState: (v, ep) => validatorToState(v, ep, bondType),
     saveMeta: tx => saveAuctionMeta(tx, bondType, meta, logger),

--- a/packages/bonds-eventing/src/evaluate-deltas.ts
+++ b/packages/bonds-eventing/src/evaluate-deltas.ts
@@ -450,6 +450,9 @@ export function evaluateDeltas(
   epoch: number,
   bondType: BondType,
   logger: LoggerWrapper,
+  // bondGoodForNEpochs is offset by this, so consumers cannot recover the
+  // absolute runway without it. Optional: older callers emit null.
+  requiredEpochs?: number | null,
 ): BondsEventV1[] {
   const configAddress = configAddressForBondType(bondType)
   const events: BondsEventV1[] = []
@@ -607,6 +610,7 @@ export function evaluateDeltas(
           {
             previous_epochs: prev.bond_good_for_n_epochs,
             current_epochs: currentEpochsRounded,
+            required_epochs: requiredEpochs ?? null,
             previous_deficit_sol: previousDeficitSol,
             bond_balance_sol: v.bondBalanceSol,
             marinade_activated_stake_sol: v.marinadeActivatedStakeSol,

--- a/packages/bonds-eventing/src/evaluate-deltas.ts
+++ b/packages/bonds-eventing/src/evaluate-deltas.ts
@@ -444,6 +444,11 @@ export function buildValidatorDelistedEvent(
   )
 }
 
+// Mirrors the offset ds-sam-sdk subtracts when it computes bondGoodForNEpochs.
+export function requiredEpochsFor(minBondEpochs: number): number {
+  return 1 + minBondEpochs
+}
+
 export function evaluateDeltas(
   currentValidators: AuctionValidator[],
   previousState: Map<string, ValidatorState>,

--- a/packages/bonds-eventing/src/evaluate-deltas.ts
+++ b/packages/bonds-eventing/src/evaluate-deltas.ts
@@ -444,19 +444,12 @@ export function buildValidatorDelistedEvent(
   )
 }
 
-// Mirrors the offset ds-sam-sdk subtracts when it computes bondGoodForNEpochs.
-export function requiredEpochsFor(minBondEpochs: number): number {
-  return 1 + minBondEpochs
-}
-
 export function evaluateDeltas(
   currentValidators: AuctionValidator[],
   previousState: Map<string, ValidatorState>,
   epoch: number,
   bondType: BondType,
   logger: LoggerWrapper,
-  // bondGoodForNEpochs is offset by this, so consumers cannot recover the
-  // absolute runway without it. Optional: older callers emit null.
   requiredEpochs?: number | null,
 ): BondsEventV1[] {
   const configAddress = configAddressForBondType(bondType)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       '@marinade.finance/notifications-bonds-event-v1':
-        specifier: 1.0.4
-        version: 1.0.4
+        specifier: link:../../../marinade-notifications/message-types/typescript/bonds-event-v1
+        version: link:../../../marinade-notifications/message-types/typescript/bonds-event-v1
       '@marinade.finance/ts-common':
         specifier: 5.1.2
         version: 5.1.2
@@ -1147,16 +1147,6 @@ packages:
   '@marinade.finance/native-staking-sdk@1.3.4':
     resolution: {integrity: sha512-//7kjIJFXmCIOauxzQl3B+Y/Av66Sf2pjJsmu+e8/Nk74rUBO4aL0rPSEiGhMvatZV1NXOQXdEZ3Ue34FN6Aaw==}
 
-  '@marinade.finance/notifications-bonds-event-v1@1.0.4':
-    resolution: {integrity: sha512-4H5eDCbJSl6jWrC9g1rWBD7NaEXjkUzEEKXlb55Whl1s+0EIPkBU8HMkk+wNdhojk8BDRPcjTkRN9lVIZ+LJ6g==}
-
-  '@marinade.finance/notifications-header-v1@1.0.0':
-    resolution: {integrity: sha512-hoHr0gw8SrLEY8JePl0Te4nPT6EPAVL8cKLlURWvwii/NCC4gZkSr5L/t93GBpNqWJpMu48Y1BlnSwUadJ6Vvg==}
-
-  '@marinade.finance/notifications-ts-message@1.0.0':
-    resolution: {integrity: sha512-pY0gCEAzW6Md7FV/GKpQ1zWSEKmfhj5Yn3rywZZrXvtNRbJDdpjn8zKs+4YukJWyJrczJVPvBSmcJJyjARE1PA==}
-    engines: {node: '>=20.0.0'}
-
   '@marinade.finance/notifications-ts-subscription-client@1.0.4':
     resolution: {integrity: sha512-Kmu2ayuDfXnYu5nxmN/nDNbVFmKT0XxHg3rojYoWwLSrXS07IuLGEtrDubcSPgrlU9jfmz0dfUuH7BlgA4OYYw==}
     engines: {node: '>=20.0.0'}
@@ -2115,27 +2105,8 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
-  ajv-formats@2.1.1:
-    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
-  ajv@8.20.0:
-    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   anchor-bankrun@0.2.0:
     resolution: {integrity: sha512-k/GIiYjkFzj10iluAXPjLjDInZtNNZ2FTcCTrtqgxwm5wofLbD8T0sy13LU9IfQSirj8/6eaTawDo+IvI03KRQ==}
@@ -2888,6 +2859,7 @@ packages:
   eslint@9.36.0:
     resolution: {integrity: sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -2982,9 +2954,6 @@ packages:
 
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
-
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
@@ -3586,9 +3555,6 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -4146,10 +4112,6 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-cwd@3.0.0:
@@ -5621,20 +5583,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@marinade.finance/notifications-bonds-event-v1@1.0.4':
-    dependencies:
-      '@marinade.finance/notifications-ts-message': 1.0.0
-      ajv: 8.20.0
-      ajv-formats: 2.1.1(ajv@8.20.0)
-
-  '@marinade.finance/notifications-header-v1@1.0.0': {}
-
-  '@marinade.finance/notifications-ts-message@1.0.0':
-    dependencies:
-      '@marinade.finance/notifications-header-v1': 1.0.0
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-
   '@marinade.finance/notifications-ts-subscription-client@1.0.4': {}
 
   '@marinade.finance/ts-common@5.1.2':
@@ -6769,27 +6717,12 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ajv-formats@2.1.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
-
-  ajv-formats@3.0.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
-
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.20.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   anchor-bankrun@0.2.0(bufferutil@4.1.0)(typescript@5.4.5)(utf-8-validate@6.0.6):
     dependencies:
@@ -7833,8 +7766,6 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.2: {}
-
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
   fastq@1.20.1:
@@ -8614,8 +8545,6 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
-  json-schema-traverse@1.0.0: {}
-
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
@@ -9197,8 +9126,6 @@ snapshots:
       set-function-name: 2.0.2
 
   require-directory@2.1.1: {}
-
-  require-from-string@2.0.2: {}
 
   resolve-cwd@3.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       '@marinade.finance/notifications-bonds-event-v1':
-        specifier: link:../../../marinade-notifications/message-types/typescript/bonds-event-v1
-        version: link:../../../marinade-notifications/message-types/typescript/bonds-event-v1
+        specifier: 1.0.5-rc.1
+        version: 1.0.5-rc.1
       '@marinade.finance/ts-common':
         specifier: 5.1.2
         version: 5.1.2
@@ -1147,6 +1147,16 @@ packages:
   '@marinade.finance/native-staking-sdk@1.3.4':
     resolution: {integrity: sha512-//7kjIJFXmCIOauxzQl3B+Y/Av66Sf2pjJsmu+e8/Nk74rUBO4aL0rPSEiGhMvatZV1NXOQXdEZ3Ue34FN6Aaw==}
 
+  '@marinade.finance/notifications-bonds-event-v1@1.0.5-rc.1':
+    resolution: {integrity: sha512-pBFb48fS9YjpaxrXyEr63yPDLrK1rB6yCULBNWI4XGY3FSnE5mCjO4mYz4jGXoeaB+hwV/e9DvQtg+QMiEYeUw==}
+
+  '@marinade.finance/notifications-header-v1@1.0.0':
+    resolution: {integrity: sha512-hoHr0gw8SrLEY8JePl0Te4nPT6EPAVL8cKLlURWvwii/NCC4gZkSr5L/t93GBpNqWJpMu48Y1BlnSwUadJ6Vvg==}
+
+  '@marinade.finance/notifications-ts-message@1.0.0':
+    resolution: {integrity: sha512-pY0gCEAzW6Md7FV/GKpQ1zWSEKmfhj5Yn3rywZZrXvtNRbJDdpjn8zKs+4YukJWyJrczJVPvBSmcJJyjARE1PA==}
+    engines: {node: '>=20.0.0'}
+
   '@marinade.finance/notifications-ts-subscription-client@1.0.4':
     resolution: {integrity: sha512-Kmu2ayuDfXnYu5nxmN/nDNbVFmKT0XxHg3rojYoWwLSrXS07IuLGEtrDubcSPgrlU9jfmz0dfUuH7BlgA4OYYw==}
     engines: {node: '>=20.0.0'}
@@ -2105,8 +2115,27 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   anchor-bankrun@0.2.0:
     resolution: {integrity: sha512-k/GIiYjkFzj10iluAXPjLjDInZtNNZ2FTcCTrtqgxwm5wofLbD8T0sy13LU9IfQSirj8/6eaTawDo+IvI03KRQ==}
@@ -2955,6 +2984,9 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
+
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
 
@@ -3555,6 +3587,9 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -4112,6 +4147,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-cwd@3.0.0:
@@ -5583,6 +5622,20 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@marinade.finance/notifications-bonds-event-v1@1.0.5-rc.1':
+    dependencies:
+      '@marinade.finance/notifications-ts-message': 1.0.0
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+
+  '@marinade.finance/notifications-header-v1@1.0.0': {}
+
+  '@marinade.finance/notifications-ts-message@1.0.0':
+    dependencies:
+      '@marinade.finance/notifications-header-v1': 1.0.0
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+
   '@marinade.finance/notifications-ts-subscription-client@1.0.4': {}
 
   '@marinade.finance/ts-common@5.1.2':
@@ -6717,12 +6770,27 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
+  ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.7
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   anchor-bankrun@0.2.0(bufferutil@4.1.0)(typescript@5.4.5)(utf-8-validate@6.0.6):
     dependencies:
@@ -7766,6 +7834,8 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
+  fast-uri@3.1.7: {}
+
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
   fastq@1.20.1:
@@ -8545,6 +8615,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
@@ -9126,6 +9198,8 @@ snapshots:
       set-function-name: 2.0.2
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-cwd@3.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       '@marinade.finance/notifications-bonds-event-v1':
-        specifier: 1.0.5-rc.1
-        version: 1.0.5-rc.1
+        specifier: 1.0.5
+        version: 1.0.5
       '@marinade.finance/ts-common':
         specifier: 5.1.2
         version: 5.1.2
@@ -1147,8 +1147,8 @@ packages:
   '@marinade.finance/native-staking-sdk@1.3.4':
     resolution: {integrity: sha512-//7kjIJFXmCIOauxzQl3B+Y/Av66Sf2pjJsmu+e8/Nk74rUBO4aL0rPSEiGhMvatZV1NXOQXdEZ3Ue34FN6Aaw==}
 
-  '@marinade.finance/notifications-bonds-event-v1@1.0.5-rc.1':
-    resolution: {integrity: sha512-pBFb48fS9YjpaxrXyEr63yPDLrK1rB6yCULBNWI4XGY3FSnE5mCjO4mYz4jGXoeaB+hwV/e9DvQtg+QMiEYeUw==}
+  '@marinade.finance/notifications-bonds-event-v1@1.0.5':
+    resolution: {integrity: sha512-WnXb93dnsxEsadPcTli0NsvvdFaVw2Qt+pFa+jiDV+Gvh95bUJPGLnuJMvQ+Xlmkmq7RE8jFXVVkJvjn/seoRQ==}
 
   '@marinade.finance/notifications-header-v1@1.0.0':
     resolution: {integrity: sha512-hoHr0gw8SrLEY8JePl0Te4nPT6EPAVL8cKLlURWvwii/NCC4gZkSr5L/t93GBpNqWJpMu48Y1BlnSwUadJ6Vvg==}
@@ -5622,7 +5622,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@marinade.finance/notifications-bonds-event-v1@1.0.5-rc.1':
+  '@marinade.finance/notifications-bonds-event-v1@1.0.5':
     dependencies:
       '@marinade.finance/notifications-ts-message': 1.0.0
       ajv: 8.20.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ minimumReleaseAgeExclude:
   - '@marinade.finance/ts-common@5.1.2'
   - '@marinade.finance/web3js-1x-testing@5.1.2'
   - '@marinade.finance/web3js-1x@5.1.2'
+  - '@marinade.finance/notifications-bonds-event-v1@1.0.5-rc.1'
 overrides:
   glob@<8: ^10.3.10
   rpc-websockets: ^10.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ minimumReleaseAgeExclude:
   - '@marinade.finance/ts-common@5.1.2'
   - '@marinade.finance/web3js-1x-testing@5.1.2'
   - '@marinade.finance/web3js-1x@5.1.2'
-  - '@marinade.finance/notifications-bonds-event-v1@1.0.5-rc.1'
+  - '@marinade.finance/notifications-bonds-event-v1@1.0.5'
 overrides:
   glob@<8: ^10.3.10
   rpc-websockets: ^10.0.1


### PR DESCRIPTION
Processing the notification update for Select report from TLG group. 

Interlinked to https://github.com/marinade-finance/marinade-notifications/pull/69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bond underfunding change events now include the required epoch count.
  - Required epochs reflect the configured minimum bond epochs with the expected one-epoch offset.
  - Events report `null` when no required epoch value is available.

- **Tests**
  - Retained coverage for supplied and omitted required epoch values in bond underfunding events.
  - Added coverage confirming the required epoch value is correctly propagated in event details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->